### PR TITLE
Change the way SDL.h is included to standard cross-platform way.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(SDL REQUIRED)
 if(NOT SDL_FOUND)
 	  message(FATAL_ERROR "SDL library not found")
 endif(NOT SDL_FOUND)
-include_directories(SDL_INCLUDE_DIR)
+include_directories(${SDL_INCLUDE_DIR})
 
 set(SOURCES main.cpp
             src/Engine/AnimatedPalette.cpp

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@
 #include "src/Engine/ResourceManager.h"
 #include "src/States/StartState.h"
 #include "src/Engine/CrossPlatform.h"
-#include <SDL/SDL.h>
+#include "SDL.h"
 #include <algorithm>
 #include "lib/libfalltergeist/libfalltergeist.h"
 

--- a/src/Engine/AnimatedPalette.cpp
+++ b/src/Engine/AnimatedPalette.cpp
@@ -24,7 +24,7 @@
 #include "../Engine/AnimatedPalette.h"
 
 // Third party includes
-#include <SDL/SDL.h>
+#include "SDL.h"
 
 namespace Falltergeist
 {

--- a/src/Engine/Event.h
+++ b/src/Engine/Event.h
@@ -25,7 +25,7 @@
 // Falltergeist includes
 
 // Third party includes
-#include <SDL/SDL.h>
+#include "SDL.h"
 
 namespace Falltergeist
 {

--- a/src/Engine/Game.h
+++ b/src/Engine/Game.h
@@ -28,7 +28,7 @@
 // Falltergeist includes
 
 // Third party includes
-#include <SDL/SDL.h>
+#include "SDL.h"
 
 #define VERSION "0.0.7"
 

--- a/src/Engine/Mouse.h
+++ b/src/Engine/Mouse.h
@@ -28,7 +28,7 @@
 #include "../Engine/ResourceManager.h"
 
 // Third party includes
-#include <SDL/SDL.h>
+#include "SDL.h"
 
 namespace Falltergeist
 {

--- a/src/Engine/Screen.h
+++ b/src/Engine/Screen.h
@@ -26,7 +26,7 @@
 // Falltergeist includes
 
 // Third party includes
-#include <SDL/SDL.h>
+#include "SDL.h"
 
 namespace Falltergeist
 {

--- a/src/Engine/Surface.h
+++ b/src/Engine/Surface.h
@@ -28,7 +28,7 @@
 #include "../Engine/ResourceManager.h"
 
 // Third party includes
-#include <SDL/SDL.h>
+#include "SDL.h"
 
 namespace Falltergeist
 {


### PR DESCRIPTION
Fallgergeist is currently intended to be run on unix-like systems only, but SDL is a cross platform library and it supports a lot of systems Windows included. The most portable way to include SDL.h is #include "SDL.h" ( http://wiki.libsdl.org/FAQDevelopment#Do_I_.23include_.3CSDL.h.3E_or_.3CSDL.2FSDL.h.3E.3F ) .
Cmake script had to be corrected to add directory with SDL.h to include path.

P.S.
I tried to compile falltergeist under Windows and after removing some linux specific code (handling files) managed 
to succeed. Falltergeist doesn't work properly, because of slashes inside paths I think, but it is no big deal. I mean
it would require some effort to support Windows, but it's not impossible.
