### PR TITLE
Fast fix to provide compatibility with the recent version of libfallterg...

### DIFF
--- a/src/Engine/Font.cpp
+++ b/src/Engine/Font.cpp
@@ -114,7 +114,8 @@ Surface * Font::glyph(unsigned char chr)
     {
         for (int x = 0; x != charWidth; ++x)
         {
-            unsigned char ch = _aafFileType->glyphs()->at(chr)->data()->at(i);
+            std::string tmpStr(_aafFileType->glyphs()->at(chr)->data());
+            unsigned char ch = tmpStr.at(i);
             if (ch != 0)
             {
                 float lightness;


### PR DESCRIPTION
I am able to compile falltergeist now, but it crashes because of std::out_of_range on line 118.
And it shouldn't because the changes I made are very simple and obvious.
I don't know the code well enough to find out what happened, so I hope you will fix the issue :).

P.S. Why did you make the change in libfalltergeist anyway? I mean why changing sdt::string to char *? You don't like C++ :)? Or is it something else?
