### PR TITLE
Add ctime header so that falltergeist could be compiled with mingw

### DIFF
--- a/src/States/StartState.cpp
+++ b/src/States/StartState.cpp
@@ -20,6 +20,7 @@
 // C++ standard includes
 #include <vector>
 #include <string>
+#include <ctime>
 
 // Falltergeist includes
 #include "../Engine/Game.h"

--- a/src/VM/VM.cpp
+++ b/src/VM/VM.cpp
@@ -19,6 +19,7 @@
 
 // C++ standard includes
 #include <iostream>
+#include <ctime>
 
 
 // Falltergeist includes


### PR DESCRIPTION
Без этих инклюдов под windows не получается собрать.

P.S. Вообще в С++11 есть собственный механизм для генерации случайных чисел и получения текущего момента времени. Как будет время я оформлю реквест с предложением по внедрению.
