### PR TITLE
Change API for `OpcodeHandler`

### DIFF
--- a/src/VM/Handlers/Opcode8002Handler.cpp
+++ b/src/VM/Handlers/Opcode8002Handler.cpp
@@ -32,10 +32,8 @@ Opcode8002Handler::Opcode8002Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode8002Handler::run()
+void Opcode8002Handler::_run()
 {
-    OpcodeHandler::run();
-
     CrossPlatform::debug("lock", DEBUG_SCRIPT);
 }
 

--- a/src/VM/Handlers/Opcode8002Handler.h
+++ b/src/VM/Handlers/Opcode8002Handler.h
@@ -34,7 +34,8 @@ class Opcode8002Handler : public OpcodeHandler
 {
 public:
     Opcode8002Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode8005Handler.cpp
+++ b/src/VM/Handlers/Opcode8005Handler.cpp
@@ -34,10 +34,8 @@ Opcode8005Handler::Opcode8005Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode8005Handler::run()
+void Opcode8005Handler::_run()
 {
-    OpcodeHandler::run();
-
     auto functionIndex = _vm->popDataInteger();
     _vm->setProgramCounter(_vm->script()->function(functionIndex));
 

--- a/src/VM/Handlers/Opcode8005Handler.h
+++ b/src/VM/Handlers/Opcode8005Handler.h
@@ -34,7 +34,8 @@ class Opcode8005Handler : public OpcodeHandler
 {
 public:
     Opcode8005Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode8033Handler.cpp
+++ b/src/VM/Handlers/Opcode8033Handler.cpp
@@ -34,10 +34,8 @@ Opcode8033Handler::Opcode8033Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode8033Handler::run()
+void Opcode8033Handler::_run()
 {
-    OpcodeHandler::run();
-
     CrossPlatform::debug("[*] eq ==", DEBUG_SCRIPT);
     switch (_vm->dataStack()->top()->type())
     {

--- a/src/VM/Handlers/Opcode8033Handler.h
+++ b/src/VM/Handlers/Opcode8033Handler.h
@@ -34,7 +34,8 @@ class Opcode8033Handler : public OpcodeHandler
 {
 public:
     Opcode8033Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode8034Handler.cpp
+++ b/src/VM/Handlers/Opcode8034Handler.cpp
@@ -34,10 +34,8 @@ Opcode8034Handler::Opcode8034Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode8034Handler::run()
+void Opcode8034Handler::_run()
 {
-    OpcodeHandler::run();
-
     switch (_vm->dataStack()->top()->type())
     {
         case VMStackValue::TYPE_INTEGER:

--- a/src/VM/Handlers/Opcode8034Handler.h
+++ b/src/VM/Handlers/Opcode8034Handler.h
@@ -34,7 +34,8 @@ class Opcode8034Handler : public OpcodeHandler
 {
 public:
     Opcode8034Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode8039Handler.cpp
+++ b/src/VM/Handlers/Opcode8039Handler.cpp
@@ -35,10 +35,8 @@ Opcode8039Handler::Opcode8039Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode8039Handler::run()
+void Opcode8039Handler::_run()
 {
-    OpcodeHandler::run();
-
     CrossPlatform::debug("[*] plus +", DEBUG_SCRIPT);
     auto b = _vm->dataStack()->top();
     switch (b->type())

--- a/src/VM/Handlers/Opcode8039Handler.h
+++ b/src/VM/Handlers/Opcode8039Handler.h
@@ -34,7 +34,8 @@ class Opcode8039Handler : public OpcodeHandler
 {
 public:
     Opcode8039Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode80BAHandler.cpp
+++ b/src/VM/Handlers/Opcode80BAHandler.cpp
@@ -36,10 +36,8 @@ Opcode80BAHandler::Opcode80BAHandler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode80BAHandler::run()
+void Opcode80BAHandler::_run()
 {
-    OpcodeHandler::run();
-
     auto PID = _vm->popDataInteger();
     auto pointer = _vm->popDataPointer();
     int amount = 0;

--- a/src/VM/Handlers/Opcode80BAHandler.h
+++ b/src/VM/Handlers/Opcode80BAHandler.h
@@ -34,7 +34,8 @@ class Opcode80BAHandler : public OpcodeHandler
 {
 public:
     Opcode80BAHandler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode80DEHandler.cpp
+++ b/src/VM/Handlers/Opcode80DEHandler.cpp
@@ -37,10 +37,8 @@ Opcode80DEHandler::Opcode80DEHandler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode80DEHandler::run()
+void Opcode80DEHandler::_run()
 {
-    OpcodeHandler::run();
-
     auto dialog = std::shared_ptr<CritterDialogState>(new CritterDialogState());
     Game::getInstance()->setDialog(dialog);
     // @todo Implement!

--- a/src/VM/Handlers/Opcode80DEHandler.h
+++ b/src/VM/Handlers/Opcode80DEHandler.h
@@ -35,7 +35,8 @@ class Opcode80DEHandler : public OpcodeHandler
 {
 public:
     Opcode80DEHandler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/Opcode9001Handler.cpp
+++ b/src/VM/Handlers/Opcode9001Handler.cpp
@@ -33,10 +33,8 @@ Opcode9001Handler::Opcode9001Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode9001Handler::run()
+void Opcode9001Handler::_run()
 {
-    OpcodeHandler::run();
-
     unsigned int value;
     unsigned short nextOpcode;
     *(_vm->script()) >> value >> nextOpcode;

--- a/src/VM/Handlers/Opcode9001Handler.h
+++ b/src/VM/Handlers/Opcode9001Handler.h
@@ -34,7 +34,8 @@ class Opcode9001Handler : public OpcodeHandler
 {
 public:
     Opcode9001Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/Handlers/OpcodeC001Handler.cpp
+++ b/src/VM/Handlers/OpcodeC001Handler.cpp
@@ -35,10 +35,8 @@ OpcodeC001Handler::OpcodeC001Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void OpcodeC001Handler::run()
+void OpcodeC001Handler::_run()
 {
-    OpcodeHandler::run();
-
     int value;
     *(_vm->script()) >> value;
 

--- a/src/VM/Handlers/OpcodeC001Handler.h
+++ b/src/VM/Handlers/OpcodeC001Handler.h
@@ -34,7 +34,8 @@ class OpcodeC001Handler : public OpcodeHandler
 {
 public:
     OpcodeC001Handler(VM* vm);
-    virtual void run();
+private:
+    void _run();
 };
 
 }

--- a/src/VM/OpcodeHandler.cpp
+++ b/src/VM/OpcodeHandler.cpp
@@ -35,6 +35,7 @@ OpcodeHandler::OpcodeHandler(VM* vm) : _vm(vm)
 void OpcodeHandler::run()
 {
     _vm->setProgramCounter(_vm->programCounter() + 2);
+    _run();
 }
 
 }

--- a/src/VM/OpcodeHandler.h
+++ b/src/VM/OpcodeHandler.h
@@ -35,9 +35,10 @@ class OpcodeHandler
 {
 protected:
     VM* _vm;
+    virtual void _run() = 0;
 public:
     OpcodeHandler(VM* vm);
-    virtual void run();
+    void run();
 };
 
 }


### PR DESCRIPTION
Make `OpcodeHandler::run` call pure virtual method `OpcodeHandler::_run` (must be implemented in derived classes), so there is no need to invoke `OpcodeHandler::run` from instances of derived classes.

In short:
1. derived handlers should implement `OpcodeHandler::_run` instead of `OpcodeHandler::run`;
2. `OpcodeHandler::run` must not be invoked manually from derived classes anymore.

See [changed files](https://github.com/alexeevdv/falltergeist/pull/82/files) for more info.

Related to #77 
