### PR TITLE
Add a stream-returning version of CrossPlatform::debug

### DIFF
--- a/src/Engine/CrossPlatform.cpp
+++ b/src/Engine/CrossPlatform.cpp
@@ -252,4 +252,20 @@ std::vector<std::string> * CrossPlatform::findFalloutDataFiles()
 
     return _dataFiles;
 }
+
+std::ostream &CrossPlatform::debug(unsigned char level)
+{
+    // /dev/null-like stream
+    static std::ostream nullstream(nullptr);
+    // Check debug level
+    // TODO: perform real check
+    if (false)
+    {
+        return nullstream << std::dec;
+    }
+    else
+    {
+        return std::cout << std::dec;
+    }
+}
 }

--- a/src/Engine/CrossPlatform.h
+++ b/src/Engine/CrossPlatform.h
@@ -57,6 +57,7 @@ public:
     static std::vector<std::string> * findFalloutDataFiles();
     static void debug(std::string message, unsigned char level = 0);
     static void debug(bool newline, std::string message, unsigned char level = 0);
+    static std::ostream &debug(unsigned char level = 0);
 };
 
 }


### PR DESCRIPTION
Usage:

``` c++
CrossPlatform::debug(DEBUG_LEVEL)
    << "some string"
    << someVariable
    << std::someIoManipulator
    << std::endl;
```
