### PR TITLE
Fix segfault when changing player's name.

### DIFF
--- a/src/States/PlayerEditNameState.cpp
+++ b/src/States/PlayerEditNameState.cpp
@@ -126,7 +126,7 @@ void PlayerEditNameState::init()
     addUI(_cursor);
 }
 
-void PlayerEditNameState::onKeyboardPress(std::shared_ptr<KeyboardEvent> event)
+void PlayerEditNameState::onKeyboardPress(KeyboardEvent* event)
 {
     auto sender = dynamic_cast<TextArea*>(event->emitter());
     auto state = dynamic_cast<PlayerEditNameState*>(event->reciever());

--- a/src/States/PlayerEditNameState.h
+++ b/src/States/PlayerEditNameState.h
@@ -47,7 +47,7 @@ public:
     void init();
     void think();
     void onDoneButtonClick(MouseEvent* event);
-    void onKeyboardPress(std::shared_ptr<KeyboardEvent> event);
+    void onKeyboardPress(KeyboardEvent* event);
 };
 
 


### PR DESCRIPTION
If we want to use a shared_ptr, we'd probably need to change what _receiver and _emitter in Event are first.
