### PR TITLE
Proper game shutdown

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char* argv[])
         auto game = Game::getInstance();
         game->setState(new StartState());
         game->run();
+        game->shutdown();
         return 0;
     }
     catch(const libfalltergeist::Exception &e)

--- a/src/Engine/Game.cpp
+++ b/src/Engine/Game.cpp
@@ -125,6 +125,21 @@ Game::~Game()
     delete _currentTime;
 }
 
+void Game::shutdown()
+{
+    delete _mouse;
+    delete _fpsCounter;
+    delete _mousePosition;
+    delete _falltergeistVersion;
+    delete _mixer;
+    delete _resourceManager;
+    while (!_states.empty()) popState();
+    delete _engineSettings;
+    delete _gameTime;
+    delete _currentTime;
+    delete _renderer;
+}
+
 void Game::pushState(State* state)
 {
     _states.push_back(state);

--- a/src/Engine/Game.h
+++ b/src/Engine/Game.h
@@ -84,6 +84,7 @@ public:
     ~Game();
     static Game* getInstance();
 
+    void shutdown();
     std::vector<State*>* states();
     std::vector<State*>* statesForRender();
     std::vector<State*>* statesForThinkAndHandle();


### PR DESCRIPTION
As Game is singleton, destructor is never called. This leads to situations, when, for example, ResourceManager is destroyed before AudioMixer, and lead to segfault (because SDL_mixer runs in separate thread)
Also renderer should be destroyed last, as UI subclasses call unregisterTexture on destroy.
This should fix this.
