### PR TITLE
Fix movement and animation related crashes.

### DIFF
--- a/src/Engine/Graphics/Animation.cpp
+++ b/src/Engine/Graphics/Animation.cpp
@@ -252,6 +252,7 @@ void Animation::think()
             auto event = new Event("animationEnded");
             emitEvent(event);
             delete event;
+            return;
         }
         auto frame = frames()->at(_currentFrame);
         setXOffset(frame->xOffset());

--- a/src/States/LocationState.cpp
+++ b/src/States/LocationState.cpp
@@ -442,6 +442,7 @@ void LocationState::handle(Event* event)
                     auto path = hexagonGrid()->findPath(game->player()->hexagon(), hexagon);
                     if (path.size())
                     {
+                        game->player()->movementQueue()->clear();
                         for (auto hexagon : path)
                         {
                             game->player()->movementQueue()->push_back(hexagon);


### PR DESCRIPTION
orientationTo() still REALLY needs to be fixed. Just returning _something_ at the end of the switch would help.
