### PR TITLE
Delete GameLocation pointers in ResourceManager destructor.

### DIFF
--- a/src/Engine/ResourceManager.cpp
+++ b/src/Engine/ResourceManager.cpp
@@ -60,6 +60,11 @@ ResourceManager::~ResourceManager()
     {
         delete it->second;
     }
+
+    for (auto it = _gameLocations.begin(); it != _gameLocations.end(); ++it)
+    {
+        delete it->second;
+    }
 }
 
 


### PR DESCRIPTION
Locations haven't been inserted into the map yet, but this will probably be needed later!
