### PR TITLE
fix for #255 by introducing "buffer_size" setting

### DIFF
--- a/src/Audio/AudioMixer.cpp
+++ b/src/Audio/AudioMixer.cpp
@@ -62,7 +62,7 @@ void AudioMixer::_init()
     Logger::info() << message + "[OK]" << std::endl;
 
     message = "[AUDIO] - Mix_OpenAudio - ";
-    if (Mix_OpenAudio(22050, AUDIO_S16LSB, 2, 4096) < 0)
+    if (Mix_OpenAudio(22050, AUDIO_S16LSB, 2, Game::getInstance()->settings()->audioBufferSize()) < 0)
     {
         Logger::critical() << message + "[FAIL]" << std::endl;
         throw Exception(Mix_GetError());

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -70,6 +70,7 @@ const double Settings::_defaultMasterVolume=1.0;
 const double Settings::_defaultMusicVolume=1.0;
 const double Settings::_defaultSFXVolume=1.0;
 const double Settings::_defaultVoiceVolume=1.0;
+const int Settings::_defaultAudioBufferSize = 512;
 
 Settings::Settings()
 {
@@ -138,6 +139,7 @@ void Settings::_createDefaultConfig(Ini::File &ini)
     audio->setPropertyDouble("voice_volume", _defaultVoiceVolume);
     audio->setPropertyDouble("sfx_volume", _defaultSFXVolume);
     audio->setPropertyString("music_path", _defaultMusicPath);
+    audio->setPropertyInt("buffer_size", _defaultAudioBufferSize);
 
     auto logger = ini.section("logger");
     logger->setPropertyString("level", _defaultLoggerLevel);
@@ -190,6 +192,7 @@ void Settings::saveConfig()
     audio->setPropertyDouble("voice_volume", _voiceVolume);
     audio->setPropertyDouble("sfx_volume", _sfxVolume);
     audio->setPropertyString("music_path", _musicPath);
+    audio->setPropertyInt("buffer_size", _audioBufferSize);
 
     auto logger = ini.section("logger");
     logger->setPropertyString("level", _loggerLevel);
@@ -294,6 +297,7 @@ void Settings::_readConfig(Ini::File &ini)
     _voiceVolume = audio->propertyDouble("voice_volume", _defaultVoiceVolume);
     _sfxVolume = audio->propertyDouble("sfx_volume", _defaultSFXVolume);
     _musicPath = audio->propertyString("music_path", _defaultMusicPath);
+    _audioBufferSize = audio->propertyInt("buffer_size", _defaultAudioBufferSize);
 
     auto logger = ini.section("logger");
     _loggerLevel = logger->propertyString("level", _defaultLoggerLevel);
@@ -567,6 +571,16 @@ void Settings::setFullscreen(bool _fullscreen)
 bool Settings::fullscreen() const
 {
     return _fullscreen;
+}
+
+void Settings::setAudioBufferSize(int _audioBufferSize)
+{
+    this->_audioBufferSize = _audioBufferSize;
+}
+
+int Settings::audioBufferSize() const
+{
+    return _audioBufferSize;
 }
 
 } // Falltergeist

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -106,6 +106,8 @@ public:
     unsigned int scale() const;
     void setFullscreen(bool _fullscreen);
     bool fullscreen() const;
+    void setAudioBufferSize(int _audioBufferSize);
+    int audioBufferSize() const;
 
 private:
     unsigned int _screenWidth;
@@ -143,6 +145,7 @@ private:
     double _musicVolume;
     double _sfxVolume;
     double _voiceVolume;
+    int _audioBufferSize;
 
     void _createDefaultConfig(Ini::File &ini);
     void _readConfig(Ini::File &ini);
@@ -184,6 +187,7 @@ private:
     static const double _defaultMusicVolume;
     static const double _defaultSFXVolume;
     static const double _defaultVoiceVolume;
+    static const int _defaultAudioBufferSize;
 
 };
 


### PR DESCRIPTION
Default value 4096 is way too much for 22050 frequency, this resulted in very high latency. I added "buffer_size" setting with default value of 512 (tested with 256 on my machine - seem to work fine, so I doubled this value to be safe).

Testing on my machine revealed that:
* 128 and below starts to crackle and skip sound
* values above 1024 start to give noticeable delay