### PR TITLE
Rework interaction with object using cursor and CursorDropdown

### DIFF
--- a/src/Game/DudeObject.cpp
+++ b/src/Game/DudeObject.cpp
@@ -284,7 +284,7 @@ void GameDudeObject::_generateUi()
 
     if (_ui)
     {
-        _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, static_cast<GameObject*>(this)));
+        _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onObjectMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, static_cast<GameObject*>(this)));
     }
 }
 

--- a/src/Game/DudeObject.cpp
+++ b/src/Game/DudeObject.cpp
@@ -282,10 +282,7 @@ void GameDudeObject::_generateUi()
     queue->start();
     _ui = queue;
 
-    if (_ui)
-    {
-        _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onObjectMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, static_cast<GameObject*>(this)));
-    }
+    addUIEventHandlers();
 }
 
 unsigned int GameDudeObject::radiationLevel()

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -162,7 +162,7 @@ void GameObject::setUI(ActiveUI* ui)
 {
     delete _ui;
     _ui = ui;
-    _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, this));
+    _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onObjectMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, this));
 }
 
 void GameObject::_generateUi()
@@ -190,7 +190,7 @@ void GameObject::_generateUi()
 
     if (_ui)
     {
-        _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onObjectMouseDown, Game::getInstance()->locationState(), std::placeholders::_1, this));
     }
 }
 

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -173,6 +173,7 @@ void GameObject::addUIEventHandlers()
         _ui->addEventHandler("mouseleftup", std::bind(&State::Location::onObjectMouseEvent, Game::getInstance()->locationState(), std::placeholders::_1, this));
         _ui->addEventHandler("mousein", std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
         _ui->addEventHandler("mousemove", std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->addEventHandler("mouseout", std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
     }
 }
 

--- a/src/Game/Object.h
+++ b/src/Game/Object.h
@@ -63,6 +63,7 @@ protected:
     ActiveUI* _ui = 0;
     Hexagon* _hexagon = 0;
     virtual void _generateUi();
+    void addUIEventHandlers();
     TextArea* _floatMessage = 0;
     bool _inRender = false;
     unsigned int _trans = 0;

--- a/src/Graphics/ActiveUI.cpp
+++ b/src/Graphics/ActiveUI.cpp
@@ -117,7 +117,7 @@ void ActiveUI::handle(Event* event)
         }
         else
         {
-            if (mouseEvent->name() == "mousemove"&& _hovered)
+            if (mouseEvent->name() == "mousemove" && _hovered)
             {
                 if (_drag)
                 {

--- a/src/Input/Mouse.cpp
+++ b/src/Input/Mouse.cpp
@@ -40,12 +40,11 @@ Mouse::Mouse()
 {
     // Hide cursor
     SDL_ShowCursor(0);
-    //SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
-    // Trap mouse in window
-    if (!Game::getInstance()->settings()->fullscreen())
+    // Trap mouse in window         - mouse warp doesn't work currently with this setting -- phobos2077
+    /*if (!Game::getInstance()->settings()->fullscreen())
     {
-        //SDL_SetRelativeMouseMode(SDL_TRUE);
-    }
+        SDL_SetRelativeMouseMode(SDL_TRUE);
+    }*/
 }
 
 Mouse::~Mouse()

--- a/src/Input/Mouse.cpp
+++ b/src/Input/Mouse.cpp
@@ -40,10 +40,11 @@ Mouse::Mouse()
 {
     // Hide cursor
     SDL_ShowCursor(0);
+    //SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
     // Trap mouse in window
     if (!Game::getInstance()->settings()->fullscreen())
     {
-        SDL_SetRelativeMouseMode(SDL_TRUE);
+        //SDL_SetRelativeMouseMode(SDL_TRUE);
     }
 }
 

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -37,6 +37,7 @@
 #include "../UI/Image.h"
 #include "../UI/TextArea.h"
 #include "../VM/VM.h"
+#include "Input/Mouse.h"
 
 // Third party includes
 

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -37,7 +37,6 @@
 #include "../UI/Image.h"
 #include "../UI/TextArea.h"
 #include "../VM/VM.h"
-#include "Input/Mouse.h"
 
 // Third party includes
 

--- a/src/State/CritterInteract.cpp
+++ b/src/State/CritterInteract.cpp
@@ -26,8 +26,10 @@
 #include "../PathFinding/Hexagon.h"
 #include "../Game/CritterObject.h"
 #include "../State/CritterInteract.h"
+#include "../State/CursorDropdown.h"
 #include "../State/Location.h"
 #include "../UI/Image.h"
+#include "../Input/Mouse.h"
 
 // Third party includes
 
@@ -38,6 +40,10 @@ namespace State
 
 CritterInteract::CritterInteract() : State()
 {
+    auto game = Game::getInstance();
+    if (dynamic_cast<CursorDropdown*>(game->states()->back()) != NULL) {
+        game->popState();
+    }
 }
 
 CritterInteract::~CritterInteract()
@@ -45,6 +51,16 @@ CritterInteract::~CritterInteract()
     auto camera = Game::getInstance()->locationState()->camera();
     camera->setXPosition(_oldCameraX);
     camera->setYPosition(_oldCameraY);
+}
+
+void CritterInteract::onStateActivate(StateEvent* event)
+{
+    Game::getInstance()->mouse()->pushState(Mouse::BIG_ARROW);
+}
+
+void CritterInteract::onStateDeactivate(StateEvent* event)
+{
+    Game::getInstance()->mouse()->popState();
 }
 
 void CritterInteract::init()

--- a/src/State/CritterInteract.cpp
+++ b/src/State/CritterInteract.cpp
@@ -40,10 +40,6 @@ namespace State
 
 CritterInteract::CritterInteract() : State()
 {
-    auto game = Game::getInstance();
-    if (dynamic_cast<CursorDropdown*>(game->states()->back()) != NULL) {
-        game->popState();
-    }
 }
 
 CritterInteract::~CritterInteract()

--- a/src/State/CritterInteract.h
+++ b/src/State/CritterInteract.h
@@ -71,6 +71,9 @@ public:
 
     VM* script();
     void setScript(VM* script);
+    
+    virtual void onStateActivate(StateEvent* event);
+    virtual void onStateDeactivate(StateEvent* event);
 };
 
 }

--- a/src/State/CursorDropdown.cpp
+++ b/src/State/CursorDropdown.cpp
@@ -234,17 +234,40 @@ void CursorDropdown::think()
 
 void CursorDropdown::onStateActivate(StateEvent* event)
 {
-    
+    if (_needToHide)
+    {
+        Game::getInstance()->popState();
+    }
 }
 
 void CursorDropdown::onStateDeactivate(StateEvent* event)
 {
     auto game = Game::getInstance();
-    game->mouse()->popState();
-    if (!_onlyShowIcon)
+    bool deleted = true;
+    for (auto state : *game->states()) 
     {
-        game->mouse()->setX(_initialX);
-        game->mouse()->setY(_initialY);
+        if (state == this)
+        {
+            deleted = false;
+            break;
+        }
+    }
+    if (deleted) // this happens when state is deactivated after popState())
+    {
+        game->mouse()->popState();
+    }
+    if (!_needToHide)
+    {
+        if (!_onlyShowIcon)
+        {
+            game->mouse()->setX(_initialX);
+            game->mouse()->setY(_initialY);
+        }
+        for (auto ui : _ui)
+        {
+            ui->setVisible(false);
+        }
+        _needToHide = true;
     }
 }
 

--- a/src/State/CursorDropdown.cpp
+++ b/src/State/CursorDropdown.cpp
@@ -138,9 +138,8 @@ void CursorDropdown::showMenu()
     _surface = new Image(40, 40*_icons.size());
     _surface->setX(_initialX + 29);
     _surface->setY(_initialY);
-    auto location = game->locationState();
-    int deltaX = _surface->x() + _surface->width() - location->viewWidth();
-    int deltaY = _surface->y() + _surface->height() - location->viewHeight();
+    int deltaX = _surface->x() + _surface->width() - game->renderer()->width();
+    int deltaY = _surface->y() + _surface->height() - game->renderer()->height() + game->locationState()->playerPanelState()->height();
     if (deltaX > 0)
     {
         _surface->setX(_surface->x() - 40 - 29 - 29);

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -45,7 +45,7 @@ class CursorDropdown : public State
 {
 protected:
     Game::GameObject* _object;
-    int _initialType;
+    bool _onlyShowIcon;
     std::vector<int> _icons;
     int _initialX;
     int _initialY;
@@ -55,8 +55,11 @@ protected:
     UI* _surface = 0;
     HiddenMask* _mask = 0;
     UI* _cursor = 0;
+    unsigned int _activatedAt = 0;
+    
+    void showMenu();
 public:
-    CursorDropdown(std::vector<int> icons);
+    CursorDropdown(std::vector<int> icons, bool onlyIcon = false);
     virtual ~CursorDropdown();
     virtual void init();
     virtual void think();
@@ -65,6 +68,10 @@ public:
 
     Game::GameObject* object();
     void setObject(Game::GameObject* object);
+
+    virtual void onStateActivate(StateEvent* event);
+    virtual void onStateDeactivate(StateEvent* event);
+
 };
 
 }

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -55,7 +55,6 @@ protected:
     UI* _surface = 0;
     HiddenMask* _mask = 0;
     UI* _cursor = 0;
-    unsigned int _activatedAt = 0;
     
     void showMenu();
 public:

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -55,6 +55,7 @@ protected:
     UI* _surface = 0;
     HiddenMask* _mask = 0;
     UI* _cursor = 0;
+    bool _needToHide = false;
     
     void showMenu();
 public:

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -608,7 +608,7 @@ void Location::handle(Event* event)
             }
         }
         // let event fall down to all objects when using action cursor and within active view
-        if ((mouse->state() != Mouse::ACTION && mouse->state() != Mouse::NONE) || mouseEvent->y() > viewHeight())
+        if (mouse->state() != Mouse::ACTION && mouse->state() != Mouse::NONE)
         {
             event->setHandled(true);
         }
@@ -834,14 +834,9 @@ void Location::displayMessage(std::string message)
     Logger::info("MESSAGE") << message << std::endl;
 }
 
-unsigned int Location::viewWidth()
+PlayerPanel* Location::playerPanelState()
 {
-    return Game::getInstance()->renderer()->width();
-}
-
-unsigned int Location::viewHeight()
-{
-    return Game::getInstance()->renderer()->height() - _playerPanel->height();
+    return _playerPanel;
 }
 
 HexagonGrid* Location::hexagonGrid()

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -244,9 +244,11 @@ void Location::setLocation(std::string name)
     }
 }
 
-void Location::onMouseDown(Event* event, Game::GameObject* object)
+void Location::onObjectMouseDown(Event* event, Game::GameObject* object)
 {
     if (!object) return;
+    
+    _actionPressedTicks = SDL_GetTicks();
 
     std::vector<int> icons;
 
@@ -291,14 +293,6 @@ void Location::onMouseDown(Event* event, Game::GameObject* object)
 }
 
 void Location::onBackgroundClick(MouseEvent* event)
-{
-}
-
-void Location::onObjectClick(MouseEvent* event)
-{
-}
-
-void Location::onKeyUp(std::shared_ptr<KeyboardEvent> event)
 {
 }
 

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -119,6 +119,11 @@ public:
     void onObjectHover(Event* event, Game::GameObject* object);
     virtual void onKeyDown(KeyboardEvent* event);
 
+    virtual void onStateActivate(StateEvent* event);
+    virtual void onStateDeactivate(StateEvent* event);
+
+
+
 };
 
 }

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -25,6 +25,7 @@
 
 // Falltergeist includes
 #include "State.h"
+#include "../State/PlayerPanel.h"
 #include "../UI/ImageButton.h"
 
 // Third party includes
@@ -71,8 +72,10 @@ protected:
     bool _locationEnter = true;
     unsigned int _currentElevation = 0;
     unsigned int _lastClickedTile = 0;
+    Game::GameObject* _objectUnderCursor = NULL;
     Game::GameObject* _actionCursorLastObject = NULL;
     bool _actionCursorButtonPressed = false;
+    PlayerPanel* _playerPanel = NULL;
 
     bool _scrollLeft = false;
     bool _scrollRight = false;
@@ -106,6 +109,8 @@ public:
     void centerCameraAtHexagon(Hexagon* hexagon);
     void handleAction(Game::GameObject* object, int action);
     void toggleCursorMode();
+    unsigned int viewWidth();
+    unsigned int viewHeight();
     
     void displayMessage(std::string message);
 

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -57,6 +57,7 @@ protected:
     // Timers
     unsigned int _scrollTicks = 0;
     unsigned int _scriptsTicks = 0;
+    unsigned int _actionPressedTicks = 0;
 
     HexagonGrid* _hexagonGrid = 0;
     LocationCamera* _camera = 0;
@@ -103,9 +104,7 @@ public:
     void toggleCursorMode();
 
     void onBackgroundClick(MouseEvent* event);
-    void onKeyUp(std::shared_ptr<KeyboardEvent> event);
-    void onObjectClick(MouseEvent* event);
-    void onMouseDown(Event* event, Game::GameObject* object);
+    void onObjectMouseDown(Event* event, Game::GameObject* object);
     virtual void onKeyDown(KeyboardEvent* event);
 
 };

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -57,7 +57,7 @@ protected:
     // Timers
     unsigned int _scrollTicks = 0;
     unsigned int _scriptsTicks = 0;
-    unsigned int _actionPressedTicks = 0;
+    unsigned int _actionCursorTicks = 0;
 
     HexagonGrid* _hexagonGrid = 0;
     LocationCamera* _camera = 0;
@@ -71,6 +71,8 @@ protected:
     bool _locationEnter = true;
     unsigned int _currentElevation = 0;
     unsigned int _lastClickedTile = 0;
+    Game::GameObject* _actionCursorLastObject = NULL;
+    bool _actionCursorButtonPressed = false;
 
     bool _scrollLeft = false;
     bool _scrollRight = false;
@@ -79,6 +81,8 @@ protected:
 
     std::vector<Game::GameObject*> _objects;
     TextArea* _hexagonInfo = 0;
+    
+    std::vector<int> getCursorIconsForObject(Game::GameObject* object);
 public:
     Location();
     ~Location();
@@ -102,9 +106,12 @@ public:
     void centerCameraAtHexagon(Hexagon* hexagon);
     void handleAction(Game::GameObject* object, int action);
     void toggleCursorMode();
+    
+    void displayMessage(std::string message);
 
     void onBackgroundClick(MouseEvent* event);
-    void onObjectMouseDown(Event* event, Game::GameObject* object);
+    void onObjectMouseEvent(Event* event, Game::GameObject* object);
+    void onObjectHover(Event* event, Game::GameObject* object);
     virtual void onKeyDown(KeyboardEvent* event);
 
 };

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -109,8 +109,7 @@ public:
     void centerCameraAtHexagon(Hexagon* hexagon);
     void handleAction(Game::GameObject* object, int action);
     void toggleCursorMode();
-    unsigned int viewWidth();
-    unsigned int viewHeight();
+    PlayerPanel* playerPanelState();
     
     void displayMessage(std::string message);
 

--- a/src/State/PlayerPanel.cpp
+++ b/src/State/PlayerPanel.cpp
@@ -283,7 +283,8 @@ void PlayerPanel::onKeyDown(KeyboardEvent* event)
             // @TODO: volume up
             break;
         case SDLK_F4:
-            doSaveGame();
+            if (!event->altPressed())
+                doSaveGame();
             break;
         case SDLK_F5:
             doLoadGame();

--- a/src/State/PlayerPanel.cpp
+++ b/src/State/PlayerPanel.cpp
@@ -66,14 +66,14 @@ void PlayerPanel::init()
 
     auto game = Game::getInstance();
 
+    auto iface = new Image("art/intrface/iface.frm");
     setX((game->renderer()->width() - 640)*0.5);
-    setY(game->renderer()->height() - 99);
-
-    auto background = addUI("background", new Image("art/intrface/iface.frm"));
+    setY(game->renderer()->height() - iface->height());
+    auto background = addUI("background", iface);
     background->addEventHandler("mouseleftdown", [this](Event* event){ this->onPanelMouseDown(dynamic_cast<MouseEvent*>(event)); });
     background->addEventHandler("mousein", [this](Event* event){ this->onPanelMouseIn(dynamic_cast<MouseEvent*>(event)); });
     background->addEventHandler("mouseout", [this](Event* event){ this->onPanelMouseOut(dynamic_cast<MouseEvent*>(event)); });
-
+  
     addUI("change_hand_button", new ImageButton(ImageButton::TYPE_BIG_RED_CIRCLE, 218, 5));
     getActiveUI("change_hand_button")->addEventHandler("mouseleftclick", [this](Event* event){ this->onChangeHandButtonClick(dynamic_cast<MouseEvent*>(event)); });
 
@@ -301,6 +301,11 @@ void PlayerPanel::onKeyDown(KeyboardEvent* event)
             // @TODO: save screenshot
             break;
     }
+}
+
+unsigned int PlayerPanel::height()
+{
+    return getActiveUI("background")->height();
 }
 
 void PlayerPanel::openInventory()

--- a/src/State/PlayerPanel.h
+++ b/src/State/PlayerPanel.h
@@ -42,6 +42,8 @@ public:
     virtual void render();
     virtual void think();
     virtual void handle(Event* event);
+    
+    unsigned int height();
 
     void onChangeHandButtonClick(MouseEvent* event);
     void onPanelMouseDown(MouseEvent* event);

--- a/src/VM/Handlers/Opcode802FHandler.cpp
+++ b/src/VM/Handlers/Opcode802FHandler.cpp
@@ -37,7 +37,7 @@ void Opcode802FHandler::_run()
 {
     auto condition = _vm->popDataLogical();
     auto address = _vm->popDataInteger();
-    Logger::debug("SCRIPT") << "[802F] [*] ifthen(address, condition)" << std::endl
+    Logger::debug("SCRIPT") << "[802F] [*] ifthen(address, condition) " << std::hex << _vm->programCounter() << std::endl
                             << "    address = " << std::hex << address << std::endl
                             << "    condition = " << std::dec << condition << std::endl;
     if (!condition)

--- a/src/VM/Handlers/Opcode80B8Handler.cpp
+++ b/src/VM/Handlers/Opcode80B8Handler.cpp
@@ -23,8 +23,8 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode80B8Handler.h"
 #include "../../VM/VM.h"
-
-
+#include "../../Game/Game.h"
+#include "../../State/Location.h"
 
 
 // Third party includes
@@ -40,7 +40,8 @@ void Opcode80B8Handler::_run()
 {
     Logger::debug("SCRIPT") << "[80B8] [*] void display_msg(string*)" << std::endl;
     std::string* pointer = static_cast<std::string*>(_vm->popDataPointer());
-    Logger::debug("SCRIPT") << *pointer << std::endl;
+    auto game = Game::getInstance();
+    game->locationState()->displayMessage(*pointer);
 }
 
 }

--- a/src/VM/Handlers/Opcode80CFHandler.cpp
+++ b/src/VM/Handlers/Opcode80CFHandler.cpp
@@ -42,6 +42,8 @@ void Opcode80CFHandler::_run()
     _vm->popDataInteger();
     _vm->popDataInteger();
     _vm->popDataInteger();
+    _vm->popDataInteger();
+    // @TODO: implement
     _vm->pushDataInteger(0);
 }
 

--- a/src/VM/Handlers/Opcode80E1Handler.cpp
+++ b/src/VM/Handlers/Opcode80E1Handler.cpp
@@ -41,17 +41,29 @@ void Opcode80E1Handler::_run()
     auto p2 = _vm->popDataInteger();
     auto p1 = _vm->dataStack()->pop();
     auto meta = _vm->popDataInteger();
-    int result;
+    int result = 0;
     switch(meta)
     {
-        case 100: // rm_fixed_timer_event
-            result = 0;
+        case 100: // rm_fixed_timer_event(object, fixed_param, 0) 
             break;
-        case 110:   // unknown
-            result = 0;
+        case 101: // mark subtile visited on worldmap - mark_world_subtile_visited(x, y, radius)
+            break;
+        case 102: // METARULE3_SET_WM_MUSIC - (map index, ACM file name)
+            break;
+        case 103: // player_kill_count(critterType)
+            break;
+        case 104: // int mark_map_entrance_state(int map_idx, int state, int elev); elev -1 means for all elevations
+            break;
+        case 105: // int wm_get_subtile_state(int xPos, int yPos)  (0 - unknown, 1 - known, 2 - visited)
+            break;
+        case 106: // ObjectPtr tile_get_next_critter(int tile_num, int elev, ObjectPtr last_critter)
+            break; 
+        case 107: // int art_change_fid_num(ObjectPtr who, int fid) - change base FID num for object
+            break;
+        case 108: // void tile_set_center(int tileNum) - center camera on given tile
             break;
         default:
-            throw Exception("Opcode80E11Handler - unknown meta: " + std::to_string(meta));
+            throw Exception("Opcode80E1Handler - unknown meta: " + std::to_string(meta));
             break;
     }
     _vm->pushDataInteger(result);


### PR DESCRIPTION
1) Implemented actions when hovering over objects (with delay) to match original game.
2) Dropdown is opened only after delay and various other tweaks for dropdown.
3) Added sound FX for dropdown.
4) Implemented look_at_p_proc() and description_p_proc() actions for all objects.
5) Added stub method Location::displayMessage() - currently plays monitor.acm and prints message to log
6) Disabled capturing mouse in SDL window because currently it breaks mouse warping which is required for dropdown to work.
7) display_msg() opcode will use Location::displayMessage() method.
8) Fixed invalid number of stack arguments in tile_in_tile_rect() handler.
9) Stubs for all "meta" types in metarule3() handler.