### PR TITLE
Opcodes update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,8 @@ set(SOURCES main.cpp
     src/VM/Handlers/Opcode8150Handler.cpp
     src/VM/Handlers/Opcode8151Handler.h
     src/VM/Handlers/Opcode8151Handler.cpp
+    src/VM/Handlers/Opcode8152Handler.h
+    src/VM/Handlers/Opcode8152Handler.cpp
     src/VM/Handlers/Opcode8153Handler.h
     src/VM/Handlers/Opcode8153Handler.cpp
     src/VM/Handlers/Opcode8154Handler.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,8 @@ set(SOURCES main.cpp
     src/VM/Handlers/Opcode8040Handler.cpp
     src/VM/Handlers/Opcode8041Handler.h
     src/VM/Handlers/Opcode8041Handler.cpp
+    src/VM/Handlers/Opcode8044Handler.h
+    src/VM/Handlers/Opcode8044Handler.cpp
     src/VM/Handlers/Opcode8045Handler.h
     src/VM/Handlers/Opcode8045Handler.cpp
     src/VM/Handlers/Opcode8046Handler.h

--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -555,6 +555,15 @@ Animation* GameCritterObject::setActionAnimation(std::string action)
     return animation;
 }
 
+void GameCritterObject::setRadiationLevel(int radiationLevel)
+{
+    this->_radiationLevel = radiationLevel;
+}
+
+int GameCritterObject::radiationLevel()
+{
+    return _radiationLevel;
+}
 
 std::string GameCritterObject::_generateArmorFrmString()
 {

--- a/src/Game/CritterObject.h
+++ b/src/Game/CritterObject.h
@@ -46,6 +46,7 @@ protected:
 
     int _gender = GENDER_MALE;
     int _poisonLevel = 0;
+    int _radiationLevel = 0;
     int _hitPoints = 0;
     int _hitPointsMax = 0;
     int _healingRate = 0;
@@ -233,6 +234,9 @@ public:
 
     int poisonLevel();
     void setPoisonLevel(int value);
+    
+    int radiationLevel();
+    void setRadiationLevel(int radiationLevel);
 
     virtual int damageResist(unsigned int type);
     void setDamageResist(unsigned int type, int value);

--- a/src/VM/Handlers/Opcode8002Handler.cpp
+++ b/src/VM/Handlers/Opcode8002Handler.cpp
@@ -34,7 +34,7 @@ Opcode8002Handler::Opcode8002Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8002Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8002] lock" << std::endl;
+    Logger::debug("SCRIPT") << "[8002] op_critical_start" << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode8003Handler.cpp
+++ b/src/VM/Handlers/Opcode8003Handler.cpp
@@ -34,7 +34,7 @@ Opcode8003Handler::Opcode8003Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8003Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8003] unlock" << std::endl;
+    Logger::debug("SCRIPT") << "[8003] op_critical_done" << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode8004Handler.cpp
+++ b/src/VM/Handlers/Opcode8004Handler.cpp
@@ -38,7 +38,7 @@ void Opcode8004Handler::_run()
     auto address = _vm->popDataInteger();
     _vm->setProgramCounter(address);
 
-    Logger::debug("SCRIPT") << "[8004] [*] goto(address)" << std::endl
+    Logger::debug("SCRIPT") << "[8004] [*] op_jmp(address)" << std::endl
                             << "    address: " << std::hex << address << std::endl;
 
 

--- a/src/VM/Handlers/Opcode8005Handler.cpp
+++ b/src/VM/Handlers/Opcode8005Handler.cpp
@@ -36,16 +36,14 @@ Opcode8005Handler::Opcode8005Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8005Handler::_run()
 {
     auto functionIndex = _vm->popDataInteger();
-    auto argumentCount = _vm->popDataInteger();
+    // @TODO: pass arguments and call external procedures
+    /*auto argumentCount = _vm->popDataInteger();
     std::vector<int> args;
-    // just eat arguments from stack for now, so scripts won't crash completely
     for (int i = 0; i < argumentCount; i++)  
     {
         args.push_back(_vm->popDataInteger());
-    }
-    // @TODO: pass arguments
+    }*/
     _vm->setProgramCounter(_vm->script()->function(functionIndex));
-
     Logger::debug("SCRIPT") << "[8005] [*] op_call(0x" << std::hex << functionIndex << ") = 0x" << _vm->programCounter() << std::endl;
 }
 

--- a/src/VM/Handlers/Opcode8005Handler.cpp
+++ b/src/VM/Handlers/Opcode8005Handler.cpp
@@ -36,9 +36,17 @@ Opcode8005Handler::Opcode8005Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8005Handler::_run()
 {
     auto functionIndex = _vm->popDataInteger();
+    auto argumentCount = _vm->popDataInteger();
+    std::vector<int> args;
+    // just eat arguments from stack for now, so scripts won't crash completely
+    for (int i = 0; i < argumentCount; i++)  
+    {
+        args.push_back(_vm->popDataInteger());
+    }
+    // @TODO: pass arguments
     _vm->setProgramCounter(_vm->script()->function(functionIndex));
 
-    Logger::debug("SCRIPT") << "[8005] [*] call(0x" << std::hex << functionIndex << ") = 0x" << _vm->programCounter() << std::endl;
+    Logger::debug("SCRIPT") << "[8005] [*] op_call(0x" << std::hex << functionIndex << ") = 0x" << _vm->programCounter() << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode800CHandler.cpp
+++ b/src/VM/Handlers/Opcode800CHandler.cpp
@@ -35,7 +35,7 @@ Opcode800CHandler::Opcode800CHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode800CHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[800C] [*] pop_r => push_d" << std::endl;
+    Logger::debug("SCRIPT") << "[800C] [*] op_a_to_d" << std::endl;
     _vm->dataStack()->push(_vm->returnStack()->pop());
 }
 

--- a/src/VM/Handlers/Opcode800DHandler.cpp
+++ b/src/VM/Handlers/Opcode800DHandler.cpp
@@ -35,7 +35,7 @@ Opcode800DHandler::Opcode800DHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode800DHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[800D] [*] pop_d => push_r" << std::endl;
+    Logger::debug("SCRIPT") << "[800D] [*] op_d_to_a" << std::endl;
     _vm->returnStack()->push(_vm->dataStack()->pop());
 }
 

--- a/src/VM/Handlers/Opcode8010Handler.cpp
+++ b/src/VM/Handlers/Opcode8010Handler.cpp
@@ -36,7 +36,7 @@ Opcode8010Handler::Opcode8010Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8010Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8010] [*] startdone" << std::endl;
+    Logger::debug("SCRIPT") << "[8010] [*] op_exit_prog" << std::endl;
     _vm->setInitialized(true);
     throw VMHaltException();
 }

--- a/src/VM/Handlers/Opcode8012Handler.cpp
+++ b/src/VM/Handlers/Opcode8012Handler.cpp
@@ -45,7 +45,7 @@ void Opcode8012Handler::_run()
 
     auto& debug = Logger::debug("SCRIPT");
 
-    debug   << "[8012] [*] value = SVAR[num]" << std::endl
+    debug   << "[8012] [*] value = op_fetch_global[num]" << std::endl
             << "      num: "  << number << std::endl
             << "     type: " << value->type() << std::endl
             << "    value: ";

--- a/src/VM/Handlers/Opcode8013Handler.cpp
+++ b/src/VM/Handlers/Opcode8013Handler.cpp
@@ -45,7 +45,7 @@ void Opcode8013Handler::_run()
 
     auto& debug = Logger::debug("SCRIPT");
 
-    debug   << "[8013] [*] SVAR[num] = value" << std::endl
+    debug   << "[8013] [*] op_store_global" << std::endl
             << "      num: "  << number << std::endl
             << "     type: " << value->type() << std::endl
             << "    value: ";

--- a/src/VM/Handlers/Opcode8014Handler.cpp
+++ b/src/VM/Handlers/Opcode8014Handler.cpp
@@ -61,7 +61,7 @@ void Opcode8014Handler::_run()
     auto value = EVARS->at(name);
     _vm->dataStack()->push(value);
 
-    debug << "[8014] [+] value = getExported(name)" << std::endl;
+    debug << "[8014] [+] value = op_fetch_external(name)" << std::endl;
     debug << "    name = " << name << std::endl;
     debug << "    type = " << value->type() << std::endl;
     switch (value->type())

--- a/src/VM/Handlers/Opcode8015Handler.cpp
+++ b/src/VM/Handlers/Opcode8015Handler.cpp
@@ -39,7 +39,7 @@ Opcode8015Handler::Opcode8015Handler(Falltergeist::VM *vm) : OpcodeHandler(vm)
 
 void Opcode8015Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8015] [*] export(value, name)" << std::endl;
+    Logger::debug("SCRIPT") << "[8015] [*] op_store_external(name, value)" << std::endl;
     auto name = static_cast<std::string*>(_vm->popDataPointer());
     auto value = _vm->dataStack()->pop();
     auto game = Game::getInstance();

--- a/src/VM/Handlers/Opcode8016Handler.cpp
+++ b/src/VM/Handlers/Opcode8016Handler.cpp
@@ -43,7 +43,7 @@ void Opcode8016Handler::_run()
     {
         EVARS->insert(std::make_pair(name, nullptr));
     }
-    Logger::debug("SCRIPT") << "[8016] [*] export(name)" << std::endl
+    Logger::debug("SCRIPT") << "[8016] [*] op_export_var(name)" << std::endl
                             << "    name: " << name << std::endl;
 }
 

--- a/src/VM/Handlers/Opcode8018Handler.cpp
+++ b/src/VM/Handlers/Opcode8018Handler.cpp
@@ -35,7 +35,7 @@ Opcode8018Handler::Opcode8018Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8018Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8018] [*] dswap" << std::endl;
+    Logger::debug("SCRIPT") << "[8018] [*] op_swap" << std::endl;
     _vm->dataStack()->swap();
 }
 

--- a/src/VM/Handlers/Opcode8019Handler.cpp
+++ b/src/VM/Handlers/Opcode8019Handler.cpp
@@ -35,7 +35,7 @@ Opcode8019Handler::Opcode8019Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8019Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8019] [*] rswap" << std::endl;
+    Logger::debug("SCRIPT") << "[8019] [*] op_swapa" << std::endl;
     _vm->returnStack()->swap();
 }
 

--- a/src/VM/Handlers/Opcode801AHandler.cpp
+++ b/src/VM/Handlers/Opcode801AHandler.cpp
@@ -35,7 +35,7 @@ Opcode801AHandler::Opcode801AHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode801AHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[801A] [*] pop_d" << std::endl;
+    Logger::debug("SCRIPT") << "[801A] [*] op_pop" << std::endl;
     _vm->dataStack()->pop();
 }
 

--- a/src/VM/Handlers/Opcode801BHandler.cpp
+++ b/src/VM/Handlers/Opcode801BHandler.cpp
@@ -35,8 +35,8 @@ Opcode801BHandler::Opcode801BHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode801BHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[801B] [?] dup_r" << std::endl;
-    _vm->returnStack()->push(_vm->returnStack()->top());
+    Logger::debug("SCRIPT") << "[801B] op_dup" << std::endl;
+    _vm->dataStack()->push(_vm->dataStack()->top());
 }
 
 }

--- a/src/VM/Handlers/Opcode801CHandler.cpp
+++ b/src/VM/Handlers/Opcode801CHandler.cpp
@@ -36,7 +36,7 @@ Opcode801CHandler::Opcode801CHandler(VM* vm) : OpcodeHandler(vm)
 void Opcode801CHandler::_run()
 {
     _vm->setProgramCounter(_vm->popReturnInteger());
-    Logger::debug("SCRIPT") << "[801C] [*] ret = 0x" << std::hex << _vm->programCounter() << std::endl;
+    Logger::debug("SCRIPT") << "[801C] [*] op_pop_return 0x" << std::hex << _vm->programCounter() << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode8027Handler.cpp
+++ b/src/VM/Handlers/Opcode8027Handler.cpp
@@ -36,9 +36,10 @@ Opcode8027Handler::Opcode8027Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8027Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8027] [?] unknown pop_d pop_d" << std::endl;
-    _vm->dataStack()->pop();
-    _vm->dataStack()->pop();
+    Logger::debug("SCRIPT") << "[8027] [?] op_check_arg_count" << std::endl;
+    _vm->dataStack()->pop(); // number of actual arguments
+    _vm->dataStack()->pop(); // procedure index
+    // @TODO: compare number of arguments with procedure info and throw script exception if they are not equal
 }
 
 }

--- a/src/VM/Handlers/Opcode8028Handler.cpp
+++ b/src/VM/Handlers/Opcode8028Handler.cpp
@@ -23,6 +23,7 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode8028Handler.h"
 #include "../../VM/VM.h"
+#include "../../VM/VMHaltException.h"
 
 // Third party includes
 
@@ -36,7 +37,7 @@ Opcode8028Handler::Opcode8028Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8028Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8028] [?] int lookup_string_proc(string)" << std::endl;
-    std::string* name = _vm->popDataPointer();
+    std::string name = _vm->popDataString();
     try
     {
         _vm->pushDataInteger(_vm->script()->function(name));

--- a/src/VM/Handlers/Opcode8028Handler.cpp
+++ b/src/VM/Handlers/Opcode8028Handler.cpp
@@ -23,7 +23,7 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode8028Handler.h"
 #include "../../VM/VM.h"
-#include "../../VM/VMHaltException.h"
+#include "../../Exception.h"
 
 // Third party includes
 
@@ -44,8 +44,7 @@ void Opcode8028Handler::_run()
     }
     catch (libfalltergeist::Exception &e)
     {
-        Logger::warning("SCRIPT") << "lookup_string_proc: " << e.what() << std::endl;
-        throw VMHaltException();
+        throw Exception(std::string("lookup_string_proc - ") + e.what());
     }
 }
 

--- a/src/VM/Handlers/Opcode8028Handler.cpp
+++ b/src/VM/Handlers/Opcode8028Handler.cpp
@@ -35,9 +35,17 @@ Opcode8028Handler::Opcode8028Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8028Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8028] [?] ? lookup_string_proc(? p1)" << std::endl;
-    _vm->popDataInteger();
-    _vm->pushDataPointer(0);
+    Logger::debug("SCRIPT") << "[8028] [?] int lookup_string_proc(string)" << std::endl;
+    std::string* name = _vm->popDataPointer();
+    try
+    {
+        _vm->pushDataInteger(_vm->script()->function(name));
+    }
+    catch (libfalltergeist::Exception &e)
+    {
+        Logger::warning("SCRIPT") << "lookup_string_proc: " << e.what() << std::endl;
+        throw VMHaltException();
+    }
 }
 
 }

--- a/src/VM/Handlers/Opcode8029Handler.cpp
+++ b/src/VM/Handlers/Opcode8029Handler.cpp
@@ -36,7 +36,7 @@ Opcode8029Handler::Opcode8029Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8029Handler::_run()
 {
     _vm->setDVARBase(_vm->popReturnInteger());
-    Logger::debug("SCRIPT") << "[8029] [*] DVAR restore = " << _vm->DVARbase() << std::endl;
+    Logger::debug("SCRIPT") << "[8029] [*] op_pop_base " << _vm->DVARbase() << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode802AHandler.cpp
+++ b/src/VM/Handlers/Opcode802AHandler.cpp
@@ -35,7 +35,7 @@ Opcode802AHandler::Opcode802AHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode802AHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[802A] [*] DVAR clear" << std::endl;
+    Logger::debug("SCRIPT") << "[802A] [*] op_pop_to_base" << std::endl;
     while (_vm->dataStack()->size() > _vm->DVARbase())
     {
         _vm->dataStack()->pop();

--- a/src/VM/Handlers/Opcode802BHandler.cpp
+++ b/src/VM/Handlers/Opcode802BHandler.cpp
@@ -38,7 +38,7 @@ void Opcode802BHandler::_run()
     auto argumentsCounter = _vm->popDataInteger();
     _vm->pushReturnInteger(_vm->DVARbase());
     _vm->setDVARBase(_vm->dataStack()->size() - argumentsCounter);
-    Logger::debug("SCRIPT") << "[802B] [*] set DVAR base = " << _vm->DVARbase() << std::endl;
+    Logger::debug("SCRIPT") << "[802B] [*] op_push_base = " << _vm->DVARbase() << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode802CHandler.cpp
+++ b/src/VM/Handlers/Opcode802CHandler.cpp
@@ -36,7 +36,7 @@ Opcode802CHandler::Opcode802CHandler(VM* vm) : OpcodeHandler(vm)
 void Opcode802CHandler::_run()
 {
     _vm->setSVARbase(_vm->dataStack()->size());
-    Logger::debug("SCRIPT") << "[802C] [*] set SVAR_base = " << _vm->SVARbase() << std::endl;
+    Logger::debug("SCRIPT") << "[802C] [*] op_set_global = " << _vm->SVARbase() << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode8030Handler.cpp
+++ b/src/VM/Handlers/Opcode8030Handler.cpp
@@ -37,9 +37,10 @@ void Opcode8030Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8030] [*] while(address, condition)" << std::endl;
     auto condition = _vm->popDataLogical();
-    if (condition)
+    auto address = _vm->popDataInteger();
+    if (!condition)
     {
-        _vm->setProgramCounter(_vm->popDataInteger());
+        _vm->setProgramCounter(address);
     }
 }
 

--- a/src/VM/Handlers/Opcode8031Handler.cpp
+++ b/src/VM/Handlers/Opcode8031Handler.cpp
@@ -37,7 +37,7 @@ void Opcode8031Handler::_run()
 {
     auto num = _vm->popDataInteger();
     auto value = _vm->dataStack()->pop();
-    Logger::debug("SCRIPT") << "[8031] [*] DVAR[num] = value " << "num = " << std::hex << num << " type = " << value->type() << std::endl;
+    Logger::debug("SCRIPT") << "[8031] [*] op_store " << "var" << std::hex << num << " type = " << value->type() << std::endl;
     _vm->dataStack()->values()->at(_vm->DVARbase() + num) = value;
 }
 

--- a/src/VM/Handlers/Opcode8032Handler.cpp
+++ b/src/VM/Handlers/Opcode8032Handler.cpp
@@ -38,7 +38,7 @@ void Opcode8032Handler::_run()
     auto num = _vm->popDataInteger();
     auto value = _vm->dataStack()->values()->at(_vm->DVARbase() + num);
     _vm->dataStack()->push(value);
-    Logger::debug("SCRIPT") << "[8032] [*] DVAR[num] " << "num = " << std::hex << num << " type = " << value->type() << std::endl;
+    Logger::debug("SCRIPT") << "[8032] [*] op_fetch " << "var" << std::hex << num << " type = " << value->type() << std::endl;
 }
 
 }

--- a/src/VM/Handlers/Opcode8033Handler.cpp
+++ b/src/VM/Handlers/Opcode8033Handler.cpp
@@ -36,7 +36,7 @@ Opcode8033Handler::Opcode8033Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8033Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8033] [*] eq ==" << std::endl;
+    Logger::debug("SCRIPT") << "[8033] [*] op_equal ==" << std::endl;
     switch (_vm->dataStack()->top()->type())
     {
         case VMStackValue::TYPE_INTEGER:
@@ -67,6 +67,7 @@ void Opcode8033Handler::_run()
         }
         case VMStackValue::TYPE_POINTER:
         {
+            // @TODO: proper string comparison
             auto p2 = _vm->popDataPointer();
             auto p1 = _vm->popDataPointer();
             _vm->pushDataInteger(p1 == p2);

--- a/src/VM/Handlers/Opcode8034Handler.cpp
+++ b/src/VM/Handlers/Opcode8034Handler.cpp
@@ -55,6 +55,7 @@ void Opcode8034Handler::_run()
         }
         case VMStackValue::TYPE_POINTER:
         {
+            // @TODO: add string comparison
             auto p2 = (int)(bool)_vm->popDataPointer();
             if (_vm->dataStack()->top()->type() == VMStackValue::TYPE_POINTER) // to check if the pointer is null
             {
@@ -76,7 +77,7 @@ void Opcode8034Handler::_run()
             break;
         }
     }
-    Logger::debug("SCRIPT") << "[8034] [*] neq !=" << std::endl;
+    Logger::debug("SCRIPT") << "[8034] [*] op_not_equal !=" << std::endl;
 
 }
 

--- a/src/VM/Handlers/Opcode8035Handler.cpp
+++ b/src/VM/Handlers/Opcode8035Handler.cpp
@@ -35,7 +35,8 @@ Opcode8035Handler::Opcode8035Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8035Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8035] [*] leq <=" << std::endl;
+    Logger::debug("SCRIPT") << "[8035] [*] op_less_equal <=" << std::endl;
+    // @TODO: add float and string comparison
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     _vm->pushDataInteger(a <= b);

--- a/src/VM/Handlers/Opcode8036Handler.cpp
+++ b/src/VM/Handlers/Opcode8036Handler.cpp
@@ -35,7 +35,8 @@ Opcode8036Handler::Opcode8036Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8036Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8036] [*] geq >=" << std::endl;
+    Logger::debug("SCRIPT") << "[8036] [*] op_greater_equal >=" << std::endl;
+    // @TODO: float and string comparison
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     _vm->pushDataInteger(a >= b);

--- a/src/VM/Handlers/Opcode8037Handler.cpp
+++ b/src/VM/Handlers/Opcode8037Handler.cpp
@@ -35,11 +35,12 @@ Opcode8037Handler::Opcode8037Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8037Handler::_run()
 {
+    // @TODO: float, string comparison
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     auto result = a < b;
 
-    Logger::debug("SCRIPT") << "[8037] [*] lt (a < b)" << std::endl
+    Logger::debug("SCRIPT") << "[8037] [*] op_less (a < b)" << std::endl
                             << "    a = " << a << std::endl
                             << "    b = " << b << std::endl
                             << "    result = " << result << std::endl;

--- a/src/VM/Handlers/Opcode8038Handler.cpp
+++ b/src/VM/Handlers/Opcode8038Handler.cpp
@@ -35,10 +35,11 @@ Opcode8038Handler::Opcode8038Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8038Handler::_run()
 {
+    // @TODO: float, string comparison
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     auto result = a > b;
-    Logger::debug("SCRIPT") << "[8038] [*] gt >" << std::endl
+    Logger::debug("SCRIPT") << "[8038] [*] op_greater >" << std::endl
                             << "    a = " << a << std::endl
                             << "    b = " << b << std::endl
                             << "    result = " << result << std::endl;

--- a/src/VM/Handlers/Opcode8039Handler.cpp
+++ b/src/VM/Handlers/Opcode8039Handler.cpp
@@ -38,7 +38,7 @@ Opcode8039Handler::Opcode8039Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8039Handler::_run()
 {
     auto& debug = Logger::debug("SCRIPT");
-    debug << "[8039] [*] value = value1 + value2" << std::endl;
+    debug << "[8039] [*] op_add(a, b)" << std::endl;
     auto b = _vm->dataStack()->top();
     switch (b->type())
     {

--- a/src/VM/Handlers/Opcode803AHandler.cpp
+++ b/src/VM/Handlers/Opcode803AHandler.cpp
@@ -35,7 +35,8 @@ Opcode803AHandler::Opcode803AHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode803AHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[803A] [*] minus -" << std::endl;
+    Logger::debug("SCRIPT") << "[803A] [*] op_sub(a, b) -" << std::endl;
+    // @TODO: other types
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     _vm->pushDataInteger(a - b);

--- a/src/VM/Handlers/Opcode803BHandler.cpp
+++ b/src/VM/Handlers/Opcode803BHandler.cpp
@@ -35,7 +35,8 @@ Opcode803BHandler::Opcode803BHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode803BHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[803B] [*] mult *" << std::endl;
+    Logger::debug("SCRIPT") << "[803B] [*] op_mul(a, b) *" << std::endl;
+    // @TODO: other types
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     _vm->pushDataInteger(a * b);

--- a/src/VM/Handlers/Opcode803CHandler.cpp
+++ b/src/VM/Handlers/Opcode803CHandler.cpp
@@ -23,7 +23,7 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode803CHandler.h"
 #include "../../VM/VM.h"
-#include "VMHaltException.h"
+#include "../../VM/VMHaltException.h"
 
 // Third party includes
 

--- a/src/VM/Handlers/Opcode803CHandler.cpp
+++ b/src/VM/Handlers/Opcode803CHandler.cpp
@@ -23,7 +23,7 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode803CHandler.h"
 #include "../../VM/VM.h"
-#include "../../VM/VMHaltException.h"
+#include "../../Exception.h"
 
 // Third party includes
 
@@ -42,8 +42,7 @@ void Opcode803CHandler::_run()
     auto a = _vm->popDataInteger();
     if (b == 0) 
     {
-        Logger::warning("SCRIPT") << "division by zero!" << std::endl;
-        throw VMHaltException();
+        throw Exception("Opcode803CHandler - division by zero!");
     }
     _vm->pushDataInteger(a/b);
 }

--- a/src/VM/Handlers/Opcode803CHandler.cpp
+++ b/src/VM/Handlers/Opcode803CHandler.cpp
@@ -23,6 +23,7 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode803CHandler.h"
 #include "../../VM/VM.h"
+#include "VMHaltException.h"
 
 // Third party includes
 
@@ -35,9 +36,15 @@ Opcode803CHandler::Opcode803CHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode803CHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[803C] [*] div /" << std::endl;
+    Logger::debug("SCRIPT") << "[803C] [*] op_div /" << std::endl;
+    // @TODO: other types
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
+    if (b == 0) 
+    {
+        Logger::warning("SCRIPT") << "division by zero!" << std::endl;
+        throw VMHaltException();
+    }
     _vm->pushDataInteger(a/b);
 }
 

--- a/src/VM/Handlers/Opcode803DHandler.cpp
+++ b/src/VM/Handlers/Opcode803DHandler.cpp
@@ -36,12 +36,13 @@ Opcode803DHandler::Opcode803DHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode803DHandler::_run()
 {
-    Logger::debug("SCRIPT") << "[803D] [*] mod %" << std::endl;
+    Logger::debug("SCRIPT") << "[803D] [*] op_mod %" << std::endl;
+    // @TODO: may probably need type conversions
     auto b = _vm->dataStack()->pop();
     auto a = _vm->dataStack()->pop();
     auto p1 = dynamic_cast<VMStackIntValue*>(a);
     auto p2 = dynamic_cast<VMStackIntValue*>(b);
-    _vm->pushDataInteger(p1->value()%p2->value());
+    _vm->pushDataInteger(p1->value() % p2->value());
 }
 
 }

--- a/src/VM/Handlers/Opcode803EHandler.cpp
+++ b/src/VM/Handlers/Opcode803EHandler.cpp
@@ -35,7 +35,7 @@ Opcode803EHandler::Opcode803EHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode803EHandler::_run()
 {
-        Logger::debug("SCRIPT") << "[803E] [*] &&" << std::endl;
+        Logger::debug("SCRIPT") << "[803E] [*] op_and" << std::endl;
         auto b = _vm->popDataLogical();
         auto a = _vm->popDataLogical();
         _vm->pushDataInteger(a && b);

--- a/src/VM/Handlers/Opcode803FHandler.cpp
+++ b/src/VM/Handlers/Opcode803FHandler.cpp
@@ -35,7 +35,7 @@ Opcode803FHandler::Opcode803FHandler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode803FHandler::_run()
 {
-        Logger::debug("SCRIPT") << "[803F] [+] ||" << std::endl;
+        Logger::debug("SCRIPT") << "[803F] [+] op_or" << std::endl;
         auto b = _vm->popDataLogical();
         auto a = _vm->popDataLogical();
         _vm->pushDataInteger(a || b);

--- a/src/VM/Handlers/Opcode8040Handler.cpp
+++ b/src/VM/Handlers/Opcode8040Handler.cpp
@@ -35,7 +35,8 @@ Opcode8040Handler::Opcode8040Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8040Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8040] [*] &" << std::endl;
+    Logger::debug("SCRIPT") << "[8040] [*] op_bwand" << std::endl;
+    // @TODO: may need type conversion
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     _vm->pushDataInteger(a & b);

--- a/src/VM/Handlers/Opcode8041Handler.cpp
+++ b/src/VM/Handlers/Opcode8041Handler.cpp
@@ -35,7 +35,8 @@ Opcode8041Handler::Opcode8041Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8041Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8041] [*] |" << std::endl;
+    Logger::debug("SCRIPT") << "[8041] [*] op_bwor" << std::endl;
+    // @TODO: type conversions or checks
     auto b = _vm->popDataInteger();
     auto a = _vm->popDataInteger();
     _vm->pushDataInteger(a | b);

--- a/src/VM/Handlers/Opcode8044Handler.cpp
+++ b/src/VM/Handlers/Opcode8044Handler.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2015 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// C++ standard includes
+
+// Falltergeist includes
+#include "../../Logger.h"
+#include "../../VM/Handlers/Opcode8044Handler.h"
+#include "../../VM/VM.h"
+#include "../../VM/VMStackValue.h"
+#include "../../Exception.h"
+
+// Third party includes
+
+namespace Falltergeist
+{
+
+Opcode8044Handler::Opcode8044Handler(VM* vm) : OpcodeHandler(vm)
+{
+}
+
+void Opcode8044Handler::_run()
+{
+    Logger::debug("SCRIPT") << "[8044] [*] op_floor" << std::endl;
+    auto value = _vm->dataStack()->pop();
+    auto intValue = dynamic_cast<VMStackIntValue*>(value);
+    auto floatValue = dynamic_cast<VMStackFloatValue*>(value);
+    int result = 0;
+    if (intValue) 
+    {
+        result = intValue->value();
+    }
+    else if (floatValue)
+    {
+        result = (int)floatValue->value(); // this is how "floor" originally worked..
+    }
+    _vm->pushDataInteger(result);
+}
+
+}

--- a/src/VM/Handlers/Opcode8044Handler.h
+++ b/src/VM/Handlers/Opcode8044Handler.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012-2015 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALLTERGEIST_OPCODE8044HANDLER_H
+#define FALLTERGEIST_OPCODE8044HANDLER_H
+
+// C++ standard includes
+
+// Falltergeist includes
+#include "../../VM/OpcodeHandler.h"
+
+// Third party includes
+
+namespace Falltergeist
+{
+
+class Opcode8044Handler : public OpcodeHandler
+{
+public:
+    Opcode8044Handler(VM* vm);
+    virtual void _run();
+};
+
+}
+#endif // FALLTERGEIST_OPCODE8045HANDLER_H

--- a/src/VM/Handlers/Opcode8045Handler.cpp
+++ b/src/VM/Handlers/Opcode8045Handler.cpp
@@ -35,7 +35,7 @@ Opcode8045Handler::Opcode8045Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8045Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8045] [*] !" << std::endl;
+    Logger::debug("SCRIPT") << "[8045] [*] op_not" << std::endl;
     auto a = _vm->popDataLogical();
     _vm->pushDataInteger(!a);
 }

--- a/src/VM/Handlers/Opcode8046Handler.cpp
+++ b/src/VM/Handlers/Opcode8046Handler.cpp
@@ -23,6 +23,8 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode8046Handler.h"
 #include "../../VM/VM.h"
+#include "VMStackIntValue.h"
+#include "VMStackFloatValue.h"
 
 // Third party includes
 
@@ -35,9 +37,21 @@ Opcode8046Handler::Opcode8046Handler(VM* vm) : OpcodeHandler(vm)
 
 void Opcode8046Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[8046] [*] - value (change sign)" << std::endl;
-    auto value = _vm->popDataInteger();
-    _vm-> pushDataInteger(-value);
+    Logger::debug("SCRIPT") << "[8046] [*] op_negate" << std::endl;
+    auto value = _vm->dataStack()->pop();
+    if (value->type() == VMStackValue::TYPE_INTEGER) 
+    {
+        _vm->pushDataInteger(- static_cast<VMStackIntValue>(value)->value());
+    }
+    else
+    if (value->type() == VMStackValue::TYPE_FLOAT) 
+    {
+        _vm->pushDataFloat(- static_cast<VMStackFloatValue>(value)->value());
+    }
+    else
+    {
+        _vm->pushDataInteger(0);
+    }
 }
 
 }

--- a/src/VM/Handlers/Opcode8046Handler.cpp
+++ b/src/VM/Handlers/Opcode8046Handler.cpp
@@ -23,8 +23,8 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode8046Handler.h"
 #include "../../VM/VM.h"
-#include "VMStackIntValue.h"
-#include "VMStackFloatValue.h"
+#include "../../VM/VMStackIntValue.h"
+#include "../../VM/VMStackFloatValue.h"
 
 // Third party includes
 
@@ -41,12 +41,12 @@ void Opcode8046Handler::_run()
     auto value = _vm->dataStack()->pop();
     if (value->type() == VMStackValue::TYPE_INTEGER) 
     {
-        _vm->pushDataInteger(- static_cast<VMStackIntValue>(value)->value());
+        _vm->pushDataInteger(- (dynamic_cast<VMStackIntValue*>(value))->value());
     }
     else
     if (value->type() == VMStackValue::TYPE_FLOAT) 
     {
-        _vm->pushDataFloat(- static_cast<VMStackFloatValue>(value)->value());
+        _vm->pushDataFloat(- (dynamic_cast<VMStackFloatValue*>(value))->value());
     }
     else
     {

--- a/src/VM/Handlers/Opcode80A3Handler.cpp
+++ b/src/VM/Handlers/Opcode80A3Handler.cpp
@@ -23,6 +23,8 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode80A3Handler.h"
 #include "../../VM/VM.h"
+#include "../../Game/Game.h"
+#include "../../Audio/AudioMixer.h"
 
 // Third party includes
 
@@ -36,7 +38,8 @@ Opcode80A3Handler::Opcode80A3Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode80A3Handler::_run()
 {
     Logger::debug("SCRIPT") << "[80A3] [=] void play_sfx(string* p1)" << std::endl;
-    _vm->popDataPointer();
+    auto name = _vm->popDataString();
+    Game::Game::getInstance()->mixer()->playACMSound("sound/sfx/" + name + ".acm");
 }
 
 }

--- a/src/VM/Handlers/Opcode80CAHandler.cpp
+++ b/src/VM/Handlers/Opcode80CAHandler.cpp
@@ -31,6 +31,8 @@
 namespace Falltergeist
 {
 
+using namespace Game;
+
 Opcode80CAHandler::Opcode80CAHandler(VM* vm) : OpcodeHandler(vm)
 {
 }
@@ -98,6 +100,89 @@ void Opcode80CAHandler::_run()
             result = critter->criticalChance();
             break;
         }
+        case 16: // better criticals
+            // @TODO
+            break;
+        case 17: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_NORMAL);
+            break;
+        }
+        case 18: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_LASER);
+            break;
+        }
+        case 19: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_FIRE);
+            break;
+        }
+        case 20: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_PLASMA);
+            break;
+        }
+        case 21: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_ELECTRICAL);
+            break;
+        }
+        case 22: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_EMP);
+            break;
+        }
+        case 23: // 
+        {
+            result = critter->damageThreshold(GameCritterObject::DAMAGE_EXPLOSION);
+            break;
+        }
+        case 24: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_NORMAL);
+            break;
+        }
+        case 25: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_LASER);
+            break;
+        }
+        case 26: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_FIRE);
+            break;
+        }
+        case 27: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_PLASMA);
+            break;
+        }
+        case 28: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_ELECTRICAL);
+            break;
+        }
+        case 29: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_EMP);
+            break;
+        }
+        case 30: // 
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_EXPLOSION);
+            break;
+        }
+        case 31: // rad resist
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_RADIATION);
+            break;
+        }
+        case 32: // poison resist
+        {
+            result = critter->damageResist(GameCritterObject::DAMAGE_POISON);
+            break;
+        }
         case 33: // age
         {
             result = critter->gender();
@@ -111,6 +196,16 @@ void Opcode80CAHandler::_run()
         case 35: // hit points
         {
             result = critter->hitPoints();
+            break;
+        }
+        case 36: // current poison
+        {
+            result = critter->poisonLevel();
+            break;
+        }
+        case 37: // current radiation
+        {
+            result = critter->radiationLevel();
             break;
         }
         default:

--- a/src/VM/Handlers/Opcode80CAHandler.cpp
+++ b/src/VM/Handlers/Opcode80CAHandler.cpp
@@ -31,8 +31,6 @@
 namespace Falltergeist
 {
 
-using namespace Game;
-
 Opcode80CAHandler::Opcode80CAHandler(VM* vm) : OpcodeHandler(vm)
 {
 }
@@ -105,82 +103,82 @@ void Opcode80CAHandler::_run()
             break;
         case 17: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_NORMAL);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_NORMAL);
             break;
         }
         case 18: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_LASER);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_LASER);
             break;
         }
         case 19: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_FIRE);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_FIRE);
             break;
         }
         case 20: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_PLASMA);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_PLASMA);
             break;
         }
         case 21: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_ELECTRICAL);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_ELECTRICAL);
             break;
         }
         case 22: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_EMP);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_EMP);
             break;
         }
         case 23: // 
         {
-            result = critter->damageThreshold(GameCritterObject::DAMAGE_EXPLOSION);
+            result = critter->damageThreshold(Game::GameCritterObject::DAMAGE_EXPLOSION);
             break;
         }
         case 24: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_NORMAL);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_NORMAL);
             break;
         }
         case 25: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_LASER);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_LASER);
             break;
         }
         case 26: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_FIRE);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_FIRE);
             break;
         }
         case 27: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_PLASMA);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_PLASMA);
             break;
         }
         case 28: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_ELECTRICAL);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_ELECTRICAL);
             break;
         }
         case 29: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_EMP);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_EMP);
             break;
         }
         case 30: // 
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_EXPLOSION);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_EXPLOSION);
             break;
         }
         case 31: // rad resist
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_RADIATION);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_RADIATION);
             break;
         }
         case 32: // poison resist
         {
-            result = critter->damageResist(GameCritterObject::DAMAGE_POISON);
+            result = critter->damageResist(Game::GameCritterObject::DAMAGE_POISON);
             break;
         }
         case 33: // age

--- a/src/VM/Handlers/Opcode8152Handler.cpp
+++ b/src/VM/Handlers/Opcode8152Handler.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2014 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// C++ standard includes
+
+// Falltergeist includes
+#include "../../Logger.h"
+#include "../../VM/Handlers/Opcode8152Handler.h"
+#include "../../VM/VM.h"
+
+
+
+// Third party includes
+
+namespace Falltergeist
+{
+
+Opcode8152Handler::Opcode8152Handler(VM* vm) : OpcodeHandler(vm)
+{
+}
+
+void Opcode8152Handler::_run()
+{
+    Logger::debug("SCRIPT") << "[8152] [=] void op_critter_set_flee_state(critter who, boolean flag)" << std::endl;
+    // @TODO: add implementation
+    _vm->popDataLogical();
+    _vm->popDataPointer();
+}
+
+}
+

--- a/src/VM/Handlers/Opcode8152Handler.h
+++ b/src/VM/Handlers/Opcode8152Handler.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2012-2014 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALLTERGEIST_OPCODE8152HANDLER_H
+#define FALLTERGEIST_OPCODE8152HANDLER_H
+
+// C++ standard includes
+
+// Falltergeist includes
+#include "../../VM/OpcodeHandler.h"
+
+// Third party includes
+
+namespace Falltergeist
+{
+
+class Opcode8152Handler : public OpcodeHandler
+{
+public:
+    Opcode8152Handler(VM* vm);
+private:
+    void _run();
+};
+
+}
+#endif

--- a/src/VM/OpcodeFactory.cpp
+++ b/src/VM/OpcodeFactory.cpp
@@ -64,6 +64,7 @@
 #include "../VM/Handlers/Opcode803FHandler.h"
 #include "../VM/Handlers/Opcode8040Handler.h"
 #include "../VM/Handlers/Opcode8041Handler.h"
+#include "../VM/Handlers/Opcode8044Handler.h"
 #include "../VM/Handlers/Opcode8045Handler.h"
 #include "../VM/Handlers/Opcode8046Handler.h"
 #include "../VM/Handlers/Opcode80A1Handler.h"
@@ -330,6 +331,9 @@ OpcodeHandler* OpcodeFactory::createOpcode(unsigned int number, VM* vm)
             break;
         case 0x8041:
             return new Opcode8041Handler(vm);
+            break;
+        case 0x8044:
+            return new Opcode8044Handler(vm);
             break;
         case 0x8045:
             return new Opcode8045Handler(vm);

--- a/src/VM/OpcodeFactory.cpp
+++ b/src/VM/OpcodeFactory.cpp
@@ -187,6 +187,7 @@
 #include "../VM/Handlers/Opcode814EHandler.h"
 #include "../VM/Handlers/Opcode8150Handler.h"
 #include "../VM/Handlers/Opcode8151Handler.h"
+#include "../VM/Handlers/Opcode8152Handler.h"
 #include "../VM/Handlers/Opcode8153Handler.h"
 #include "../VM/Handlers/Opcode8154Handler.h"
 #include "../VM/Handlers/Opcode9001Handler.h"
@@ -698,6 +699,9 @@ OpcodeHandler* OpcodeFactory::createOpcode(unsigned int number, VM* vm)
             break;
         case 0x8151:
             return new Opcode8151Handler(vm);
+            break;
+        case 0x8152:
+            return new Opcode8152Handler(vm);
             break;
         case 0x8153:
             return new Opcode8153Handler(vm);

--- a/src/VM/OpcodeFactory.cpp
+++ b/src/VM/OpcodeFactory.cpp
@@ -202,6 +202,8 @@ OpcodeHandler* OpcodeFactory::createOpcode(unsigned int number, VM* vm)
 {
     switch (number)
     {
+        case 0x8000: // O_NOOP
+            break;
         case 0x8002:
             return new Opcode8002Handler(vm);
             break;

--- a/src/VM/VM.cpp
+++ b/src/VM/VM.cpp
@@ -171,6 +171,29 @@ void VM::pushDataPointer(void* value, unsigned int type)
     _dataStack.push(pointer);
 }
 
+std::string VM::popDataString()
+{
+    auto stackValue = _dataStack.pop();
+    if (stackValue->type() == VMStackValue::TYPE_POINTER)
+    {
+        auto stackPointerValue = dynamic_cast<VMStackPointerValue*>(stackValue);
+        if (stackPointerValue->type() == VMStackPointerValue::POINTER_TYPE_STRING)
+        {
+            auto value = static_cast<std::string*>(stackPointerValue->value());
+            return *value;
+        }
+        throw Exception("VM::popDataString() - stack value is not a string");
+    }
+    throw Exception("VM::popDataString() - stack value is not a pointer");
+}
+
+void VM::pushDataString(std::string value)
+{
+    auto pointer = new VMStackPointerValue(new std::string(value));
+    pointer->setPointerType(VMStackPointerValue::POINTER_TYPE_STRING);
+    _dataStack.push(pointer);
+}
+
 int VM::popReturnInteger()
 {
     auto stackValue = _returnStack.pop();

--- a/src/VM/VM.cpp
+++ b/src/VM/VM.cpp
@@ -226,6 +226,7 @@ unsigned int VM::programCounter()
 
 void VM::setProgramCounter(unsigned int value)
 {
+    // @TODO: add check for valid address
     _programCounter = value;
 }
 

--- a/src/VM/VM.h
+++ b/src/VM/VM.h
@@ -25,6 +25,8 @@
 
 // Falltergeist includes
 #include "../VM/VMStack.h"
+#include "../VM/VMStackIntValue.h"
+#include "../VM/VMStackFloatValue.h"
 #include "../VM/VMStackPointerValue.h"
 
 // Third party includes

--- a/src/VM/VM.h
+++ b/src/VM/VM.h
@@ -79,6 +79,8 @@ public:
     void pushDataFloat(float value);
     void* popDataPointer();
     void pushDataPointer(void* value, unsigned int type = VMStackPointerValue::POINTER_TYPE_UNKNOWN);
+    std::string popDataString();
+    void pushDataString(std::string value);
     bool popDataLogical();
 
     VMStack* dataStack();


### PR DESCRIPTION
First pass: 
* Updated names for core opcodes.
* Add some comments for missing features.
* Fixed invalid op_dub behavior.
* Implemented op_lookup_string_proc, op_negate, op_play_sfx.
* Added handlers for op_floor, op_critter_set_flee_state.
* Added division by zero check.
* Added missing cases for op_get_critter_stat (along with new radiation property for all Critters).