### PR TITLE
Fix walking and running animations

### DIFF
--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -458,7 +458,7 @@ void GameCritterObject::think()
             delete _ui;
             _orientation = hexagon()->orientationTo(movementQueue()->back());
             auto animation = _generateMovementAnimation();
-            animation->setActionFrame(_running ? 3 : 4);
+            animation->setActionFrame(_running ? 2 : 4);
             animation->addEventHandler("actionFrame",    std::bind(&GameCritterObject::onMovementAnimationEnded, this, std::placeholders::_1));
             animation->addEventHandler("animationEnded", std::bind(&GameCritterObject::onMovementAnimationEnded, this, std::placeholders::_1));
             animation->play();
@@ -487,28 +487,30 @@ void GameCritterObject::onMovementAnimationEnded(Event* event)
 
     if (event->name() == "actionFrame" && newOrientation == orientation())
     {
-        // fixing animation offsets
+        // at each action frame critter switches to the next hex and frame positions are offset relative to the action frame offsets
         auto animation = dynamic_cast<Animation*>(ui());
-        auto actionFrame = animation->frames()->at(animation->actionFrame() - 1);
-
+        auto actionFrame = animation->frames()->at(animation->actionFrame());
         for (auto it = animation->frames()->rbegin(); it != animation->frames()->rend(); ++it)
         {
             auto frame = (*it);
-            if (frame == actionFrame) break;
-
             frame->setXOffset(frame->xOffset() - actionFrame->xOffset());
             frame->setYOffset(frame->yOffset() - actionFrame->yOffset());
+            if (frame == actionFrame) break;
         }
 
         if (_running)
         {
             switch (animation->actionFrame())
             {
-                case 3:
-                    animation->setActionFrame(5);
+                // those frame numbers were guessed to make seamless running animation
+                case 2:
+                    animation->setActionFrame(4);
+                    break;
+                case 4:
+                    animation->setActionFrame(6);
                     break;
                 case 5:
-                    animation->setActionFrame(8);
+                    animation->setActionFrame(7);
                     break;
             }
         }
@@ -519,7 +521,7 @@ void GameCritterObject::onMovementAnimationEnded(Event* event)
         delete _ui;
         _orientation = newOrientation;
         auto animation = _generateMovementAnimation();
-        animation->setActionFrame(_running ? 3 : 4);
+        animation->setActionFrame(_running ? 2 : 4);
         animation->addEventHandler("actionFrame",    std::bind(&GameCritterObject::onMovementAnimationEnded, this, std::placeholders::_1));
         animation->addEventHandler("animationEnded", std::bind(&GameCritterObject::onMovementAnimationEnded, this, std::placeholders::_1));
         animation->play();
@@ -653,6 +655,15 @@ void GameCritterObject::setRunning(bool value)
 {
     _running = value;
 }
+
+void GameCritterObject::stopMovement()
+{
+    _movementQueue.clear();
+    auto queue = dynamic_cast<AnimationQueue*>(_ui);
+    if (queue) queue->stop();
+    _moving = false;
+}
+
 
 }
 }

--- a/src/Game/CritterObject.h
+++ b/src/Game/CritterObject.h
@@ -259,6 +259,8 @@ public:
 
     virtual bool running();
     virtual void setRunning(bool value);
+    
+    virtual void stopMovement();
 
     virtual Animation* setActionAnimation(std::string action);
 };

--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -333,6 +333,12 @@ unsigned int Animation::currentFrame()
     return _currentFrame;
 }
 
+void Animation::setCurrentFrame(unsigned int value)
+{
+    _currentFrame = value;
+    _progress = _reverse ? frames()->size() - _currentFrame - 1 : _currentFrame;
+}
+
 unsigned int Animation::actionFrame()
 {
     return _actionFrame;

--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -235,9 +235,9 @@ void Animation::think()
     {
         _frameTicks = SDL_GetTicks();
 
-        if (_progress < frames()->size() - 1)
+        _progress += 1;
+        if (_progress < frames()->size())
         {
-            _progress += 1;
             _currentFrame = _reverse ? frames()->size() - _progress - 1 : _progress;
             if (_actionFrame == _currentFrame)
             {

--- a/src/Graphics/Animation.h
+++ b/src/Graphics/Animation.h
@@ -75,6 +75,7 @@ public:
     void setReverse(bool value);
 
     unsigned int currentFrame();
+    void setCurrentFrame(unsigned int value);
     unsigned int actionFrame();
     void setActionFrame(unsigned int value);
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -556,7 +556,7 @@ void Location::handle(Event* event)
                     auto path = hexagonGrid()->findPath(game->player()->hexagon(), hexagon);
                     if (path.size())
                     {
-                        game->player()->movementQueue()->clear();
+                        game->player()->stopMovement();
                         game->player()->setRunning((_lastClickedTile != 0 && hexagon->number() == _lastClickedTile) || (mouseEvent->shiftPressed() != game->settings()->running()));
                         for (auto hexagon : path)
                         {

--- a/src/VM/Handlers/Opcode810EHandler.cpp
+++ b/src/VM/Handlers/Opcode810EHandler.cpp
@@ -24,6 +24,7 @@
 #include "../../Graphics/AnimationQueue.h"
 #include "../../Logger.h"
 #include "../../Game/Object.h"
+#include "../../Game/CritterObject.h"
 #include "../../VM/Handlers/Opcode810EHandler.h"
 #include "../../VM/VM.h"
 
@@ -54,10 +55,14 @@ void Opcode810EHandler::_run()
         case 0x2: // ANIM_CLEAR
         {
             auto object = static_cast<Game::GameObject*>(_vm->popDataPointer());
-            auto queue = dynamic_cast<AnimationQueue*>(object->ui());
-            if (queue)
+            if (auto critterObject = dynamic_cast<Game::GameCritterObject*>(object))
             {
-                queue->clear();
+                critterObject->stopMovement();
+            }
+            else
+            {
+                auto queue = dynamic_cast<AnimationQueue*>(object->ui());
+                if (queue) queue->stop();
             }
             break;
         }


### PR DESCRIPTION
1) Fixed incorrect frame offset applying after switching to next hex.
2) Tweaked action frame numbers to make seamless walking and running.
3) Added CritterObject::stopMovements() to immediately stop critter at their current hex.
4) Animations will continue from the same frame after changing direction during movement.

Fixes https://github.com/falltergeist/falltergeist/issues/252