### PR TITLE
Fix ItemsList vector out of range crash

### DIFF
--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -109,8 +109,8 @@ void ItemsList::onMouseLeftDown(MouseEvent* event)
 
 void ItemsList::onMouseDragStart(MouseEvent* event)
 {
-    unsigned int index = (event->y() - y())/_slotHeight;
     //half-assed fix for crashing when dragging items
+    unsigned int index = (unsigned int)(((event->y()) - y()) / _slotHeight);
     if(index > inventoryItems()->size() - 1)
     {
         index--;

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -110,6 +110,11 @@ void ItemsList::onMouseLeftDown(MouseEvent* event)
 void ItemsList::onMouseDragStart(MouseEvent* event)
 {
     unsigned int index = (event->y() - y())/_slotHeight;
+    //half-assed fix for crashing when dragging items
+    if(index > inventoryItems()->size() - 1)
+    {
+        index--;
+    }
     _draggedItem = inventoryItems()->at(index);
     _draggedItem->setType(InventoryItem::TYPE_DRAG);
     _draggedItem->setX(event->x());


### PR DESCRIPTION
when clicking or dragging just above or below items the game would crash with vector out of range error. This seems to fix the crashing related to it.

A non half-assed fix would be to write a better algorithm, but I couldn't think of a better way to do it. :)