### PR TITLE
add text outlining to game object floatmessages

### DIFF
--- a/src/VM/Handlers/Opcode810AHandler.cpp
+++ b/src/VM/Handlers/Opcode810AHandler.cpp
@@ -97,6 +97,8 @@ void Opcode810AHandler::_run()
     floatMessage->setWordWrap(true);
     floatMessage->setHorizontalAlign(TextArea::HORIZONTAL_ALIGN_CENTER);
     floatMessage->setFont(ResourceManager::font("font1.aaf", color));
+    floatMessage->setOutline(true);
+    floatMessage->setOutlineColor(0x000000ff);
     object->setFloatMessage(floatMessage);
 
 }


### PR DESCRIPTION

![falltergeist_float_outline](https://cloud.githubusercontent.com/assets/12400513/7738489/025b51a2-ff23-11e4-9c17-8eb04d027641.png)

