### PR TITLE
Fix clang warings

### DIFF
--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -354,18 +354,7 @@ void Animation::render(bool eggTransparency)
         if (pal->getCounter(MASK::REDDOT) < _reddotTextures.size())
             _reddotTextures.at(pal->getCounter(MASK::REDDOT))->copyTo(_tmptex);
 
-        //This is sloooow. But unfortunately sdl doesnt allow to blit over only alpha =/
-        for (unsigned int x = 0; x < texture()->width(); x++)
-        {
-            for (unsigned int y = 0; y < texture()->height(); y++)
-            {
-                if (x+egg_dx >= egg->width()) continue;
-                if (y+egg_dy >= egg->height()) continue;
-                if (x+egg_dx < 0) continue;
-                if (y+egg_dy < 0) continue;
-                _tmptex->setPixel(x, y, _tmptex->pixel(x,y) & egg->pixel(x+egg_dx, y+egg_dy));
-            }
-        }
+        _tmptex->blitWithAlpha(egg, egg_dx, egg_dy);
         Game::getInstance()->renderer()->drawTexture(_tmptex, x() + xOffset(), y() + yOffset(), frame->x(), frame->y(), frame->width(), frame->height());
     }
     else
@@ -404,13 +393,13 @@ unsigned int Animation::width()
 
 unsigned int Animation::pixel(unsigned int x, unsigned int y)
 {
-    auto frame = frames()->at(_currentFrame);
+    const auto frame = frames()->at(_currentFrame);
 
     x -= xOffset();
     y -= yOffset();
 
-    if (x < 0 || x > frame->width()) return 0;
-    if (y < 0 || y > frame->height()) return 0;
+    if (x > frame->width()) return 0;
+    if (y > frame->height()) return 0;
 
     return ActiveUI::pixel(x + frame->x(), y + frame->y());
 }

--- a/src/Graphics/Texture.cpp
+++ b/src/Graphics/Texture.cpp
@@ -280,4 +280,27 @@ SDL_BlendMode Texture::blendMode()
     return _blendMode;
 }
 
+bool Texture::blitWithAlpha(Texture* blitMask, int maskOffsetX, int maskOffsetY)
+{
+    if (!blitMask)
+        return false;
+
+    // TODO: Lock both surfaces only once and then use direct pixel access to blend.
+    const auto thisWidth = width();
+    const auto thisHeight = height();
+    const auto maskWidth = blitMask->width();
+    const auto maskHeight = blitMask->height();
+
+    //This is sloooow. But unfortunately sdl doesnt allow to blit over only alpha =/
+    for (unsigned int x = 0, maskX = std::max(0, maskOffsetX); x < thisWidth && maskX < maskWidth; ++x, ++maskX)
+    {
+        for (unsigned int y = 0, maskY = std::max(0, maskOffsetY); y < thisHeight && maskY < maskHeight; ++y, ++maskY)
+        {
+            setPixel(x, y, pixel(x,y) & blitMask->pixel(maskX, maskY));
+        }
+    }
+
+    return true;
+}
+
 }

--- a/src/Graphics/Texture.cpp
+++ b/src/Graphics/Texture.cpp
@@ -288,13 +288,16 @@ bool Texture::blitWithAlpha(Texture* blitMask, int maskOffsetX, int maskOffsetY)
     // TODO: Lock both surfaces only once and then use direct pixel access to blend.
     const auto thisWidth = width();
     const auto thisHeight = height();
-    const auto maskWidth = blitMask->width();
-    const auto maskHeight = blitMask->height();
+
+    unsigned int maskX = std::max(0, maskOffsetX);
+    unsigned int maskY = std::max(0, maskOffsetY);
+    const unsigned int maskWidth = blitMask->width() - (maskX - maskOffsetX);
+    const unsigned int maskHeight = blitMask->height() - (maskY - maskOffsetY);
 
     //This is sloooow. But unfortunately sdl doesnt allow to blit over only alpha =/
-    for (unsigned int x = 0, maskX = std::max(0, maskOffsetX); x < thisWidth && maskX < maskWidth; ++x, ++maskX)
+    for (unsigned int x = 0; x < thisWidth && maskX < maskWidth; ++x, ++maskX)
     {
-        for (unsigned int y = 0, maskY = std::max(0, maskOffsetY); y < thisHeight && maskY < maskHeight; ++y, ++maskY)
+        for (unsigned int y = 0; y < thisHeight && maskY < maskHeight; ++y, ++maskY)
         {
             setPixel(x, y, pixel(x,y) & blitMask->pixel(maskX, maskY));
         }

--- a/src/Graphics/Texture.h
+++ b/src/Graphics/Texture.h
@@ -81,6 +81,7 @@ public:
     void setBlendMode(SDL_BlendMode blendMode);
     SDL_BlendMode blendMode();
 
+    bool blitWithAlpha(Texture* blitMask, int maskOffsetX, int maskOffsetY);
 };
 
 }

--- a/src/Graphics/UI.cpp
+++ b/src/Graphics/UI.cpp
@@ -130,18 +130,7 @@ void UI::render(bool eggTransparency)
         if (!_tmptex) _tmptex = new Texture(texture()->width(),texture()->height());
         texture()->copyTo(_tmptex);
 
-        //This is sloooow. But unfortunately sdl doesnt allow to blit over only alpha =/
-        for (unsigned int x = 0; x < texture()->width(); x++)
-        {
-            for (unsigned int y = 0; y < texture()->height(); y++)
-            {
-                if (x+egg_dx >= egg->width()) continue;
-                if (y+egg_dy >= egg->height()) continue;
-                if (x+egg_dx < 0) continue;
-                if (y+egg_dy < 0) continue;
-                _tmptex->setPixel(x, y, _tmptex->pixel(x,y) & egg->pixel(x+egg_dx, y+egg_dy));
-            }
-        }
+        _tmptex->blitWithAlpha(egg, egg_dx, egg_dy);
         Game::getInstance()->renderer()->drawTexture(_tmptex, x(), y());
     }
     else

--- a/src/UI/AnimatedImage.cpp
+++ b/src/UI/AnimatedImage.cpp
@@ -268,18 +268,7 @@ void AnimatedImage::render(bool eggTransparency)
         if (pal->getCounter(MASK::REDDOT) < _reddotTextures.size())
             _reddotTextures.at(pal->getCounter(MASK::REDDOT))->copyTo(_tmptex);
 
-        //This is sloooow. But unfortunately sdl doesnt allow to blit over only alpha =/
-        for (unsigned int x = 0; x < texture()->width(); x++)
-        {
-            for (unsigned int y = 0; y < texture()->height(); y++)
-            {
-                if (x+egg_dx >= egg->width()) continue;
-                if (y+egg_dy >= egg->height()) continue;
-                if (x+egg_dx < 0) continue;
-                if (y+egg_dy < 0) continue;
-                _tmptex->setPixel(x, y, _tmptex->pixel(x,y) & egg->pixel(x+egg_dx, y+egg_dy));
-            }
-        }
+        _tmptex->blitWithAlpha(egg, egg_dx, egg_dy);
         Game::getInstance()->renderer()->drawTexture(_tmptex, x(), y());
     }
     else

--- a/src/VM/Handlers/Opcode80CAHandler.cpp
+++ b/src/VM/Handlers/Opcode80CAHandler.cpp
@@ -41,7 +41,7 @@ void Opcode80CAHandler::_run()
     int number = _vm->dataStack()->popInteger();
     debug << "    number = " << number << std::endl;
     auto object = _vm->dataStack()->popObject();
-    if (!object) 
+    if (!object)
     {
         _error("get_critter_stat(who, stat) - who is NULL");
     }
@@ -50,7 +50,7 @@ void Opcode80CAHandler::_run()
     {
         _error("get_critter_stat(who, stat) - who is not a critter");
     }
-    int result;
+    int result = 0;
     switch (number)
     {
         case 0: // ST
@@ -107,72 +107,72 @@ void Opcode80CAHandler::_run()
         case 16: // better criticals
             // @TODO
             break;
-        case 17: // 
+        case 17: //
         {
             result = critter->damageThreshold(DAMAGE::NORMAL);
             break;
         }
-        case 18: // 
+        case 18: //
         {
             result = critter->damageThreshold(DAMAGE::LASER);
             break;
         }
-        case 19: // 
+        case 19: //
         {
             result = critter->damageThreshold(DAMAGE::FIRE);
             break;
         }
-        case 20: // 
+        case 20: //
         {
             result = critter->damageThreshold(DAMAGE::PLASMA);
             break;
         }
-        case 21: // 
+        case 21: //
         {
             result = critter->damageThreshold(DAMAGE::ELECTRICAL);
             break;
         }
-        case 22: // 
+        case 22: //
         {
             result = critter->damageThreshold(DAMAGE::EMP);
             break;
         }
-        case 23: // 
+        case 23: //
         {
             result = critter->damageThreshold(DAMAGE::EXPLOSIVE);
             break;
         }
-        case 24: // 
+        case 24: //
         {
             result = critter->damageResist(DAMAGE::NORMAL);
             break;
         }
-        case 25: // 
+        case 25: //
         {
             result = critter->damageResist(DAMAGE::LASER);
             break;
         }
-        case 26: // 
+        case 26: //
         {
             result = critter->damageResist(DAMAGE::FIRE);
             break;
         }
-        case 27: // 
+        case 27: //
         {
             result = critter->damageResist(DAMAGE::PLASMA);
             break;
         }
-        case 28: // 
+        case 28: //
         {
             result = critter->damageResist(DAMAGE::ELECTRICAL);
             break;
         }
-        case 29: // 
+        case 29: //
         {
             result = critter->damageResist(DAMAGE::EMP);
             break;
         }
-        case 30: // 
+        case 30: //
         {
             result = critter->damageResist(DAMAGE::EXPLOSIVE);
             break;

--- a/src/VM/Handlers/Opcode80E1Handler.cpp
+++ b/src/VM/Handlers/Opcode80E1Handler.cpp
@@ -39,11 +39,8 @@ void Opcode80E1Handler::_run()
 {
     // @TODO: add implementation
     Logger::debug("SCRIPT") << "[80E1] [*] int metarule3(int meta, int p1, int p2, int p3)" << std::endl;
-    auto arg3 = _vm->dataStack()->popInteger();
-    auto arg2 = _vm->dataStack()->popInteger();
-    // Unused at the moment.
-    UNUSED_ARG(arg3);
-    UNUSED_ARG(arg2);
+    /* auto arg3 = */ (void)_vm->dataStack()->popInteger();
+    /* auto arg2 = */ (void)_vm->dataStack()->popInteger();
     auto arg1 = _vm->dataStack()->pop();
     auto meta = _vm->dataStack()->popInteger();
     int result = 0;

--- a/src/VM/Handlers/Opcode80E1Handler.cpp
+++ b/src/VM/Handlers/Opcode80E1Handler.cpp
@@ -41,12 +41,15 @@ void Opcode80E1Handler::_run()
     Logger::debug("SCRIPT") << "[80E1] [*] int metarule3(int meta, int p1, int p2, int p3)" << std::endl;
     auto arg3 = _vm->dataStack()->popInteger();
     auto arg2 = _vm->dataStack()->popInteger();
+    // Unused at the moment.
+    UNUSED_ARG(arg3);
+    UNUSED_ARG(arg2);
     auto arg1 = _vm->dataStack()->pop();
     auto meta = _vm->dataStack()->popInteger();
     int result = 0;
     switch(meta)
     {
-        case 100: // rm_fixed_timer_event(object, fixed_param, 0) 
+        case 100: // rm_fixed_timer_event(object, fixed_param, 0)
             break;
         case 101: // mark subtile visited on worldmap - mark_world_subtile_visited(x, y, radius)
             break;
@@ -59,7 +62,7 @@ void Opcode80E1Handler::_run()
         case 105: // int wm_get_subtile_state(int xPos, int yPos)  (0 - unknown, 1 - known, 2 - visited)
             break;
         case 106: // ObjectPtr tile_get_next_critter(int tile_num, int elev, ObjectPtr last_critter)
-            break; 
+            break;
         case 107: // int art_change_fid_num(ObjectPtr who, int fid) - change base FID num for object
             break;
         case 108: // void tile_set_center(int tileNum) - center camera on given tile

--- a/src/VM/Handlers/Opcode80E9Handler.cpp
+++ b/src/VM/Handlers/Opcode80E9Handler.cpp
@@ -37,6 +37,8 @@ void Opcode80E9Handler::_run()
 {
     Logger::debug("SCRIPT") << "[80E9] [*] void set_light_level(int level)" << std::endl;
     auto level = _vm->dataStack()->popInteger();
+    // Unused at the moment.
+    UNUSED_ARG(level);
 }
 
 }

--- a/src/VM/Handlers/Opcode80E9Handler.cpp
+++ b/src/VM/Handlers/Opcode80E9Handler.cpp
@@ -36,9 +36,7 @@ Opcode80E9Handler::Opcode80E9Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode80E9Handler::_run()
 {
     Logger::debug("SCRIPT") << "[80E9] [*] void set_light_level(int level)" << std::endl;
-    auto level = _vm->dataStack()->popInteger();
-    // Unused at the moment.
-    UNUSED_ARG(level);
+    /* auto level = */ (void)_vm->dataStack()->popInteger();
 }
 
 }

--- a/src/VM/Handlers/Opcode8102Handler.cpp
+++ b/src/VM/Handlers/Opcode8102Handler.cpp
@@ -42,6 +42,11 @@ void Opcode8102Handler::_run()
     auto trait = _vm->dataStack()->popInteger();
     auto trait_type = _vm->dataStack()->popInteger();
     auto who = _vm->dataStack()->popObject();
+
+    UNUSED_ARG(amount);
+    UNUSED_ARG(trait);
+    UNUSED_ARG(trait_type);
+    UNUSED_ARG(who);
     _vm->dataStack()->push(0);
 }
 

--- a/src/VM/Handlers/Opcode8102Handler.cpp
+++ b/src/VM/Handlers/Opcode8102Handler.cpp
@@ -38,15 +38,10 @@ Opcode8102Handler::Opcode8102Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8102Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8102] [*] int critter_add_trait(void* who, int trait_type, int trait, int amount) " << std::endl;
-    auto amount = _vm->dataStack()->popInteger();
-    auto trait = _vm->dataStack()->popInteger();
-    auto trait_type = _vm->dataStack()->popInteger();
-    auto who = _vm->dataStack()->popObject();
-
-    UNUSED_ARG(amount);
-    UNUSED_ARG(trait);
-    UNUSED_ARG(trait_type);
-    UNUSED_ARG(who);
+    /* auto amount = */ (void)_vm->dataStack()->popInteger();
+    /* auto trait = */ (void)_vm->dataStack()->popInteger();
+    /* auto trait_type = */ (void)_vm->dataStack()->popInteger();
+    /* auto who = */ (void)_vm->dataStack()->popObject();
     _vm->dataStack()->push(0);
 }
 

--- a/src/VM/Handlers/Opcode810AHandler.cpp
+++ b/src/VM/Handlers/Opcode810AHandler.cpp
@@ -40,7 +40,7 @@ void Opcode810AHandler::_run()
 {
     Logger::debug("SCRIPT") << "[810A] [=] void float_msg(object who, string msg, int type) " << std::endl;
     int type = _vm->dataStack()->popInteger();
-    unsigned int color;
+    unsigned int color = 0x000000ff;
     switch (type)
     {
         case -2:

--- a/src/VM/Handlers/Opcode810BHandler.cpp
+++ b/src/VM/Handlers/Opcode810BHandler.cpp
@@ -38,7 +38,7 @@ void Opcode810BHandler::_run()
     Logger::debug("SCRIPT") << "[810B] [*] int metarule(int type, value)" << std::endl;
     auto value = _vm->dataStack()->pop();
     auto type = _vm->dataStack()->popInteger();
-    int result;
+    int result = 0;
 
     switch(type)
     {

--- a/src/VM/Handlers/Opcode8115Handler.cpp
+++ b/src/VM/Handlers/Opcode8115Handler.cpp
@@ -37,6 +37,7 @@ void Opcode8115Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8115] [*] void playMovie(int movie)" << std::endl;
     int movie = _vm->dataStack()->popInteger();
+    UNUSED_ARG(movie);
 }
 
 }

--- a/src/VM/Handlers/Opcode8115Handler.cpp
+++ b/src/VM/Handlers/Opcode8115Handler.cpp
@@ -36,8 +36,7 @@ Opcode8115Handler::Opcode8115Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8115Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8115] [*] void playMovie(int movie)" << std::endl;
-    int movie = _vm->dataStack()->popInteger();
-    UNUSED_ARG(movie);
+    /* int movie = */ (void)_vm->dataStack()->popInteger();
 }
 
 }

--- a/src/VM/Handlers/Opcode8126Handler.cpp
+++ b/src/VM/Handlers/Opcode8126Handler.cpp
@@ -38,8 +38,7 @@ Opcode8126Handler::Opcode8126Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode8126Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8126] [-] void reg_anim_animate_forever(GameObject* obj , int delay)" << std::endl;
-    int delay = _vm->dataStack()->popInteger();
-    UNUSED_ARG(delay);
+    /* int delay = */ (void)_vm->dataStack()->popInteger();
     /*
     // delay - must be -1
     if (delay != -1)

--- a/src/VM/Handlers/Opcode8126Handler.cpp
+++ b/src/VM/Handlers/Opcode8126Handler.cpp
@@ -39,6 +39,7 @@ void Opcode8126Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8126] [-] void reg_anim_animate_forever(GameObject* obj , int delay)" << std::endl;
     int delay = _vm->dataStack()->popInteger();
+    UNUSED_ARG(delay);
     /*
     // delay - must be -1
     if (delay != -1)

--- a/src/VM/OpcodeHandler.h
+++ b/src/VM/OpcodeHandler.h
@@ -27,6 +27,9 @@
 
 // Third party includes
 
+// Marks handler parameter as unused and prevents compiler warnings.
+#define UNUSED_ARG(arg) (void)(arg)
+
 namespace Falltergeist
 {
 class VM;
@@ -36,7 +39,7 @@ class OpcodeHandler
 protected:
     VM* _vm;
     unsigned int _offset;
-    
+
     virtual void _run();
     // print warning message to log
     void _warning(const std::string& message);

--- a/src/VM/OpcodeHandler.h
+++ b/src/VM/OpcodeHandler.h
@@ -27,9 +27,6 @@
 
 // Third party includes
 
-// Marks handler parameter as unused and prevents compiler warnings.
-#define UNUSED_ARG(arg) (void)(arg)
-
 namespace Falltergeist
 {
 class VM;


### PR DESCRIPTION
Hi!

Here I'm trying to fix trivial warnings of Clang compiler, mainly related to unsigned types checks.
During this work I realized that duplicated code can be extracted as a method of Texture class.

It seems that my editor removed some trailing whitespaces, and I can revert those changes if you don't like it.