### PR TITLE
Fix possible memory leak (OpcodeHandler object).

### DIFF
--- a/src/VM/VM.cpp
+++ b/src/VM/VM.cpp
@@ -19,6 +19,7 @@
 
 // C++ standard includes
 #include <ctime>
+#include <memory>
 #include <sstream>
 
 // Falltergeist includes
@@ -103,11 +104,10 @@ void VM::run()
         unsigned short opcode;
         *_script >> opcode;
 
-        OpcodeHandler* opcodeHandler = OpcodeFactory::createOpcode(opcode, this);
+        std::unique_ptr<OpcodeHandler> opcodeHandler(OpcodeFactory::createOpcode(opcode, this));
         try
         {
             opcodeHandler->run();
-            delete opcodeHandler;
         }
         catch (VMHaltException& e)
         {


### PR DESCRIPTION
If exception will be thrown, then newly created OpcodeHandler object wouldn't be deleted.
std::unique_ptr can easily fix that issue.