### PR TITLE
Make Game a singleton.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,11 +18,13 @@
  */
 
 // C++ standard includes
+#include <memory>
 
 // Falltergeist includes
 #include "src/Exception.h"
 #include "src/Game/Game.h"
 #include "src/Logger.h"
+#include "src/Settings.h"
 #include "src/State/LuaState.h"
 #include "src/State/Start.h"
 
@@ -36,6 +38,7 @@ int main(int argc, char* argv[])
     try
     {
         auto game = Game::Game::getInstance();
+        game->init(std::unique_ptr<Settings>(new Settings()));
         game->setState(new State::Start());
         //game->setState(new State::LuaState("data/scripts/lua/state/mainmenu.lua"));
         game->run();

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -46,36 +46,29 @@ namespace Falltergeist
 namespace Game
 {
 
+class GameDudeObject;
+
 Game* getInstance()
 {
     return ::Falltergeist::Game::Game::getInstance();
 }
 
-class GameDudeObject;
-bool Game::_instanceFlag = false;
-Game* Game::_instance = NULL;
-
-Game* Game::getInstance()
+Game::Game()
 {
-    if(!_instanceFlag)
-    {
-        _instance = new Game();
-        _instanceFlag = true;
-        _instance->_initialize();
-        return _instance;
-    }
-    else
-    {
-        return _instance;
-    }
 }
 
-void Game::_initialize()
+// static
+Game* Game::getInstance()
+{
+    return Singleton<Game>::get();
+}
+
+void Game::init(std::unique_ptr<Settings> settings)
 {
     if (_initialized) return;
     _initialized = true;
 
-    _settings = new Settings();
+    _settings = std::move(settings);
     auto width = _settings->screenWidth();
     auto height = _settings->screenHeight();
 
@@ -112,7 +105,6 @@ void Game::_initialize()
 
 Game::~Game()
 {
-    _instanceFlag = false;
     shutdown();
 }
 
@@ -125,7 +117,7 @@ void Game::shutdown()
     delete _mixer;
     ResourceManager::getInstance()->shutdown();
     while (!_states.empty()) popState();
-    delete _settings;
+    _settings.reset();
     delete _gameTime;
     delete _currentTime;
     delete _renderer;
@@ -305,9 +297,9 @@ Renderer* Game::renderer()
     return _renderer;
 }
 
-Settings* Game::settings()
+Settings* Game::settings() const
 {
-    return _settings;
+    return _settings.get();
 }
 
 void Game::handle()

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 // Falltergeist includes
+#include "Base/Singleton.h"
 
 // Third party includes
 #include "SDL.h"
@@ -58,7 +59,6 @@ class GameTime;
 class Game
 {
 public:
-    ~Game();
     static Game* getInstance();
 
     void shutdown();
@@ -70,6 +70,7 @@ public:
     void popState();
     void run();
     void quit();
+    void init(std::unique_ptr<Settings> settings);
 
     void handle();
     void think();
@@ -86,7 +87,7 @@ public:
     void setGVAR(unsigned int number, int value);
     int GVAR(unsigned int number);
 
-    Settings* settings();
+    Settings* settings() const;
     AnimatedPalette* animatedPalette();
 
 protected:
@@ -105,20 +106,19 @@ protected:
     TextArea* _mousePosition = 0;
     TextArea* _currentTime = 0;
     TextArea* _falltergeistVersion = 0;
-    Settings* _settings = 0;
+    std::unique_ptr<Settings> _settings;
     AnimatedPalette* _animatedPalette = 0;
     bool _quit = false;
     SDL_Event _event;
     bool _initialized = false;
-    void _initialize();
     void _initGVARS();
 private:
-    Game() {}
-    Game(Game const&);
-    void operator=(Game const&);
-    static Game* _instance;
-    static bool _instanceFlag;
+    friend class Singleton<Game>;
 
+    Game();
+    ~Game();
+    Game(Game const&) = delete;
+    void operator=(Game const&) = delete;
 };
 
 Game* getInstance();


### PR DESCRIPTION
I have divided Game class construction into 2 phases.
First, Singleton construct a Game object.
Then it can be initialized with a Settings object.
That Settings object can be changed before passing to Game::init.
Also it seems that during Game::init() other code will try to access semi-constructed Game object via getInstance() method. It can lead to errors in future.
