### PR TITLE
Fix const override

### DIFF
--- a/src/Base/StlFeatures.h
+++ b/src/Base/StlFeatures.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2015 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALLTERGEIST_BASE_STLFEATURES_H
+#define FALLTERGEIST_BASE_STLFEATURES_H
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace Falltergeist
+{
+namespace Detail {
+template<class T> struct UniqueIf {
+    typedef std::unique_ptr<T> SingleObject;
+};
+
+template<class T> struct UniqueIf<T[]> {
+    typedef std::unique_ptr<T[]> UnknownBound;
+};
+
+template<class T, std::size_t N> struct UniqueIf<T[N]> {
+    typedef void KnownBound;
+};
+}  // namespace detail
+
+template<class T, class... Args>
+typename Detail::UniqueIf<T>::SingleObject
+make_unique(Args&&... args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+template<class T>
+typename Detail::UniqueIf<T>::UnknownBound
+make_unique(std::size_t n) {
+    typedef typename std::remove_extent<T>::type U;
+    return std::unique_ptr<T>(new U[n]());
+}
+
+template<class T, class... Args>
+typename Detail::UniqueIf<T>::KnownBound
+make_unique(Args&&...) = delete;
+}
+#endif // FALLTERGEIST_BASE_STLFEATURES_H

--- a/src/Graphics/ActiveUI.h
+++ b/src/Graphics/ActiveUI.h
@@ -38,7 +38,7 @@ class ActiveUI : public EventEmitter, public UI
 {
 public:
     ActiveUI(int x = 0, int y = 0);
-    virtual ~ActiveUI();
+    ~ActiveUI() override;
 
     virtual void handle(Event* event);
     static void export_to_lua_script(Lua::Script* script);

--- a/src/Graphics/ActiveUI.h
+++ b/src/Graphics/ActiveUI.h
@@ -37,7 +37,7 @@ namespace Falltergeist
 class ActiveUI : public EventEmitter, public UI
 {
 public:
-    ActiveUI(int x = 0, int y = 0);    
+    ActiveUI(int x = 0, int y = 0);
     virtual ~ActiveUI();
 
     virtual void handle(Event* event);

--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -381,12 +381,12 @@ void Animation::render(bool eggTransparency)
     }
 }
 
-unsigned int Animation::height()
+unsigned int Animation::height() const
 {
     return _animationFrames.at(_currentFrame)->height();
 }
 
-unsigned int Animation::width()
+unsigned int Animation::width() const
 {
     return _animationFrames.at(_currentFrame)->width();
 }

--- a/src/Graphics/Animation.h
+++ b/src/Graphics/Animation.h
@@ -66,8 +66,8 @@ public:
     virtual void setXShift(int value);
     virtual int yShift();
     virtual void setYShift(int value);
-    virtual unsigned int width();
-    virtual unsigned int height();
+    unsigned int width() const override;
+    unsigned int height() const override;
     virtual unsigned int pixel(unsigned int x, unsigned int y);
 
     void play();

--- a/src/Graphics/AnimationQueue.cpp
+++ b/src/Graphics/AnimationQueue.cpp
@@ -118,7 +118,7 @@ void AnimationQueue::think()
     }
 }
 
-Texture* AnimationQueue::texture()
+Texture* AnimationQueue::texture() const
 {
     return currentAnimation()->texture();
 }
@@ -130,17 +130,17 @@ unsigned int AnimationQueue::pixel(unsigned int x, unsigned int y)
     return currentAnimation()->pixel(x, y);
 }
 
-Animation* AnimationQueue::currentAnimation()
+Animation* AnimationQueue::currentAnimation() const
 {
     return _animations.at(_currentAnimation);
 }
 
-unsigned int AnimationQueue::width()
+unsigned int AnimationQueue::width() const
 {
     return currentAnimation()->width();
 }
 
-unsigned int AnimationQueue::height()
+unsigned int AnimationQueue::height() const
 {
     return currentAnimation()->height();
 }

--- a/src/Graphics/AnimationQueue.h
+++ b/src/Graphics/AnimationQueue.h
@@ -45,7 +45,7 @@ public:
     virtual ~AnimationQueue();
 
     std::vector<Animation*>* animations();
-    Animation* currentAnimation();
+    Animation* currentAnimation() const;
 
     void clear();
     void stop();
@@ -53,14 +53,14 @@ public:
     void setRepeat(bool value);
 
 
-    virtual Texture* texture();
+    Texture* texture() const override;
     virtual void render(bool eggTransparency = false);
     virtual void think();
     virtual unsigned int pixel(unsigned int x, unsigned int y);
 
 
-    virtual unsigned int width();
-    virtual unsigned int height();
+    unsigned int width() const override;
+    unsigned int height() const override;
     virtual int xOffset();
     virtual int yOffset();
 

--- a/src/Graphics/Texture.cpp
+++ b/src/Graphics/Texture.cpp
@@ -306,4 +306,36 @@ bool Texture::blitWithAlpha(Texture* blitMask, int maskOffsetX, int maskOffsetY)
     return true;
 }
 
+// static
+std::unique_ptr<Texture> Texture::generateTextureForNumber(
+    unsigned int number,
+    unsigned int maxLength,
+    Texture* symbolSource,
+    unsigned int charWidth,
+    unsigned int charHeight,
+    unsigned int xOffsetByColor,
+    bool isSigned)
+{
+    // number as text
+    const auto charsCount = maxLength + (isSigned ? 1 : 0);
+    auto texture = std::unique_ptr<Texture>(new Texture(charWidth * charsCount, charHeight));
+
+    // number as text
+    auto number_text = std::to_string(number);
+
+    // Fill counter padding with leading zeroes.
+    if (number_text.size() < maxLength)
+    {
+        number_text.insert(0, maxLength - number_text.size(), '0');
+    }
+
+    for (unsigned int i = 0; i < maxLength; i++)
+    {
+        const unsigned int key = 9 -  ('9' - number_text[i]);
+        const unsigned int x = charWidth * key + xOffsetByColor;
+        symbolSource->copyTo(texture.get(), charWidth * i, 0, x, 0, charWidth, charHeight);
+    }
+    return std::move(texture);
+}
+
 }

--- a/src/Graphics/Texture.cpp
+++ b/src/Graphics/Texture.cpp
@@ -20,6 +20,7 @@
 // C++ standard includes
 
 // Falltergeist includes
+#include "../Base/StlFeatures.h"
 #include "../Graphics/Texture.h"
 #include "../Game/Game.h"
 #include "../Graphics/Renderer.h"
@@ -316,9 +317,8 @@ std::unique_ptr<Texture> Texture::generateTextureForNumber(
     unsigned int xOffsetByColor,
     bool isSigned)
 {
-    // number as text
-    const auto charsCount = maxLength + (isSigned ? 1 : 0);
-    auto texture = std::unique_ptr<Texture>(new Texture(charWidth * charsCount, charHeight));
+    const auto charsCount = maxLength + (isSigned ? 1U : 0U);
+    auto texture = make_unique<Texture>(charWidth * charsCount, charHeight);
 
     // number as text
     auto number_text = std::to_string(number);

--- a/src/Graphics/Texture.h
+++ b/src/Graphics/Texture.h
@@ -82,6 +82,16 @@ public:
     SDL_BlendMode blendMode();
 
     bool blitWithAlpha(Texture* blitMask, int maskOffsetX, int maskOffsetY);
+
+    // Helpers to build some specific textures.
+    static std::unique_ptr<Texture> generateTextureForNumber(
+        unsigned int number,
+        unsigned int maxLength,
+        Texture* symbolSource,
+        unsigned int charWidth,
+        unsigned int charHeight,
+        unsigned int xOffsetByColor,
+        bool isSigned = false);
 };
 
 }

--- a/src/Graphics/UI.cpp
+++ b/src/Graphics/UI.cpp
@@ -93,7 +93,7 @@ void UI::setY(int value)
     _y = value;
 }
 
-Texture* UI::texture()
+Texture* UI::texture() const
 {
     return _texture;
 }
@@ -185,13 +185,13 @@ void UI::setYOffset(int yOffset)
     _yOffset = yOffset;
 }
 
-unsigned int UI::width()
+unsigned int UI::width() const
 {
     if (!texture()) return 0;
     return texture()->width();
 }
 
-unsigned int UI::height()
+unsigned int UI::height() const
 {
     if (!texture()) return 0;
     return texture()->height();

--- a/src/Graphics/UI.h
+++ b/src/Graphics/UI.h
@@ -54,7 +54,7 @@ public:
     virtual int yOffset();
     virtual void setYOffset(int yOffset);
 
-    virtual Texture* texture();
+    virtual Texture* texture() const;
     virtual void setTexture(Texture* texture);
 
     virtual void setVisible(bool value);
@@ -63,8 +63,8 @@ public:
     virtual void think();
     virtual void render(bool eggTransparency = false);
 
-    virtual unsigned int width();
-    virtual unsigned int height();
+    virtual unsigned int width() const;
+    virtual unsigned int height() const;
 
     virtual unsigned int pixel(unsigned int x, int unsigned y);
 
@@ -75,7 +75,7 @@ protected:
     int _y = 0;
     int _xOffset = 0;
     int _yOffset = 0;
-    Texture* _texture = 0;
+    mutable Texture* _texture = 0;
     Texture* _tmptex = 0;
     bool _leftButtonPressed = false;
     bool _rightButtonPressed = false;

--- a/src/Graphics/UI.h
+++ b/src/Graphics/UI.h
@@ -75,7 +75,7 @@ protected:
     int _y = 0;
     int _xOffset = 0;
     int _yOffset = 0;
-    mutable Texture* _texture = 0;
+    Texture* _texture = 0;
     Texture* _tmptex = 0;
     bool _leftButtonPressed = false;
     bool _rightButtonPressed = false;

--- a/src/UI/AnimatedImage.cpp
+++ b/src/UI/AnimatedImage.cpp
@@ -167,12 +167,12 @@ AnimatedImage::~AnimatedImage()
 {
 }
 
-unsigned int AnimatedImage::width()
+unsigned int AnimatedImage::width() const
 {
     return texture()->width();
 }
 
-unsigned int AnimatedImage::height()
+unsigned int AnimatedImage::height() const
 {
     return texture()->height();
 }

--- a/src/UI/AnimatedImage.h
+++ b/src/UI/AnimatedImage.h
@@ -45,8 +45,8 @@ protected:
     std::vector<Texture*> _reddotTextures;
 public:
     AnimatedImage(libfalltergeist::Frm::File* frm, unsigned int direction);
-    unsigned int width();
-    unsigned int height();
+    unsigned int width() const override;
+    unsigned int height() const override;
     ~AnimatedImage();
     void render(bool eggTransparency = false);
 };

--- a/src/UI/BigCounter.cpp
+++ b/src/UI/BigCounter.cpp
@@ -18,10 +18,9 @@
  */
 
 // C++ standard includes
-#include <sstream>
-#include <string.h>
 
 // Falltergeist includes
+#include "../Base/StlFeatures.h"
 #include "../Graphics/Texture.h"
 #include "../ResourceManager.h"
 #include "../UI/BigCounter.h"
@@ -48,7 +47,7 @@ Texture* BigCounter::texture() const
 
     if (_texture) return _texture;
 
-    auto numbers = std::unique_ptr<Image>(new Image("art/intrface/bignum.frm"));
+    auto numbers = make_unique<Image>("art/intrface/bignum.frm");
     unsigned int xOffsetByColor = 0;
     switch (_color)
     {

--- a/src/UI/BigCounter.cpp
+++ b/src/UI/BigCounter.cpp
@@ -45,7 +45,7 @@ Texture* BigCounter::texture() const
     static const int kCharWidth = 14;
     static const int kCharHeight = 24;
 
-    if (_texture) return _texture;
+    if (_textureOnDemand) return _textureOnDemand.get();
 
     auto numbers = make_unique<Image>("art/intrface/bignum.frm");
     unsigned int xOffsetByColor = 0;
@@ -58,16 +58,21 @@ Texture* BigCounter::texture() const
             break;
     }
 
-    auto texture = Texture::generateTextureForNumber(
+    _textureOnDemand = Texture::generateTextureForNumber(
         _number, _length, numbers->texture(),
         kCharWidth, kCharHeight, xOffsetByColor);
-    return (_texture = texture.release());
+    return _textureOnDemand.get();
+}
+
+void BigCounter::setTexture(Texture* texture)
+{
+    _textureOnDemand.reset(texture);
 }
 
 void BigCounter::setNumber(unsigned int number)
 {
     if (_number == number) return;
-    delete _texture; _texture = 0;
+    _textureOnDemand.reset();
     _number = number;
 }
 
@@ -75,7 +80,6 @@ unsigned int BigCounter::number()
 {
     return _number;
 }
-
 
 void BigCounter::setColor(unsigned char color)
 {
@@ -86,7 +90,7 @@ void BigCounter::setColor(unsigned char color)
             if (_color != color)
             {
                 _color = color;
-                delete _texture; _texture = 0;
+                _textureOnDemand.reset();
             }
             break;
     }

--- a/src/UI/BigCounter.cpp
+++ b/src/UI/BigCounter.cpp
@@ -41,48 +41,28 @@ BigCounter::~BigCounter()
 {
 }
 
-Texture* BigCounter::texture()
+Texture* BigCounter::texture() const
 {
+    static const int kCharWidth = 14;
+    static const int kCharHeight = 24;
+
     if (_texture) return _texture;
 
-    auto numbers = std::shared_ptr<Image>(new Image("art/intrface/bignum.frm"));
-
-    // number as text
-    std::stringstream ss;
-    ss << _number;
-
-    _texture = new Texture(14*_length, 24);
-
-    char* textNumber = new char[_length + 1]();
-
-    for (unsigned int i = 0; i < _length; ++i)
+    auto numbers = std::unique_ptr<Image>(new Image("art/intrface/bignum.frm"));
+    unsigned int xOffsetByColor = 0;
+    switch (_color)
     {
-        textNumber[i] = '0';
+        case COLOR_WHITE:
+            break;
+        case COLOR_RED:
+            xOffsetByColor = 168;
+            break;
     }
 
-    unsigned int length = strlen(ss.str().c_str());
-    unsigned int diff = _length - length;
-    for (unsigned int i = 0; i < length; i++)
-    {
-        textNumber[diff + i] = ss.str().c_str()[i];
-    }
-
-    for (unsigned int i = 0; i < _length; i++)
-    {
-        int key = 9 -  ('9' - textNumber[i]);
-        unsigned int x = 14 * key;
-        switch (_color)
-        {
-            case COLOR_WHITE:
-                break;
-            case COLOR_RED:
-                x += 168;
-                break;
-        }
-        numbers->texture()->copyTo(_texture, 14*i, 0, x, 0, 14, 24);
-    }
-    delete [] textNumber;
-    return _texture;
+    auto texture = Texture::generateTextureForNumber(
+        _number, _length, numbers->texture(),
+        kCharWidth, kCharHeight, xOffsetByColor);
+    return (_texture = texture.release());
 }
 
 void BigCounter::setNumber(unsigned int number)

--- a/src/UI/BigCounter.h
+++ b/src/UI/BigCounter.h
@@ -43,7 +43,7 @@ public:
     BigCounter(int x = 0, int y = 0, unsigned int length = 2);
     ~BigCounter();
 
-    virtual Texture* texture();
+    Texture* texture() const override;
 
     void setColor(unsigned char color);
     unsigned char color();

--- a/src/UI/BigCounter.h
+++ b/src/UI/BigCounter.h
@@ -21,7 +21,7 @@
 #define FALLTERGEIST_BIGCOUNTER_H
 
 // C++ standard includes
-#include <vector>
+#include <memory>
 
 // Falltergeist includes
 #include "../Graphics/ActiveUI.h"
@@ -38,10 +38,15 @@ protected:
     unsigned char _color = COLOR_WHITE;
     unsigned int _number = 0;
     unsigned int _length = 2;
+    mutable std::unique_ptr<Texture> _textureOnDemand;
+
+    // We should override this method to prevent changing old _texture field.
+    void setTexture(Texture* texture) override;
+
 public:
     enum {COLOR_WHITE = 1, COLOR_RED};
     BigCounter(int x = 0, int y = 0, unsigned int length = 2);
-    ~BigCounter();
+    ~BigCounter() override;
 
     Texture* texture() const override;
 
@@ -50,6 +55,13 @@ public:
 
     void setNumber(unsigned int number);
     unsigned int number();
+
+private:
+    // Hide unused field from childs.
+    using ActiveUI::_texture;
+
+    BigCounter(const BigCounter&) = delete;
+    void operator=(const BigCounter&) = delete;
 };
 
 }

--- a/src/UI/Image.cpp
+++ b/src/UI/Image.cpp
@@ -99,12 +99,12 @@ void Image::export_to_lua_script(Lua::Script* script)
         .endNamespace();
 }
 
-unsigned int Image::width()
+unsigned int Image::width() const
 {
     return texture()->width();
 }
 
-unsigned int Image::height()
+unsigned int Image::height() const
 {
     return texture()->height();
 }

--- a/src/UI/Image.h
+++ b/src/UI/Image.h
@@ -52,8 +52,8 @@ public:
     static void export_to_lua_script(Lua::Script* script);
 
 
-    unsigned int width();
-    unsigned int height();
+    unsigned int width() const override;
+    unsigned int height() const override;
 };
 
 }

--- a/src/UI/ImageButton.cpp
+++ b/src/UI/ImageButton.cpp
@@ -221,7 +221,7 @@ void ImageButton::export_to_lua_script(Lua::Script* script)
         .endNamespace();
 }
 
-Texture* ImageButton::texture()
+Texture* ImageButton::texture() const
 {
     if (_checkboxMode && _checked) return _textures.at(1);
 

--- a/src/UI/ImageButton.h
+++ b/src/UI/ImageButton.h
@@ -73,7 +73,7 @@ public:
     ~ImageButton();
 
     void setState(unsigned int value);
-    virtual Texture* texture();
+    Texture* texture() const;
     bool checked();
     void setChecked(bool _checked);
 

--- a/src/UI/ImageList.cpp
+++ b/src/UI/ImageList.cpp
@@ -51,7 +51,7 @@ ImageList::~ImageList()
     }
 }
 
-unsigned int ImageList::currentImage()
+unsigned int ImageList::currentImage() const
 {
     return _currentImage;
 }
@@ -63,7 +63,7 @@ void ImageList::setCurrentImage(unsigned int number)
 
 void ImageList::addImage(Image* image)
 {
-    images()->push_back(image);
+    _images.push_back(image);
 }
 
 void ImageList::addImage(const std::string& filename)
@@ -71,12 +71,12 @@ void ImageList::addImage(const std::string& filename)
     addImage(new Image(filename));
 }
 
-Texture* ImageList::texture()
+Texture* ImageList::texture() const
 {
     return images()->at(currentImage())->texture();
 }
 
-std::vector<Image*>* ImageList::images()
+const std::vector<Image*>* ImageList::images() const
 {
     return &_images;
 }

--- a/src/UI/ImageList.h
+++ b/src/UI/ImageList.h
@@ -46,9 +46,9 @@ public:
     void addImage(Image* image);
     void addImage(const std::string& filename);
     void setCurrentImage(unsigned int number);
-    unsigned int currentImage();
-    virtual Texture* texture();
-    std::vector<Image*>* images();
+    unsigned int currentImage() const;
+    Texture* texture() const override;
+    const std::vector<Image*>* images() const;
 };
 
 }

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -44,7 +44,7 @@ InventoryItem::InventoryItem(Game::GameItemObject *item, int x, int y) : ActiveU
     addEventHandler("mousedragstop", [this](Event* event){ this->onMouseDragStop(dynamic_cast<MouseEvent*>(event)); });
 }
 
-unsigned int InventoryItem::type()
+unsigned int InventoryItem::type() const
 {
     return _type;
 }
@@ -54,7 +54,7 @@ void InventoryItem::setType(unsigned int value)
     _type = value;
 }
 
-Texture* InventoryItem::texture()
+Texture* InventoryItem::texture() const
 {
     //if (!_texture)
     //{
@@ -174,12 +174,12 @@ void InventoryItem::onHandDragStop(MouseEvent* event)
     }
 }
 
-unsigned int InventoryItem::width()
+unsigned int InventoryItem::width() const
 {
     return type() == TYPE_SLOT ? 90 : 70;
 }
 
-unsigned int InventoryItem::height()
+unsigned int InventoryItem::height() const
 {
     return type() == TYPE_SLOT ? 63 : 49;
 }

--- a/src/UI/InventoryItem.h
+++ b/src/UI/InventoryItem.h
@@ -46,7 +46,7 @@ public:
     InventoryItem(Game::GameItemObject* item, int x = 0, int y = 0);
 
 
-    unsigned int type();
+    unsigned int type() const;
     void setType(unsigned int value);
 
     Game::GameItemObject* item();
@@ -54,9 +54,9 @@ public:
 
     virtual void render(bool eggTransparency = false);
     virtual unsigned int pixel(unsigned int x, unsigned int y);
-    virtual Texture* texture();
-    virtual unsigned int width();
-    virtual unsigned int height();
+    Texture* texture() const override;
+    unsigned int width() const override;
+    unsigned int height() const override;
 
     void onMouseLeftDown(MouseEvent* event);
     void onMouseDragStart(MouseEvent* event);

--- a/src/UI/MultistateImageButton.cpp
+++ b/src/UI/MultistateImageButton.cpp
@@ -175,7 +175,7 @@ void MultistateImageButton::_onLeftButtonUp(MouseEvent* event)
     }
 }
 
-Texture* MultistateImageButton::texture()
+Texture* MultistateImageButton::texture() const
 {
     return _imageList.images()->at(_currentState)->texture();
 }

--- a/src/UI/MultistateImageButton.h
+++ b/src/UI/MultistateImageButton.h
@@ -62,7 +62,7 @@ public:
     int mode();
     void setModeFactor(int factor);
     int modeFactor();
-    virtual Texture* texture();
+    Texture* texture() const override;
 };
 
 }

--- a/src/UI/Slider.cpp
+++ b/src/UI/Slider.cpp
@@ -104,7 +104,7 @@ void Slider::_onLeftButtonUp(MouseEvent* event)
     }
 }
 
-Texture* Slider::texture()
+Texture* Slider::texture() const
 {
     if (_drag) return _imageList.images()->at(0)->texture();
     return _imageList.images()->at(1)->texture();
@@ -141,7 +141,7 @@ void Slider::setValue(double value)
     _xOffset = (218/(maxValue() - minValue())) * _value;
 }
 
-int Slider::x()
+int Slider::x() const
 {
     return _x + _xOffset;
 }

--- a/src/UI/Slider.h
+++ b/src/UI/Slider.h
@@ -44,8 +44,8 @@ protected:
 public:
     Slider(int x, int y);
     virtual ~Slider();
-    virtual Texture* texture();
-    virtual int x();
+    Texture* texture() const override;
+    int x() const override;
     virtual void handle(Event* event);
     double minValue();
     void setMinValue(double value);

--- a/src/UI/SmallCounter.h
+++ b/src/UI/SmallCounter.h
@@ -46,7 +46,7 @@ public:
     SmallCounter(int x = 0, int y = 0);
     ~SmallCounter();
 
-    virtual Texture* texture();
+    Texture* texture() const override;
 
     void setColor(unsigned char color);
     unsigned char color();

--- a/src/UI/SmallCounter.h
+++ b/src/UI/SmallCounter.h
@@ -21,7 +21,7 @@
 #define FALLTERGEIST_SMALLCOUNTER_H
 
 // C++ standard includes
-#include <vector>
+#include <memory>
 
 // Falltergeist includes
 #include "../Graphics/ActiveUI.h"
@@ -39,12 +39,16 @@ protected:
     signed int _number = 0;
     unsigned int _length = 3;
     unsigned int _type = UNSIGNED; // unsigned by default
+    mutable std::unique_ptr<Texture> _textureOnDemand;
+
+    void setTexture(Texture* texture) override;
+
 public:
     enum {COLOR_WHITE = 1, COLOR_YELLOW, COLOR_RED};
     enum {UNSIGNED = 0, SIGNED};
 
     SmallCounter(int x = 0, int y = 0);
-    ~SmallCounter();
+    ~SmallCounter() override;
 
     Texture* texture() const override;
 
@@ -59,6 +63,13 @@ public:
 
     void setType(unsigned int type);
     unsigned int type();
+
+private:
+    // Hide unused field from childs.
+    using ActiveUI::_texture;
+
+    SmallCounter(const SmallCounter&) = delete;
+    void operator=(const SmallCounter&) = delete;
 };
 
 }


### PR DESCRIPTION
Fix for wrong functions override and tons of compiler warnings.
Without const some methods will be hidden but not overloaded.

During this work I moved generic implementation for Counters texture generation.
In future it should be better to use override\const override instead of just virtual.