### PR TITLE
Push zero PID for null objects popped from stack.

### DIFF
--- a/src/VM/Handlers/Opcode8100Handler.cpp
+++ b/src/VM/Handlers/Opcode8100Handler.cpp
@@ -40,8 +40,7 @@ void Opcode8100Handler::_run()
 {
     Logger::debug("SCRIPT") << "[8100] [+] int obj_pid(void* obj)" << std::endl;
     auto object = _vm->dataStack()->popObject();
-    if (!object) _error("obj_pid - obj is NULL");
-    _vm->dataStack()->push(object->PID());
+    _vm->dataStack()->push(object ? object->PID() : 0);
 }
 
 }


### PR DESCRIPTION
This prevents an error in Opcode8100Handler.cpp when popping a null object pushed earlier in Opcode 8106. This allows the player to talk to more characters in New Reno (tested with Cody, mobsters, Salvatore's men, porn actresses, prostitutes).