### PR TITLE
Optimize includes of Libfaltergeist headers

### DIFF
--- a/src/Audio/Mixer.cpp
+++ b/src/Audio/Mixer.cpp
@@ -32,6 +32,7 @@
 #include "../Settings.h"
 
 // Third party includes
+#include <Acm/File.h>
 #include <SDL.h>
 
 namespace Falltergeist

--- a/src/Audio/Mixer.h
+++ b/src/Audio/Mixer.h
@@ -25,7 +25,6 @@
 #include <unordered_map>
 
 // Falltergeist includes
-#include <libfalltergeist.h>
 
 // Third party includes
 #include <SDL_mixer.h>

--- a/src/Font.h
+++ b/src/Font.h
@@ -28,7 +28,8 @@
 #include "Graphics/Texture.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Aaf/File.h>
+#include <Aaf/Glyph.h>
 
 namespace Falltergeist
 {

--- a/src/Game/ArmorItemObject.h
+++ b/src/Game/ArmorItemObject.h
@@ -26,7 +26,7 @@
 #include "../Game/ItemObject.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Enums.h>
 
 namespace Falltergeist
 {

--- a/src/Game/CritterObject.h
+++ b/src/Game/CritterObject.h
@@ -29,9 +29,7 @@
 #include "../PathFinding/Hexagon.h"
 
 // Third party includes
-#include <libfalltergeist.h>
-
-using namespace libfalltergeist;
+#include <Enums.h>
 
 namespace Falltergeist
 {

--- a/src/Game/DudeObject.h
+++ b/src/Game/DudeObject.h
@@ -24,9 +24,9 @@
 
 // Falltergeist includes
 #include "../Game/CritterObject.h"
-#include <libfalltergeist.h>
 
 // Third party includes
+#include <Gcd/File.h>
 
 namespace Falltergeist
 {

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -43,6 +43,7 @@
 #include "../UI/TextArea.h"
 
 // Third patry includes
+#include <Gam/File.h>
 #include <SDL_image.h>
 
 namespace Falltergeist

--- a/src/Game/ObjectFactory.cpp
+++ b/src/Game/ObjectFactory.cpp
@@ -44,6 +44,7 @@
 #include "../VM/VM.h"
 
 // Third party includes
+#include <libfalltergeist.h>
 
 namespace Falltergeist
 {

--- a/src/Graphics/AnimatedPalette.cpp
+++ b/src/Graphics/AnimatedPalette.cpp
@@ -27,7 +27,6 @@
 // Third party includes
 #include <SDL.h>
 
-using namespace libfalltergeist;
 
 namespace Falltergeist
 {

--- a/src/Graphics/AnimatedPalette.h
+++ b/src/Graphics/AnimatedPalette.h
@@ -25,7 +25,7 @@
 // Falltergeist includes
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Enums.h>
 
 namespace Falltergeist
 {

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -27,14 +27,15 @@
 #include "CrossPlatform.h"
 #include "Exception.h"
 #include "Font.h"
+#include "Game/Location.h"
 #include "Graphics/Texture.h"
 #include "Logger.h"
 #include "ResourceManager.h"
 #include "Ini/File.h"
 #include "Ini/Parser.h"
-#include "Game/Location.h"
 
 // Third party includes
+#include <libfalltergeist.h>
 #include <SDL_image.h>
 
 namespace Falltergeist
@@ -120,6 +121,9 @@ libfalltergeist::Dat::Item* ResourceManager::datFileItem(std::string filename)
             else if (extension == "pal") item = new libfalltergeist::Pal::File(stream);
             else if (extension == "pro") item = new libfalltergeist::Pro::File(stream);
             else if (extension == "rix") item = new libfalltergeist::Rix::File(stream);
+            else if (filename == "data/city.txt") item = new libfalltergeist::Txt::CityFile(stream);
+            else if (filename == "data/maps.txt") item = new libfalltergeist::Txt::MapsFile(stream);
+            //else if (filename == "worldmap.txt") item = new libfalltergeist::Txt::WorldmapFile(stream);
             else
             {
                 item = new libfalltergeist::Dat::Item(stream);
@@ -229,6 +233,16 @@ libfalltergeist::Rix::File* ResourceManager::rixFileType(const std::string& file
 libfalltergeist::Sve::File* ResourceManager::sveFileType(const std::string& filename)
 {
     return dynamic_cast<libfalltergeist::Sve::File*>(datFileItem(filename));
+}
+
+libfalltergeist::Txt::CityFile* ResourceManager::cityTxt()
+{
+    return dynamic_cast<libfalltergeist::Txt::CityFile*>(datFileItem("data/city.txt"));
+}
+
+libfalltergeist::Txt::MapsFile* ResourceManager::mapsTxt()
+{
+    return dynamic_cast<libfalltergeist::Txt::MapsFile*>(datFileItem("data/maps.txt"));
 }
 
 Graphics::Texture* ResourceManager::texture(const std::string& filename)

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -25,14 +25,47 @@
 #include <map>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 // Falltergeist includes
 #include "Base/Singleton.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Lst/File.h>
+#include <Msg/File.h>
+#include <Msg/Message.h>
 
-using namespace libfalltergeist;
+namespace libfalltergeist
+{
+namespace Aaf { class File; }
+namespace Acm { class File; }
+namespace Bio { class File; }
+namespace Dat
+{
+class File;
+class Item;
+}
+namespace Frm { class File; }
+namespace Frm { class File; }
+namespace Fon { class File; }
+namespace Gam { class File; }
+namespace Gcd { class File; }
+namespace Pal { class File; }
+namespace Int { class File; }
+namespace Int { class File; }
+namespace Lst { class File; }
+namespace Map { class File; }
+namespace Mve { class File; }
+namespace Pro { class File; }
+namespace Pro { class File; }
+namespace Rix { class File; }
+namespace Sve { class File; }
+namespace Txt
+{
+class CityFile;
+class MapsFile;
+}
+}
 
 namespace Falltergeist
 {
@@ -73,6 +106,10 @@ public:
     libfalltergeist::Pro::File* proFileType(unsigned int PID);
     libfalltergeist::Rix::File* rixFileType(const std::string& filename);
     libfalltergeist::Sve::File* sveFileType(const std::string& filename);
+
+    libfalltergeist::Txt::CityFile* cityTxt();
+    libfalltergeist::Txt::MapsFile* mapsTxt();
+
     Graphics::Texture* texture(const std::string& filename);
     std::unordered_map<std::string, Graphics::Texture*>* textures();
     std::shared_ptr<Font> font(const std::string& filename = "font1.aaf", unsigned int color = 0x3ff800ff);

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -39,6 +39,8 @@
 #include "../VM/VM.h"
 
 // Third party includes
+#include <Int/File.h>
+#include <Int/Procedure.h>
 
 namespace Falltergeist
 {

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -62,6 +62,10 @@
 #include "../VM/VM.h"
 
 // Third party includes
+#include <Gam/File.h>
+#include <Map/Elevation.h>
+#include <Map/File.h>
+#include <Map/Object.h>
 
 namespace Falltergeist
 {

--- a/src/State/Movie.h
+++ b/src/State/Movie.h
@@ -26,7 +26,7 @@
 #include "State.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Sve/File.h>
 
 namespace Falltergeist
 {

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -36,6 +36,7 @@
 #include "../UI/TextArea.h"
 
 // Third party includes
+#include <Bio/File.h>
 
 namespace Falltergeist
 {

--- a/src/State/PlayerEditGender.h
+++ b/src/State/PlayerEditGender.h
@@ -26,7 +26,7 @@
 #include "State.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Enums.h>
 
 using namespace libfalltergeist;
 

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -23,17 +23,18 @@
 #include "../functions.h"
 #include "../Game/Game.h"
 #include "../Graphics/Renderer.h"
+#include "../Input/Mouse.h"
 #include "../ResourceManager.h"
+#include "../Settings.h"
 #include "../State/SettingsMenu.h"
 #include "../UI/Image.h"
 #include "../UI/ImageButton.h"
 #include "../UI/MultistateImageButton.h"
 #include "../UI/Slider.h"
 #include "../UI/TextArea.h"
-#include "../Settings.h"
-#include "../Input/Mouse.h"
 
 // Third party includes
+#include <Aaf/File.h>
 
 namespace Falltergeist
 {

--- a/src/State/SettingsMenu.h
+++ b/src/State/SettingsMenu.h
@@ -27,7 +27,6 @@
 #include "State.h"
 
 // Third party includes
-#include <libfalltergeist.h>
 
 namespace Falltergeist
 {

--- a/src/UI/AnimatedImage.cpp
+++ b/src/UI/AnimatedImage.cpp
@@ -33,6 +33,7 @@
 #include "../State/Location.h"
 
 // Third party includes
+#include <Frm/Direction.h>
 
 namespace Falltergeist
 {

--- a/src/UI/AnimatedImage.h
+++ b/src/UI/AnimatedImage.h
@@ -27,7 +27,7 @@
 #include "../UI/Base.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Frm/File.h>
 
 namespace Falltergeist
 {

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -35,7 +35,10 @@
 #include "../UI/AnimationFrame.h"
 
 // Third party includes
-#include "SDL.h"
+#include <Frm/Direction.h>
+#include <Frm/File.h>
+#include <Frm/Frame.h>
+#include <SDL.h>
 
 namespace Falltergeist
 {

--- a/src/UI/Image.h
+++ b/src/UI/Image.h
@@ -27,7 +27,8 @@
 #include "../UI/Base.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Frm/File.h>
+#include <Frm/Direction.h>
 
 namespace Falltergeist
 {

--- a/src/UI/MvePlayer.cpp
+++ b/src/UI/MvePlayer.cpp
@@ -30,6 +30,7 @@
 #include "../Logger.h"
 
 // Third party includes
+#include <Mve/Chunk.h>
 
 //@todo Move this to Crossplatform
 #ifdef __MACH__

--- a/src/UI/MvePlayer.h
+++ b/src/UI/MvePlayer.h
@@ -27,7 +27,7 @@
 #include "../UI/Base.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Mve/File.h>
 #include <SDL.h>
 
 namespace Falltergeist

--- a/src/UI/TextArea.cpp
+++ b/src/UI/TextArea.cpp
@@ -35,7 +35,7 @@
 #include "../UI/TextSymbol.h"
 
 // Third party includes
-#include "SDL.h"
+#include <SDL.h>
 
 namespace Falltergeist
 {

--- a/src/UI/TextArea.h
+++ b/src/UI/TextArea.h
@@ -29,7 +29,6 @@
 #include "../UI/Base.h"
 
 // Third party includes
-#include <libfalltergeist.h>
 
 namespace Falltergeist
 {

--- a/src/VM/Handlers/Opcode8028Handler.cpp
+++ b/src/VM/Handlers/Opcode8028Handler.cpp
@@ -26,6 +26,7 @@
 #include "../../Exception.h"
 
 // Third party includes
+#include <libfalltergeist.h>
 
 namespace Falltergeist
 {

--- a/src/VM/VM.h
+++ b/src/VM/VM.h
@@ -28,7 +28,8 @@
 #include "../VM/VMStackValue.h"
 
 // Third party includes
-#include <libfalltergeist.h>
+#include <Int/File.h>
+#include <Int/Procedure.h>
 
 namespace Falltergeist
 {


### PR DESCRIPTION
Related to #387 

Benefits:
* Reduced dependency from libfalltergeist headers, much less sensitivity to lib's header changes.
* It is more clear what exact file types are used in each source file.

Additionally adds some changes related to lib PR (see below).

Requires lib pull request: https://github.com/falltergeist/libfalltergeist/pull/38
