### PR TITLE
Improve loading speed

### DIFF
--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -295,11 +295,10 @@ void Object::render()
         - Point(_ui->size().width() / 2, _ui->size().height())
     );
 
-    setInRender(false);
-
     // don't draw if outside of screen
     if (!Rect::intersects(_ui->position(), _ui->size(), Point(0, 0), camera->size()))
     {
+        setInRender(false);
         return;
     }
 

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -34,6 +34,7 @@
 #include <libfalltergeist/Lst/File.h>
 #include <libfalltergeist/Msg/File.h>
 #include <libfalltergeist/Msg/Message.h>
+#include <libfalltergeist/Frm/File.h>
 
 namespace libfalltergeist
 {
@@ -145,7 +146,8 @@ protected:
     friend class Base::Singleton<ResourceManager>;
 
     std::vector<std::unique_ptr<libfalltergeist::Dat::File>> _datFiles;
-    std::unordered_map<std::string, std::unique_ptr<libfalltergeist::Dat::Item>> _datFilesItems;
+    std::vector<std::unique_ptr<libfalltergeist::Dat::Item>> _datItems;
+    std::unordered_map<std::string, libfalltergeist::Dat::Item*> _datItemMap;
     std::unordered_map<std::string, std::unique_ptr<Graphics::Texture>> _textures;
     std::unordered_map<std::string, std::unique_ptr<Font>> _fonts;
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -151,6 +151,7 @@ void Location::setLocation(const std::string& name)
 
     auto mapObjects = mapFile->elevations()->at(_currentElevation)->objects();
 
+    auto ticks = SDL_GetTicks();
     // @todo remove old objects from hexagonal grid
     for (auto mapObject : *mapObjects)
     {
@@ -207,6 +208,7 @@ void Location::setLocation(const std::string& name)
 
         _objects.emplace_back(object);
     }
+    Logger::info("GAME") << "Objects loaded in " << (SDL_GetTicks() - ticks) << std::endl;
 
     // Adding dude
     {

--- a/src/UI/AnimatedImage.cpp
+++ b/src/UI/AnimatedImage.cpp
@@ -46,8 +46,7 @@ using namespace Base;
 
 AnimatedImage::AnimatedImage(libfalltergeist::Frm::File* frm, unsigned int direction) : Falltergeist::UI::Base()
 {
-    _generateTexture(frm->width(), frm->height());
-    _texture->loadFromRGBA(frm->rgba(ResourceManager::getInstance()->palFileType("color.pal")));
+    _texture = ResourceManager::getInstance()->texture(frm->filename());
     auto dir = frm->directions()->at(direction);
     setOffset(frm->offsetX(direction) + dir->shiftX(), frm->offsetY(direction) + dir->shiftY());
 

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -324,9 +324,11 @@ void Base::handle(Event::Event* event)
 
 void Base::_generateTexture(unsigned int width, unsigned int height)
 {
-    auto ptr = new Graphics::Texture(width, height);
-    _generatedTexture.reset(ptr);
-    setTexture(ptr);
+    if (!_generatedTexture || _generatedTexture->width() != width || _generatedTexture->height() != height)
+    {
+        _generatedTexture = make_unique<Graphics::Texture>(width, height);
+        setTexture(_generatedTexture.get());
+    }
 }
 
 unsigned Base::width() const

--- a/src/UI/Image.cpp
+++ b/src/UI/Image.cpp
@@ -73,8 +73,7 @@ Image::Image(libfalltergeist::Frm::File* frm, unsigned int direction) : Fallterg
     _generateTexture(directionObj->width(), directionObj->height());
 
     // full frm texture
-    Graphics::Texture texture(frm->width(), frm->height());
-    texture.loadFromRGBA(frm->rgba(ResourceManager::getInstance()->palFileType("color.pal")));
+    Graphics::Texture* texture = ResourceManager::getInstance()->texture(frm->filename());
 
     // direction offset in full texture
     unsigned int y = 0;
@@ -83,7 +82,7 @@ Image::Image(libfalltergeist::Frm::File* frm, unsigned int direction) : Fallterg
         y += frm->directions()->at(direction)->height();
     }
 
-    texture.copyTo(_texture, 0, 0, 0, y, frm->directions()->at(direction)->width(), frm->directions()->at(direction)->height());
+    texture->copyTo(_texture, 0, 0, 0, y, frm->directions()->at(direction)->width(), frm->directions()->at(direction)->height());
     auto dir = frm->directions()->at(direction);
     setOffset(
         frm->offsetX(direction) + dir->shiftX(),

--- a/src/UI/TileMap.cpp
+++ b/src/UI/TileMap.cpp
@@ -30,6 +30,7 @@
 #include "../Graphics/Renderer.h"
 #include "../Graphics/Texture.h"
 #include "../LocationCamera.h"
+#include "../Logger.h"
 #include "../Point.h"
 #include "../ResourceManager.h"
 #include "../State/Location.h"
@@ -81,6 +82,7 @@ void TileMap::render()
 
 void TileMap::_generateTexture()
 {
+    auto ticks = SDL_GetTicks();
     std::vector<unsigned int> numbers;
     for (auto& tile : _tiles)
     {
@@ -115,6 +117,8 @@ void TileMap::_generateTexture()
         unsigned int y = (i/_square)*36;
         texture->copyTo(_texture.get(), x, y);
     }
+
+    Logger::info("GAME") << "Tilemap generated in " << (SDL_GetTicks() - ticks) << std::endl;
 }
 
 }


### PR DESCRIPTION
- optimized resource manager to cache Dat::Item's previously loaded from DAT file, without trying to find them on disk first (2.5x increase in game loading speed on my setup)

- minor optimizations to UI classes (to cache RGBA textures generated from FRMs via ResourceManager)