### PR TITLE
Delegates for event system

### DIFF
--- a/src/Base/Delegate.h
+++ b/src/Base/Delegate.h
@@ -106,6 +106,11 @@ public:
         invoke(std::forward<ArgT...>(args)...);
     }
 
+    explicit operator bool () const
+    {
+        return _functors.size() > 0;
+    }
+
 private:
     FunctorCollection _functors;
 

--- a/src/Base/Delegate.h
+++ b/src/Base/Delegate.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2012-2015 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALLTERGEIST_BASE_DELEGATE_H
+#define FALLTERGEIST_BASE_DELEGATE_H
+
+// C++ standard includes
+#include <functional>
+#include <vector>
+
+// Falltergeist includes
+
+namespace Falltergeist
+{
+namespace Base
+{
+
+template <typename ...ArgT>
+class Delegate
+{
+public:
+    using Functor = std::function<void(ArgT...)>;
+    using FunctorCollection = std::vector<Functor>;
+
+    Delegate<ArgT...>() {}
+
+    Delegate<ArgT...>(Functor func)
+    {
+        add(func);
+    }
+
+    void add(Functor func)
+    {
+        _functors.emplace_back(std::move(func));
+    }
+
+    void add(const Delegate<ArgT...>& other)
+    {
+        for (auto& func : other.functors())
+        {
+            add(func);
+        }
+    }
+
+    void clear()
+    {
+        _functors.clear();
+    }
+
+    void invoke(ArgT... args)
+    {
+        for (auto& func : _functors)
+        {
+            func(args...);
+        }
+    }
+
+    const FunctorCollection& functors() const
+    {
+        return _functors;
+    }
+
+    Delegate<ArgT...>& operator =(Functor func)
+    {
+        clear();
+        add(std::move(func));
+        return *this;
+    }
+
+    Delegate<ArgT...>& operator=(std::nullptr_t)
+    {
+        clear();
+        return *this;
+    }
+
+    Delegate<ArgT...>& operator +=(Functor func)
+    {
+        add(std::move(func));
+        return *this;
+    }
+
+    Delegate<ArgT...>& operator+=(const Delegate<ArgT...>& other)
+    {
+        add(other);
+        return *this;
+    }
+
+    void operator () (ArgT... args)
+    {
+        invoke(std::forward<ArgT...>(args)...);
+    }
+
+private:
+    FunctorCollection _functors;
+
+};
+
+}
+}
+
+#endif //FALLTERGEIST_BASE_DELEGATE_H

--- a/src/Event/Dispatcher.cpp
+++ b/src/Event/Dispatcher.cpp
@@ -21,10 +21,17 @@
 #include "../Event/Dispatcher.h"
 
 // C++ standard includes
+#include <functional>
+#include <type_traits>
+#include <utility>
 
 // Falltergeist includes
-#include "../Event/EventTarget.h"
 #include "../Base/StlFeatures.h"
+#include "../Event/EventTarget.h"
+#include "../Event/Event.h"
+#include "../Event/Mouse.h"
+#include "../Event/Keyboard.h"
+#include "../Event/State.h"
 
 // Third party includes
 
@@ -41,6 +48,7 @@ template <typename T>
 Dispatcher::Task<T>::Task(EventTarget* target, std::unique_ptr<T> event, Base::Delegate<T*> handler)
     : AbstractTask(target), event(std::move(event)), handler(handler)
 {
+    static_assert(std::is_base_of<Event, T>::value, "T should be derived from Event::Event.");
 }
 
 template <typename T>

--- a/src/Event/Dispatcher.cpp
+++ b/src/Event/Dispatcher.cpp
@@ -24,6 +24,7 @@
 
 // Falltergeist includes
 #include "../Event/EventTarget.h"
+#include "../Base/StlFeatures.h"
 
 // Third party includes
 
@@ -32,27 +33,33 @@ namespace Falltergeist
 namespace Event
 {
 
+using namespace Base;
+
+Dispatcher::AbstractTask::AbstractTask(EventTarget* target) : target(target) {}
+
+template <typename T>
+Dispatcher::Task<T>::Task(EventTarget* target, std::unique_ptr<T> event, Base::Delegate<T*> handler)
+    : AbstractTask(target), event(std::move(event)), handler(handler)
+{
+}
+
+template <typename T>
+void Dispatcher::Task<T>::perform()
+{
+    event->setHandled(false);
+    for (auto& func : handler.functors())
+    {
+        func(event.get());
+        // handler may set handled flag to true - to stop other handlers from executing
+        // also, target may be deleted by any handler, so we should check that on every iteration
+        if (event->handled() || target == nullptr) break;
+    }
+}
 
 template<typename T>
 void Dispatcher::scheduleEvent(EventTarget* target, std::unique_ptr<T> eventArg, Base::Delegate<T*> handlerArg)
 {
-    // following anonymous function will capture event and associated delegate to be processed later
-    _scheduledTasks.emplace_back(target, std::bind(
-        [] (Dispatcher::Task& task, std::unique_ptr<T>& event, Base::Delegate<T*>& handler)
-        {
-            event->setHandled(false);
-            for (auto& func : handler.functors())
-            {
-                func(event.get());
-                // handler may set handled flag to true - to stop other handlers from executing
-                // also, target may be deleted by any handler, so we should check that on every iteration
-                if (event->handled() || task.target == nullptr) break;
-            }
-        },
-        std::placeholders::_1, // Task&
-        std::move(eventArg),
-        std::move(handlerArg)
-    ));
+    _scheduledTasks.emplace_back(make_unique<Task<T>>(target, std::move(eventArg), std::move(handlerArg)));
 }
 
 void Dispatcher::processScheduledEvents()
@@ -60,11 +67,11 @@ void Dispatcher::processScheduledEvents()
     while (!_scheduledTasks.empty())
     {
         swap(_tasksInProcess, _scheduledTasks);
-        for (Task& task : _tasksInProcess)
+        for (auto& task : _tasksInProcess)
         {
             // after previous tasks this target might already be "dead"
-            if (task.target == nullptr) continue;
-            task.callback(task);
+            if (task->target == nullptr) continue;
+            task->perform();
         }
         _tasksInProcess.clear();
     }
@@ -72,18 +79,24 @@ void Dispatcher::processScheduledEvents()
 
 void Dispatcher::blockEventHandlers(EventTarget* eventTarget)
 {
-    _scheduledTasks.remove_if([eventTarget](Dispatcher::Task& task)
+    _scheduledTasks.remove_if([eventTarget](std::unique_ptr<Dispatcher::AbstractTask>& task)
     {
-        return (task.target == eventTarget);
+        return (task->target == eventTarget);
     });
     for (auto& task : _tasksInProcess)
     {
-        if (task.target == eventTarget)
+        if (task->target == eventTarget)
         {
-            task.target = nullptr;
+            task->target = nullptr;
         }
     }
 }
+
+// instantiations for all event types..
+template void Dispatcher::scheduleEvent<Event>(EventTarget*, std::unique_ptr<Event>, Base::Delegate<Event*>);
+template void Dispatcher::scheduleEvent<Mouse>(EventTarget*, std::unique_ptr<Mouse>, Base::Delegate<Mouse*>);
+template void Dispatcher::scheduleEvent<Keyboard>(EventTarget*, std::unique_ptr<Keyboard>, Base::Delegate<Keyboard*>);
+template void Dispatcher::scheduleEvent<State>(EventTarget*, std::unique_ptr<State>, Base::Delegate<State*>);
 
 }
 }

--- a/src/Event/Dispatcher.cpp
+++ b/src/Event/Dispatcher.cpp
@@ -49,12 +49,12 @@ void Dispatcher::processScheduledEvents()
 
             // any handler can alter current list of handlers by calling addEventHandler or removeEventHandlers on target,
             // so we have to use copy here
-            auto handlers = task.first->getEventHandlers(task.second->name());
+            auto handler = task.first->getEventHandler(task.second->name());
 
             task.second->setHandled(false);
-            for (auto& handler : handlers)
+            for (auto& func : handler.functors())
             {
-                handler(task.second.get());
+                func(task.second.get());
                 // handler may set handled flag to true - to stop other handlers from executing
                 // also, target may be deleted by any handler, so we should check that on every iteration
                 if (task.second->handled() || task.first == nullptr) break;

--- a/src/Event/Dispatcher.h
+++ b/src/Event/Dispatcher.h
@@ -41,12 +41,18 @@ class Dispatcher
 public:
     Dispatcher() {}
 
-    void scheduleEvent(EventTarget* target, std::unique_ptr<Event> event);
+    template <typename T>
+    void scheduleEvent(EventTarget* target, std::unique_ptr<T> event, Base::Delegate<T*> handler);
     void processScheduledEvents();
     void blockEventHandlers(EventTarget* eventTarget);
 
 private:
-    using Task = std::pair<EventTarget*, std::unique_ptr<Event>>;
+    struct Task
+    {
+        EventTarget* target;
+        std::function<void(Task&)> callback;
+    };
+
 
     Dispatcher(const Dispatcher&) = delete;
     void operator=(const Dispatcher&) = delete;

--- a/src/Event/Dispatcher.h
+++ b/src/Event/Dispatcher.h
@@ -21,6 +21,7 @@
 #define FALLTERGEIST_EVENT_DISPATCHER_H
 
 // C++ standard includes
+#include <functional>
 #include <list>
 #include <memory>
 #include <utility>
@@ -41,23 +42,35 @@ class Dispatcher
 public:
     Dispatcher() {}
 
-    template <typename T>
-    void scheduleEvent(EventTarget* target, std::unique_ptr<T> event, Base::Delegate<T*> handler);
+    template<typename T>
+    void scheduleEvent(EventTarget* target, std::unique_ptr<T> eventArg, Base::Delegate<T*> handlerArg);
+
     void processScheduledEvents();
     void blockEventHandlers(EventTarget* eventTarget);
 
 private:
-    struct Task
+    struct AbstractTask
     {
+        AbstractTask(EventTarget* target);
         EventTarget* target;
-        std::function<void(Task&)> callback;
+        virtual void perform() = 0;
+    };
+
+    template <typename T>
+    struct Task : AbstractTask
+    {
+        Task(EventTarget* target, std::unique_ptr<T> event, Base::Delegate<T*> handler);
+        void perform() override;
+
+        std::unique_ptr<T> event;
+        Base::Delegate<T*> handler;
     };
 
 
     Dispatcher(const Dispatcher&) = delete;
     void operator=(const Dispatcher&) = delete;
 
-    std::list<Task> _scheduledTasks, _tasksInProcess;
+    std::list<std::unique_ptr<AbstractTask>> _scheduledTasks, _tasksInProcess;
 };
 
 }

--- a/src/Event/Dispatcher.h
+++ b/src/Event/Dispatcher.h
@@ -21,10 +21,8 @@
 #define FALLTERGEIST_EVENT_DISPATCHER_H
 
 // C++ standard includes
-#include <functional>
 #include <list>
 #include <memory>
-#include <utility>
 
 // Falltergeist includes
 #include "../Event/Event.h"

--- a/src/Event/Event.h
+++ b/src/Event/Event.h
@@ -26,7 +26,6 @@
 #define FALLTERGEIST_EVENT_EVENT_H
 
 // C++ standard includes
-#include <memory>
 #include <string>
 
 // Falltergeist includes

--- a/src/Event/EventTarget.cpp
+++ b/src/Event/EventTarget.cpp
@@ -43,59 +43,13 @@ EventTarget::~EventTarget()
     _eventDispatcher->blockEventHandlers(this);
 }
 
-void EventTarget::addEventHandler(const std::string& eventName, Handler::Functor handler)
+template<typename T>
+void EventTarget::emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler)
 {
-    _eventHandlers[eventName].add(std::move(handler));
+    event->setTarget(this);
+    _eventDispatcher->scheduleEvent<T>(this, std::move(event), handler); // handler copy is necessary here
 }
 
-/*void EventTarget::processEvent(Event* event)
-{
-    const auto it = _eventHandlers.find(event->name());
-    event->setHandled(false);
-    if (it != _eventHandlers.end())
-    {
-        event->setTarget(this);
-        for (auto& eventHandler : it->second)
-        {
-            if (event->handled()) return;
-            eventHandler(event);
-        }
-    }
-}*/
-
-void EventTarget::emitEvent(std::unique_ptr<Event> event)
-{
-    const auto it = _eventHandlers.find(event->name());
-    if (it != _eventHandlers.end())
-    {
-        event->setTarget(this);
-        _eventDispatcher->scheduleEvent(this, std::move(event));
-    }
-}
-
-void EventTarget::removeEventHandlers(const std::string& eventName)
-{
-    const auto it = _eventHandlers.find(eventName);
-    if (it != _eventHandlers.end())
-    {
-        it->second.clear();
-    }
-}
-
-Handler EventTarget::getEventHandler(const std::string& eventName)
-{
-    const auto it = _eventHandlers.find(eventName);
-    if (it != _eventHandlers.end())
-    {
-        return it->second;
-    }
-    return Handler();
-}
-
-Handler& EventTarget::_getEventHandlerRef(const std::string& eventName)
-{
-    return _eventHandlers[eventName];
-}
 
 }
 }

--- a/src/Event/EventTarget.cpp
+++ b/src/Event/EventTarget.cpp
@@ -49,8 +49,11 @@ EventTarget::~EventTarget()
 template<typename T>
 void EventTarget::emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler)
 {
-    event->setTarget(this);
-    _eventDispatcher->scheduleEvent<T>(this, std::move(event), handler); // handler copy is necessary here
+    if (handler)
+    {
+        event->setTarget(this);
+        _eventDispatcher->scheduleEvent<T>(this, std::move(event), handler); // handler copy is necessary here
+    }
 }
 
 

--- a/src/Event/EventTarget.cpp
+++ b/src/Event/EventTarget.cpp
@@ -43,9 +43,9 @@ EventTarget::~EventTarget()
     _eventDispatcher->blockEventHandlers(this);
 }
 
-void EventTarget::addEventHandler(const std::string& eventName, EventHandler handler)
+void EventTarget::addEventHandler(const std::string& eventName, Handler::Functor handler)
 {
-    _eventHandlers[eventName].emplace_back(handler);
+    _eventHandlers[eventName].add(std::move(handler));
 }
 
 /*void EventTarget::processEvent(Event* event)
@@ -82,14 +82,19 @@ void EventTarget::removeEventHandlers(const std::string& eventName)
     }
 }
 
-std::vector<EventHandler> EventTarget::getEventHandlers(const std::string& eventName)
+Handler EventTarget::getEventHandler(const std::string& eventName)
 {
     const auto it = _eventHandlers.find(eventName);
     if (it != _eventHandlers.end())
     {
         return it->second;
     }
-    return std::vector<EventHandler>();
+    return Handler();
+}
+
+Handler& EventTarget::_getEventHandlerRef(const std::string& eventName)
+{
+    return _eventHandlers[eventName];
 }
 
 }

--- a/src/Event/EventTarget.cpp
+++ b/src/Event/EventTarget.cpp
@@ -25,6 +25,9 @@
 // Falltergeist includes
 #include "../Event/Dispatcher.h"
 #include "../Event/Event.h"
+#include "../Event/Mouse.h"
+#include "../Event/Keyboard.h"
+#include "../Event/State.h"
 
 // Third party includes
 
@@ -50,6 +53,12 @@ void EventTarget::emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler
     _eventDispatcher->scheduleEvent<T>(this, std::move(event), handler); // handler copy is necessary here
 }
 
+
+// this was necessary to decouple EventDispatcher from the rest of the classes
+template void EventTarget::emitEvent<Event>(std::unique_ptr<Event>, Base::Delegate<Event*>);
+template void EventTarget::emitEvent<Mouse>(std::unique_ptr<Mouse>, Base::Delegate<Mouse*>);
+template void EventTarget::emitEvent<Keyboard>(std::unique_ptr<Keyboard>, Base::Delegate<Keyboard*>);
+template void EventTarget::emitEvent<State>(std::unique_ptr<State>, Base::Delegate<State*>);
 
 }
 }

--- a/src/Event/EventTarget.cpp
+++ b/src/Event/EventTarget.cpp
@@ -21,6 +21,7 @@
 #include "EventTarget.h"
 
 // C++ standard includes
+#include <type_traits>
 
 // Falltergeist includes
 #include "../Event/Dispatcher.h"
@@ -47,8 +48,9 @@ EventTarget::~EventTarget()
 }
 
 template<typename T>
-void EventTarget::emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler)
+void EventTarget::emitEvent(std::unique_ptr<T> event, const Base::Delegate<T*>& handler)
 {
+    static_assert(std::is_base_of<Event, T>::value, "T should be derived from Event::Event.");
     if (handler)
     {
         event->setTarget(this);
@@ -58,10 +60,10 @@ void EventTarget::emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler
 
 
 // this was necessary to decouple EventDispatcher from the rest of the classes
-template void EventTarget::emitEvent<Event>(std::unique_ptr<Event>, Base::Delegate<Event*>);
-template void EventTarget::emitEvent<Mouse>(std::unique_ptr<Mouse>, Base::Delegate<Mouse*>);
-template void EventTarget::emitEvent<Keyboard>(std::unique_ptr<Keyboard>, Base::Delegate<Keyboard*>);
-template void EventTarget::emitEvent<State>(std::unique_ptr<State>, Base::Delegate<State*>);
+template void EventTarget::emitEvent<Event>(std::unique_ptr<Event>, const Base::Delegate<Event*>&);
+template void EventTarget::emitEvent<Mouse>(std::unique_ptr<Mouse>, const Base::Delegate<Mouse*>&);
+template void EventTarget::emitEvent<Keyboard>(std::unique_ptr<Keyboard>, const Base::Delegate<Keyboard*>&);
+template void EventTarget::emitEvent<State>(std::unique_ptr<State>, const Base::Delegate<State*>&);
 
 }
 }

--- a/src/Event/EventTarget.h
+++ b/src/Event/EventTarget.h
@@ -48,29 +48,12 @@ public:
     virtual ~EventTarget();
 
     /**
-     * Adds event handler to given event name.
-     */
-    void addEventHandler(const std::string& eventName, Handler::Functor handler);
-
-    /**
      * Emit given event to Event Dispatcher for delayed processing.
      */
-    void emitEvent(std::unique_ptr<Event> event);
-    /**
-     * Remove all event handlers attached to given event name.
-     */
-    void removeEventHandlers(const std::string& eventName);
-
-    /**
-     * Returns all handlers for given event name or empty vector if no handlers were defined.
-     */
-    Handler getEventHandler(const std::string& eventName);
-
-protected:
-    Handler& _getEventHandlerRef(const std::string& eventName);
+    template <typename T>
+    void emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler);
 
 private:
-    std::unordered_map<std::string, Handler> _eventHandlers;
     Dispatcher* _eventDispatcher;
 };
 

--- a/src/Event/EventTarget.h
+++ b/src/Event/EventTarget.h
@@ -21,11 +21,7 @@
 #define FALLTERGEIST_EVENT_EMITTER_H
 
 // C++ standard includes
-#include <functional>
-#include <unordered_map>
 #include <memory>
-#include <string>
-#include <vector>
 
 // Falltergeist includes
 #include "../Event/Handler.h"
@@ -51,7 +47,7 @@ public:
      * Emit given event to Event Dispatcher for delayed processing.
      */
     template <typename T>
-    void emitEvent(std::unique_ptr<T> event, Base::Delegate<T*> handler);
+    void emitEvent(std::unique_ptr<T> event, const Base::Delegate<T*>& handler);
 
 private:
     Dispatcher* _eventDispatcher;

--- a/src/Event/EventTarget.h
+++ b/src/Event/EventTarget.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 // Falltergeist includes
+#include "../Event/Handler.h"
 
 // Third party includes
 
@@ -39,8 +40,6 @@ class Event;
 
 class Dispatcher;
 
-// TODO: make proper class with implicit conversion constructors
-using EventHandler = std::function<void(Event*)>;
 
 class EventTarget
 {
@@ -51,7 +50,8 @@ public:
     /**
      * Adds event handler to given event name.
      */
-    void addEventHandler(const std::string& eventName, EventHandler handler);
+    void addEventHandler(const std::string& eventName, Handler::Functor handler);
+
     /**
      * Emit given event to Event Dispatcher for delayed processing.
      */
@@ -60,13 +60,17 @@ public:
      * Remove all event handlers attached to given event name.
      */
     void removeEventHandlers(const std::string& eventName);
+
     /**
      * Returns all handlers for given event name or empty vector if no handlers were defined.
      */
-    std::vector<EventHandler> getEventHandlers(const std::string& eventName);
+    Handler getEventHandler(const std::string& eventName);
+
+protected:
+    Handler& _getEventHandlerRef(const std::string& eventName);
 
 private:
-    std::unordered_map<std::string, std::vector<EventHandler>> _eventHandlers;
+    std::unordered_map<std::string, Handler> _eventHandlers;
     Dispatcher* _eventDispatcher;
 };
 

--- a/src/Event/Handler.h
+++ b/src/Event/Handler.h
@@ -21,6 +21,7 @@
 #define FALLTERGEIST_EVENT_HANDLER_H
 
 // C++ standard includes
+#include <functional>
 
 // Falltergeist includes
 #include "../Base/Delegate.h"

--- a/src/Event/Handler.h
+++ b/src/Event/Handler.h
@@ -21,18 +21,18 @@
 #define FALLTERGEIST_EVENT_HANDLER_H
 
 // C++ standard includes
-#include <functional>
 
 // Falltergeist includes
 #include "../Base/Delegate.h"
-#include "../Event/Mouse.h"
-#include "../Event/Keyboard.h"
-#include "../Event/State.h"
 
 namespace Falltergeist
 {
 namespace Event
 {
+class Event;
+class Mouse;
+class Keyboard;
+class State;
 
 // TODO: copy-pasting Base::Delegate code instead of using template might improve compilation speed
 

--- a/src/Event/Handler.h
+++ b/src/Event/Handler.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2015 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALLTERGEIST_EVENT_HANDLER_H
+#define FALLTERGEIST_EVENT_HANDLER_H
+
+// C++ standard includes
+
+// Falltergeist includes
+#include "../Base/Delegate.h"
+#include "../Event/Mouse.h"
+#include "../Event/Keyboard.h"
+#include "../Event/State.h"
+
+namespace Falltergeist
+{
+namespace Event
+{
+
+// TODO: copy-pasting Base::Delegate code instead of using template might improve compilation speed
+
+using Handler = Base::Delegate<Event*>;
+using MouseHandler = Base::Delegate<Mouse*>;
+using KeyboardHandler = Base::Delegate<Keyboard*>;
+using StateHandler = Base::Delegate<State*>;
+
+}
+}
+
+#endif //FALLTERGEIST_EVENT_HANDLER_H

--- a/src/Event/Keyboard.cpp
+++ b/src/Event/Keyboard.cpp
@@ -31,8 +31,19 @@ namespace Falltergeist
 namespace Event
 {
 
-Keyboard::Keyboard(const std::string& name) : Event(name)
+const char* Keyboard::typeToString(Keyboard::Type type)
 {
+    switch (type)
+    {
+        case Type::KEY_DOWN: return "keydown";
+        case Type::KEY_UP:   return "keyup";
+        default: return "keyboard";
+    }
+}
+
+Keyboard::Keyboard(Keyboard::Type type) : Event(typeToString(type))
+{
+    _type = type;
 }
 
 Keyboard::Keyboard(const Keyboard& event, const std::string& newName) : Event(newName)
@@ -49,6 +60,11 @@ Keyboard::Keyboard(const Keyboard& event) : Keyboard(event, event._name)
 
 Keyboard::~Keyboard()
 {
+}
+
+Keyboard::Type Keyboard::originalType() const
+{
+    return _type;
 }
 
 int Keyboard::keyCode() const

--- a/src/Event/Keyboard.h
+++ b/src/Event/Keyboard.h
@@ -35,10 +35,23 @@ namespace Event
 class Keyboard : public Event
 {
 public:
-    Keyboard(const std::string& name = "keyboard");
+    enum class Type
+    {
+        KEY_DOWN,
+        KEY_UP
+    };
+
+    static const char* typeToString(Type);
+
+    Keyboard(Type type);
     Keyboard(const Keyboard& event, const std::string& newName);
     Keyboard(const Keyboard& event);
     ~Keyboard() override;
+
+    /**
+     * @brief Type of an original event from OS.
+     */
+    Type originalType() const;
 
     int keyCode() const;
     void setKeyCode(int value);
@@ -57,6 +70,8 @@ protected:
     bool _controlPressed = false;
     bool _shiftPressed = false;
     int _keyCode = 0;
+
+    Type _type;
 };
 
 }

--- a/src/Event/Mouse.cpp
+++ b/src/Event/Mouse.cpp
@@ -31,18 +31,31 @@ namespace Falltergeist
 namespace Event
 {
 
-Mouse::Mouse(const std::string& name) : Event(name)
+
+const char* Mouse::typeToString(Mouse::Type type)
 {
+    switch (type)
+    {
+        case Type::BUTTON_DOWN: return "mousedown";
+        case Type::BUTTON_UP:   return "mouseup";
+        case Type::MOVE:        return "mousemove";
+        default: return "mouse";
+    }
+}
+
+Mouse::Mouse(Type type) : Event(typeToString(type))
+{
+    _type = type;
 }
 
 Mouse::Mouse(const Mouse& event, const std::string& newName) : Event(newName)
 {
+    _button = event._button;
     _position = event._position;
     _offset = event._offset;
-    _leftButton = event._leftButton;
-    _rightButton = event._rightButton;
     _shiftPressed = event._shiftPressed;
     _controlPressed = event._controlPressed;
+    _altPressed = event._altPressed;
 }
 
 Mouse::Mouse(const Mouse& event) : Mouse(event, event._name)
@@ -53,24 +66,29 @@ Mouse::~Mouse()
 {
 }
 
-void Mouse::setLeftButton(bool value)
+Mouse::Type Mouse::originalType() const
 {
-    _leftButton = value;
+    return _type;
 }
 
 bool Mouse::leftButton() const
 {
-    return _leftButton;
-}
-
-void Mouse::setRightButton(bool value)
-{
-    _rightButton = value;
+    return _button == Button::LEFT;
 }
 
 bool Mouse::rightButton() const
 {
-    return _rightButton;
+    return _button == Button::RIGHT;
+}
+
+Mouse::Button Mouse::button() const
+{
+    return _button;
+}
+
+void Mouse::setButton(Mouse::Button button)
+{
+    _button = button;
 }
 
 void Mouse::setControlPressed(bool value)
@@ -123,5 +141,14 @@ void Mouse::setObstacle(bool obstacle)
     _obstacle = obstacle;
 }
 
+bool Mouse::altPressed() const
+{
+    return _altPressed;
+}
+
+void Mouse::setAltPressed(bool altPressed)
+{
+    _altPressed = altPressed;
+}
 }
 }

--- a/src/Event/Mouse.h
+++ b/src/Event/Mouse.h
@@ -21,7 +21,6 @@
 #define FALLTERGEIST_EVENT_MOUSE_H
 
 // C++ standard includes
-#include <memory>
 
 // Falltergeist includes
 #include "../Event/Event.h"

--- a/src/Event/Mouse.h
+++ b/src/Event/Mouse.h
@@ -66,9 +66,15 @@ public:
      */
     Type originalType() const;
 
+    /**
+     * Cursor position on screen.
+     */
     const Point& position() const;
     void setPosition(const Point& position);
 
+    /**
+     * The offset for which cursor moved relative to last event. Used for move events.
+     */
     const Point& offset() const;
     void setOffset(const Point& offset);
 

--- a/src/Event/Mouse.h
+++ b/src/Event/Mouse.h
@@ -37,30 +37,68 @@ namespace Event
 class Mouse : public Event
 {
 public:
-    Mouse(const std::string& eventName = "mouse");
+    enum class Button
+    {
+        NONE = 0,
+        LEFT,
+        RIGHT,
+        MIDDLE,
+        X1,
+        X2
+    };
+
+    enum class Type
+    {
+        BUTTON_DOWN,
+        BUTTON_UP,
+        MOVE
+    };
+
+    static const char* typeToString(Type);
+
+    Mouse(Type type);
     Mouse(const Mouse& event, const std::string& newName);
     Mouse(const Mouse& event);
     ~Mouse() override;
 
-    const Point& position() const;
+    /**
+     * @brief Type of an original event from OS.
+     */
+    Type originalType() const;
 
+    const Point& position() const;
     void setPosition(const Point& position);
 
     const Point& offset() const;
-
     void setOffset(const Point& offset);
 
+    /**
+     * @brief Which button was pressed during mouse button events.
+     */
+    Button button() const;
+    void setButton(Button);
+
     bool leftButton() const;
-    void setLeftButton(bool value);
 
     bool rightButton() const;
-    void setRightButton(bool value);
 
+    /**
+     * @brief Whether control key is pressed.
+     */
     bool controlPressed() const;
     void setControlPressed(bool value);
 
+    /**
+     * @brief Whether shift key is pressed.
+     */
     bool shiftPressed() const;
     void setShiftPressed(bool value);
+
+    /**
+     * @brief Whether alt key is pressed.
+     */
+    bool altPressed() const;
+    void setAltPressed(bool altPressed);
 
     /**
      * Indicates that an obstacle was detected under mouse cursor during event capturing.
@@ -74,9 +112,10 @@ public:
 protected:
     bool _controlPressed = false;
     bool _shiftPressed = false;
-    int _leftButton = false;
-    int _rightButton = false;
+    bool _altPressed = false;
     bool _obstacle = false;
+    Button _button = Button::NONE;
+    Type _type;
 
     Point _position;
     Point _offset;

--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -487,8 +487,8 @@ void CritterObject::think()
             _orientation = hexagon()->orientationTo(movementQueue()->back());
             auto animation = _generateMovementAnimation();
             animation->setActionFrame(_running ? 2 : 4);
-            animation->addEventHandler("actionFrame",    bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
-            animation->addEventHandler("animationEnded", bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
+            animation->actionFrameHandler().add(bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
+            animation->animationEndedHandler().add(bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
             animation->play();
             _ui = move(animation);
         }
@@ -540,8 +540,8 @@ void CritterObject::onMovementAnimationEnded(Event::Event* event)
         {
             newAnimation->setActionFrame(_running ? 2 : 4);
         }
-        newAnimation->addEventHandler("actionFrame",    bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
-        newAnimation->addEventHandler("animationEnded", bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
+        newAnimation->actionFrameHandler().add(bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
+        newAnimation->animationEndedHandler().add(bind(&CritterObject::onMovementAnimationEnded, this, placeholders::_1));
         newAnimation->play();
         animation = newAnimation.get();
         _ui = move(newAnimation);
@@ -597,7 +597,7 @@ unique_ptr<UI::Animation> CritterObject::_generateMovementAnimation()
 UI::Animation* CritterObject::setActionAnimation(const string& action)
 {
     UI::Animation* animation = new UI::Animation("art/critters/" + _generateArmorFrmString() + action + ".frm", orientation());
-    animation->addEventHandler("animationEnded", [animation](Event::Event* event)
+    animation->animationEndedHandler().add([animation](Event::Event* event)
     {
         animation->setCurrentFrame(0);
     });

--- a/src/Game/DoorSceneryObject.cpp
+++ b/src/Game/DoorSceneryObject.cpp
@@ -78,7 +78,7 @@ void DoorSceneryObject::use_p_proc(CritterObject* usedBy)
         {
             queue->start();
             queue->currentAnimation()->setReverse(false);
-            queue->addEventHandler("animationEnded", std::bind(&DoorSceneryObject::onOpeningAnimationEnded, this, std::placeholders::_1));
+            queue->animationEndedHandler().add(std::bind(&DoorSceneryObject::onOpeningAnimationEnded, this, std::placeholders::_1));
             if (_soundId) Game::getInstance()->mixer()->playACMSound(std::string("sound/sfx/sodoors") + _soundId + ".acm");
         }
     }
@@ -88,7 +88,7 @@ void DoorSceneryObject::use_p_proc(CritterObject* usedBy)
         {
             queue->start();
             queue->currentAnimation()->setReverse(true);
-            queue->addEventHandler("animationEnded", std::bind(&DoorSceneryObject::onClosingAnimationEnded, this, std::placeholders::_1));
+            queue->animationEndedHandler().add(std::bind(&DoorSceneryObject::onClosingAnimationEnded, this, std::placeholders::_1));
             if (_soundId) Game::getInstance()->mixer()->playACMSound(std::string("sound/sfx/scdoors") + _soundId + ".acm");
         }
     }
@@ -103,7 +103,7 @@ void DoorSceneryObject::onOpeningAnimationEnded(Event::Event* event)
 {
     auto queue = (UI::AnimationQueue*)event->target();
     setOpened(true);
-    queue->removeEventHandlers("animationEnded");
+    queue->animationEndedHandler().clear();
     queue->stop();
     Logger::info() << "Door opened: " << opened() << std::endl;
 }
@@ -112,7 +112,7 @@ void DoorSceneryObject::onClosingAnimationEnded(Event::Event* event)
 {
     auto queue = (UI::AnimationQueue*)event->target();
     setOpened(false);
-    queue->removeEventHandlers("animationEnded");
+    queue->animationEndedHandler().clear();
     queue->stop();
     Logger::info() << "Door opened: " << opened() << std::endl;
 }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -298,32 +298,52 @@ Settings* Game::settings() const
     return _settings.get();
 }
 
+// TODO: probably need to move this to factory class
 std::unique_ptr<Event::Event> Game::_createEventFromSDL(const SDL_Event& sdlEvent)
 {
+    using Mouse = Event::Mouse;
+    using Keyboard = Event::Keyboard;
     switch (sdlEvent.type)
     {
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP:
         {
             SDL_Keymod mods = SDL_GetModState();
-            auto mouseEvent = make_unique<Event::Mouse>((sdlEvent.type == SDL_MOUSEBUTTONDOWN) ? "mousedown" : "mouseup");
+            auto mouseEvent = make_unique<Mouse>((sdlEvent.type == SDL_MOUSEBUTTONDOWN) ? Mouse::Type::BUTTON_DOWN : Mouse::Type::BUTTON_UP);
             mouseEvent->setPosition({sdlEvent.button.x, sdlEvent.button.y});
-            mouseEvent->setLeftButton(sdlEvent.button.button == SDL_BUTTON_LEFT);
-            mouseEvent->setRightButton(sdlEvent.button.button == SDL_BUTTON_RIGHT);
+            switch (sdlEvent.button.button)
+            {
+                case SDL_BUTTON_LEFT:
+                    mouseEvent->setButton(Mouse::Button::LEFT);
+                    break;
+                case SDL_BUTTON_RIGHT:
+                    mouseEvent->setButton(Mouse::Button::RIGHT);
+                    break;
+                case SDL_BUTTON_MIDDLE:
+                    mouseEvent->setButton(Mouse::Button::MIDDLE);
+                    break;
+                case SDL_BUTTON_X1:
+                    mouseEvent->setButton(Mouse::Button::X1);
+                    break;
+                case SDL_BUTTON_X2:
+                    mouseEvent->setButton(Mouse::Button::X2);
+                    break;
+            }
             mouseEvent->setShiftPressed(mods & KMOD_SHIFT);
             mouseEvent->setControlPressed(mods & KMOD_CTRL);
+            mouseEvent->setAltPressed(mods & KMOD_ALT);
             return std::move(mouseEvent);
         }
         case SDL_MOUSEMOTION:
         {
-            auto mouseEvent = make_unique<Event::Mouse>("mousemove");
+            auto mouseEvent = make_unique<Event::Mouse>(Mouse::Type::MOVE);
             mouseEvent->setPosition({sdlEvent.motion.x, sdlEvent.motion.y});
             mouseEvent->setOffset({sdlEvent.motion.xrel,sdlEvent.motion.yrel});
             return std::move(mouseEvent);
         }
         case SDL_KEYDOWN:
         {
-            auto keyboardEvent = make_unique<Event::Keyboard>("keydown");
+            auto keyboardEvent = make_unique<Event::Keyboard>(Keyboard::Type::KEY_DOWN);
             keyboardEvent->setKeyCode(sdlEvent.key.keysym.sym);
             keyboardEvent->setAltPressed(sdlEvent.key.keysym.mod & KMOD_ALT);
             keyboardEvent->setShiftPressed(sdlEvent.key.keysym.mod & KMOD_SHIFT);
@@ -332,7 +352,7 @@ std::unique_ptr<Event::Event> Game::_createEventFromSDL(const SDL_Event& sdlEven
         }
         case SDL_KEYUP:
         {
-            auto keyboardEvent = make_unique<Event::Keyboard>("keyup");
+            auto keyboardEvent = make_unique<Event::Keyboard>(Keyboard::Type::KEY_UP);
             keyboardEvent->setKeyCode(sdlEvent.key.keysym.sym);
             keyboardEvent->setAltPressed(sdlEvent.key.keysym.mod & KMOD_ALT);
             keyboardEvent->setShiftPressed(sdlEvent.key.keysym.mod & KMOD_SHIFT);

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -127,7 +127,7 @@ void Game::pushState(State::State* state)
     _states.push_back(std::unique_ptr<State::State>(state));
     if (!state->initialized()) state->init();
     state->setActive(true);
-    state->emitEvent(make_unique<Event::State>("activate"));
+    state->emitEvent(make_unique<Event::State>("activate"), state->activateHandler());
 }
 
 void Game::popState()
@@ -138,7 +138,7 @@ void Game::popState()
     _statesForDelete.emplace_back(std::move(_states.back()));
     _states.pop_back();
     state->setActive(false);
-    state->emitEvent(make_unique<Event::State>("deactivate"));
+    state->emitEvent(make_unique<Event::State>("deactivate"), state->deactivateHandler());
 }
 
 void Game::setState(State::State* state)
@@ -265,7 +265,7 @@ std::vector<State::State*> Game::_getActiveStates()
         auto state = it->get();
         if (!state->active())
         {
-            state->emitEvent(make_unique<Event::State>("activate"));
+            state->emitEvent(make_unique<Event::State>("activate"), state->activateHandler());
             state->setActive(true);
         }
         subset.push_back(state);
@@ -281,7 +281,7 @@ std::vector<State::State*> Game::_getActiveStates()
         auto state = it->get();
         if (state->active())
         {
-            state->emitEvent(make_unique<Event::State>("deactivate"));
+            state->emitEvent(make_unique<Event::State>("deactivate"), state->deactivateHandler());
             state->setActive(false);
         }
     }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -126,6 +126,7 @@ void Game::pushState(State::State* state)
 {
     _states.push_back(std::unique_ptr<State::State>(state));
     if (!state->initialized()) state->init();
+    state->emitEvent(make_unique<Event::State>("push"), state->pushHandler());
     state->setActive(true);
     state->emitEvent(make_unique<Event::State>("activate"), state->activateHandler());
 }
@@ -139,6 +140,7 @@ void Game::popState()
     _states.pop_back();
     state->setActive(false);
     state->emitEvent(make_unique<Event::State>("deactivate"), state->deactivateHandler());
+    state->emitEvent(make_unique<Event::State>("pop"), state->popHandler());
 }
 
 void Game::setState(State::State* state)

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -24,7 +24,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <Event/Event.h>
 
 // Falltergeist includes
 #include "../Base/Singleton.h"
@@ -42,6 +41,7 @@ namespace Audio
 namespace Event
 {
     class Dispatcher;
+    class Event;
 }
 namespace Graphics
 {

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -160,12 +160,12 @@ void Object::addUIEventHandlers()
     if (_ui)
     {
         // TODO: these event handlers probably need to be set in State::Location
-        _ui->addEventHandler("mouseleftdown", std::bind(&State::Location::onObjectMouseEvent, Game::getInstance()->locationState(), std::placeholders::_1, this));
-        _ui->addEventHandler("mouseleftclick", std::bind(&State::Location::onObjectMouseEvent, Game::getInstance()->locationState(), std::placeholders::_1, this));
-        _ui->addEventHandler("mousein", std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->mouseDownHandler().add(std::bind(&State::Location::onObjectMouseEvent, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->mouseClickHandler().add(std::bind(&State::Location::onObjectMouseEvent, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->mouseInHandler().add(std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
         // TODO: get rid of mousemove handler?
-        _ui->addEventHandler("mousemove", std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
-        _ui->addEventHandler("mouseout", std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->mouseMoveHandler().add(std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
+        _ui->mouseOutHandler().add(std::bind(&State::Location::onObjectHover, Game::getInstance()->locationState(), std::placeholders::_1, this));
     }
 }
 
@@ -487,8 +487,8 @@ void Object::onUseAnimationActionFrame(Event::Event* event, CritterObject* critt
     UI::Animation* animation = dynamic_cast<UI::Animation*>(critter->ui());
     if (animation)
     {
-        animation->removeEventHandlers("actionFrame");
-        animation->addEventHandler("animationEnded", [this, critter](Event::Event* event){
+        animation->actionFrameHandler().clear();
+        animation->animationEndedHandler().add([this, critter](Event::Event* event){
             this->onUseAnimationEnd(event, critter);
         });
     }

--- a/src/Game/Object.h
+++ b/src/Game/Object.h
@@ -21,10 +21,8 @@
 #define FALLTERGEIST_GAME_OBJECT_H
 
 // C++ standard includes
-#include <cmath>
 #include <memory>
 #include <string>
-#include <vector>
 
 // Falltergeist includes
 #include "../Event/EventTarget.h"

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -185,7 +185,8 @@ void Renderer::think()
             _fadeAlpha = (_fadeAlpha <= 0 ? 0 : 255);
             _fadeDone = true;
 
-            Game::getInstance()->topState()->emitEvent(make_unique<Event::State>("fadedone"));
+            auto state = Game::getInstance()->topState();
+            state->emitEvent(make_unique<Event::State>("fadedone"), state->fadeDoneHandler());
             return;
         }
         _fadeTimer = ticks;

--- a/src/State/Container.cpp
+++ b/src/State/Container.cpp
@@ -60,7 +60,7 @@ void Container::init()
     addUI("background", new UI::Image("art/intrface/loot.frm"));
 
     addUI("button_done", new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 478, 331));
-    getUI("button_done")->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    getUI("button_done")->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
 
 
     // TAKEALL
@@ -80,8 +80,8 @@ void Container::init()
     containerList->setItems(object()->inventory());
     addUI(containerList);
 
-    dudeList->addEventHandler("itemdragstop", [containerList](Event::Event* event){ containerList->onItemDragStop(dynamic_cast<Event::Mouse*>(event)); });
-    containerList->addEventHandler("itemdragstop", [dudeList](Event::Event* event){ dudeList->onItemDragStop(dynamic_cast<Event::Mouse*>(event)); });
+    dudeList->itemDragStopHandler().add([containerList](Event::Mouse* event){ containerList->onItemDragStop(event); });
+    containerList->itemDragStopHandler().add([dudeList](Event::Mouse* event){ dudeList->onItemDragStop(event); });
 
 }
 

--- a/src/State/Container.cpp
+++ b/src/State/Container.cpp
@@ -60,7 +60,7 @@ void Container::init()
     addUI("background", new UI::Image("art/intrface/loot.frm"));
 
     addUI("button_done", new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 478, 331));
-    getUI("button_done")->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    getUI("button_done")->mouseClickHandler().add(std::bind(&Container::onDoneButtonClick, this, std::placeholders::_1));
 
 
     // TAKEALL

--- a/src/State/Credits.cpp
+++ b/src/State/Credits.cpp
@@ -162,14 +162,14 @@ void Credits::handle(Event::Event* event)
 
 void Credits::onCreditsFinished()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onCreditsFadeDone(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onCreditsFadeDone(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
 void Credits::onCreditsFadeDone(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->mouse()->popState();
     Game::getInstance()->popState();
 }

--- a/src/State/CritterBarter.cpp
+++ b/src/State/CritterBarter.cpp
@@ -57,7 +57,7 @@ void CritterBarter::init()
     addUI("offerButton", new UI::ImageButton(UI::ImageButton::Type::DIALOG_RED_BUTTON, 40, 162));
 
     addUI("talkButton", new UI::ImageButton(UI::ImageButton::Type::DIALOG_RED_BUTTON, 583, 162));
-    getUI("talkButton")->addEventHandler("mouseleftclick", std::bind(&CritterBarter::onTalkButtonClick, this, std::placeholders::_1));
+    getUI("talkButton")->mouseClickHandler().add(std::bind(&CritterBarter::onTalkButtonClick, this, std::placeholders::_1));
 
     addUI("mineInventoryScrollUpButton",   new UI::ImageButton(UI::ImageButton::Type::DIALOG_UP_ARROW,   190, 56));
     addUI("mineInventoryScrollDownButton", new UI::ImageButton(UI::ImageButton::Type::DIALOG_DOWN_ARROW, 190, 82));
@@ -66,12 +66,12 @@ void CritterBarter::init()
     addUI("theirsInventoryScrollDownButton", new UI::ImageButton(UI::ImageButton::Type::DIALOG_DOWN_ARROW, 421, 82));
 }
 
-void CritterBarter::onTalkButtonClick(Event::Event* event)
+void CritterBarter::onTalkButtonClick(Event::Mouse* event)
 {
     Game::getInstance()->popState();
 }
 
-void CritterBarter::onBackgroundClick(Event::Event* event)
+void CritterBarter::onBackgroundClick(Event::Mouse* event)
 {
 }
 

--- a/src/State/CritterBarter.h
+++ b/src/State/CritterBarter.h
@@ -40,8 +40,8 @@ public:
 
     void init() override;
 
-    void onBackgroundClick(Event::Event* event);
-    void onTalkButtonClick(Event::Event* event);
+    void onBackgroundClick(Event::Mouse* event);
+    void onTalkButtonClick(Event::Mouse* event);
 };
 
 }

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -75,11 +75,11 @@ void CritterDialog::init()
 
     // Interface buttons
     auto reviewButton = new UI::ImageButton(UI::ImageButton::Type::DIALOG_REVIEW_BUTTON, 13, 154);
-    reviewButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onReviewButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    reviewButton->mouseClickHandler().add(std::bind(&onReviewButtonClick, this, std::placeholders::_1));
     addUI(reviewButton);
 
     auto barterButton = new UI::ImageButton(UI::ImageButton::Type::DIALOG_RED_BUTTON, 593, 40);
-    barterButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onBarterButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    barterButton->mouseClickHandler().add(std::bind(&onBarterButtonClick, this, std::placeholders::_1));
     addUI(barterButton);
 }
 
@@ -94,14 +94,14 @@ void CritterDialog::setQuestion(const std::string& value)
     question->setText(value);
 }
 
-void CritterDialog::onAnswerIn(Event::Event* event)
+void CritterDialog::onAnswerIn(Event::Mouse* event)
 {
     auto sender = dynamic_cast<UI::TextArea*>(event->target());
     auto font3_a0a0a0ff = ResourceManager::getInstance()->font("font1.aaf", 0xffff7fff);
     sender->setFont(font3_a0a0a0ff);
 }
 
-void CritterDialog::onAnswerOut(Event::Event* event)
+void CritterDialog::onAnswerOut(Event::Mouse* event)
 {
     auto sender = dynamic_cast<UI::TextArea*>(event->target());
     auto font3_3ff800ff = ResourceManager::getInstance()->font("font1.aaf", 0x3ff800ff);
@@ -129,14 +129,14 @@ void CritterDialog::deleteAnswers()
     _reactions.clear();
 }
 
-void CritterDialog::onReviewButtonClick(Event::Event* event)
+void CritterDialog::onReviewButtonClick(Event::Mouse* event)
 {
     // FIXME : don't create new state each time the button is clicked
     auto state = new CritterDialogReview();
     Game::getInstance()->pushState(state);
 }
 
-void CritterDialog::onBarterButtonClick(Event::Event* event)
+void CritterDialog::onBarterButtonClick(Event::Mouse* event)
 {
     // FIXME : don't create new state each time the button is clicked
     auto state = new CritterBarter();
@@ -207,9 +207,9 @@ void CritterDialog::addAnswer(const std::string& text)
     answer->setWordWrap(true);
     answer->setSize({370, 0});
 
-    answer->addEventHandler("mousein", std::bind(&CritterDialog::onAnswerIn, this, std::placeholders::_1));
-    answer->addEventHandler("mouseout", std::bind(&CritterDialog::onAnswerOut, this, std::placeholders::_1));
-    answer->addEventHandler("mouseleftclick", std::bind(&CritterDialog::onAnswerClick, this, std::placeholders::_1));
+    answer->mouseInHandler().add(std::bind(&CritterDialog::onAnswerIn, this, std::placeholders::_1));
+    answer->mouseOutHandler().add(std::bind(&CritterDialog::onAnswerOut, this, std::placeholders::_1));
+    answer->mouseClickHandler().add(std::bind(&CritterDialog::onAnswerClick, this, std::placeholders::_1));
     _answers.push_back(answer);
     addUI(answer);
 }
@@ -219,7 +219,7 @@ bool CritterDialog::hasAnswers()
     return _answers.size() > 0;
 }
 
-void CritterDialog::onAnswerClick(Event::Event* event)
+void CritterDialog::onAnswerClick(Event::Mouse* event)
 {
     auto sender = dynamic_cast<UI::TextArea*>(event->target());
 

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -75,11 +75,11 @@ void CritterDialog::init()
 
     // Interface buttons
     auto reviewButton = new UI::ImageButton(UI::ImageButton::Type::DIALOG_REVIEW_BUTTON, 13, 154);
-    reviewButton->mouseClickHandler().add(std::bind(&onReviewButtonClick, this, std::placeholders::_1));
+    reviewButton->mouseClickHandler().add(std::bind(&CritterDialog::onReviewButtonClick, this, std::placeholders::_1));
     addUI(reviewButton);
 
     auto barterButton = new UI::ImageButton(UI::ImageButton::Type::DIALOG_RED_BUTTON, 593, 40);
-    barterButton->mouseClickHandler().add(std::bind(&onBarterButtonClick, this, std::placeholders::_1));
+    barterButton->mouseClickHandler().add(std::bind(&CritterDialog::onBarterButtonClick, this, std::placeholders::_1));
     addUI(barterButton);
 }
 

--- a/src/State/CritterDialog.h
+++ b/src/State/CritterDialog.h
@@ -68,11 +68,11 @@ public:
     bool hasAnswers();
     void addAnswer(const std::string& text);
 
-    void onReviewButtonClick(Event::Event* event);
-    void onBarterButtonClick(Event::Event* event);
-    void onAnswerIn(Event::Event* event);
-    void onAnswerOut(Event::Event* event);
-    void onAnswerClick(Event::Event* event);
+    void onReviewButtonClick(Event::Mouse* event);
+    void onBarterButtonClick(Event::Mouse* event);
+    void onAnswerIn(Event::Mouse* event);
+    void onAnswerOut(Event::Mouse* event);
+    void onAnswerClick(Event::Mouse* event);
     void onKeyDown(Event::Keyboard* event) override;
 
 };

--- a/src/State/CritterDialogReview.cpp
+++ b/src/State/CritterDialogReview.cpp
@@ -55,7 +55,7 @@ void CritterDialogReview::init()
 
     // Interface buttons
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::DIALOG_DONE_BUTTON, backgroundPos + Point(500, 398));
-    doneButton->addEventHandler("mouseleftclick", std::bind(&CritterDialogReview::onDoneButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDoneButtonClick, this, std::placeholders::_1));
 
     auto upButton = new UI::ImageButton(UI::ImageButton::Type::DIALOG_BIG_UP_ARROW, backgroundPos + Point(476, 154));
 
@@ -67,7 +67,7 @@ void CritterDialogReview::init()
     addUI(downButton);
 }
 
-void CritterDialogReview::onDoneButtonClick(Event::Event* event)
+void CritterDialogReview::onDoneButtonClick(Event::Mouse* event)
 {
     Game::getInstance()->popState();
 }

--- a/src/State/CritterDialogReview.h
+++ b/src/State/CritterDialogReview.h
@@ -41,7 +41,7 @@ public:
 
     void init() override;
 
-    void onDoneButtonClick(Event::Event* event);
+    void onDoneButtonClick(Event::Mouse* event);
 };
 
 }

--- a/src/State/CursorDropdown.cpp
+++ b/src/State/CursorDropdown.cpp
@@ -78,10 +78,9 @@ void CursorDropdown::init()
 
     showMenu();
 
-    addEventHandler("mouseup", [this](Event::Event* event)
+    _mouseUpHandler.add([this](Event::Mouse* mouseEvent)
     {
-        Event::Mouse* mouseEvent;
-        if ((mouseEvent = dynamic_cast<Event::Mouse*>(event)) && mouseEvent->leftButton())
+        if (mouseEvent->leftButton())
         {
             onLeftButtonUp(mouseEvent);
         }
@@ -94,10 +93,10 @@ void CursorDropdown::init()
             event->setHandled(true);
         }
     };
-    addEventHandler("mousemove", moveHandler);
-    addEventHandler("mousedown", [this](Event::Event* event)
+    _mouseMoveHandler.add(moveHandler);
+    _mouseDownHandler.add([this](Event::Mouse* event)
     {
-        if (active() && !dynamic_cast<Event::Mouse*>(event)->leftButton())
+        if (active() && !event->leftButton())
         {
             Game::getInstance()->popState();
         }
@@ -220,8 +219,18 @@ void CursorDropdown::handle(Event::Event* event)
     {
         // TODO: probably need to make invisible panel to catch all mouse events..
 
-        // let state catch all mouse events
-        emitEvent(make_unique<Event::Mouse>(*mouseEvent));
+        if (mouseEvent->name() == "mousedown")
+        {
+            emitEvent(make_unique<Event::Mouse>(*mouseEvent), _mouseDownHandler);
+        }
+        else if (mouseEvent->name() == "mouseup")
+        {
+            emitEvent(make_unique<Event::Mouse>(*mouseEvent), _mouseUpHandler);
+        }
+        else if (mouseEvent->name() == "mousemove")
+        {
+            emitEvent(make_unique<Event::Mouse>(*mouseEvent), _mouseMoveHandler);
+        }
         event->setHandled(true);
     }
 }

--- a/src/State/CursorDropdown.cpp
+++ b/src/State/CursorDropdown.cpp
@@ -219,19 +219,19 @@ void CursorDropdown::handle(Event::Event* event)
     {
         // TODO: probably need to make invisible panel to catch all mouse events..
 
-        if (mouseEvent->name() == "mousedown")
+        if (mouseEvent->originalType() == Event::Mouse::Type::BUTTON_DOWN)
         {
             emitEvent(make_unique<Event::Mouse>(*mouseEvent), _mouseDownHandler);
         }
-        else if (mouseEvent->name() == "mouseup")
+        else if (mouseEvent->originalType() == Event::Mouse::Type::BUTTON_UP)
         {
             emitEvent(make_unique<Event::Mouse>(*mouseEvent), _mouseUpHandler);
         }
-        else if (mouseEvent->name() == "mousemove")
+        else if (mouseEvent->originalType() == Event::Mouse::Type::MOVE)
         {
             emitEvent(make_unique<Event::Mouse>(*mouseEvent), _mouseMoveHandler);
+            event->setHandled(true);
         }
-        event->setHandled(true);
     }
 }
 

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -81,6 +81,9 @@ protected:
     bool _deactivated = false;
     unsigned int _initialMouseStack;
 
+    // TODO: state itself should not catch mouse events! delegate it to some UI (like invisible panel filling the whole screen)
+    Event::MouseHandler _mouseDownHandler, _mouseUpHandler, _mouseMoveHandler;
+
     void showMenu();
 };
 

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -81,7 +81,6 @@ protected:
     bool _deactivated = false;
     unsigned int _initialMouseStack;
 
-    // TODO: state itself should not catch mouse events! delegate it to some UI (like invisible panel filling the whole screen)
     Event::MouseHandler _mouseDownHandler, _mouseUpHandler, _mouseMoveHandler;
 
     void showMenu();

--- a/src/State/ExitConfirm.cpp
+++ b/src/State/ExitConfirm.cpp
@@ -68,8 +68,8 @@ void ExitConfirm::init()
 
     auto yesButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundPos + Point(50, 102));
     auto noButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundPos + Point(183, 102));
-    yesButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doYes(); });
-    noButton->addEventHandler("mouseleftclick",  [this](Event::Event* event){ this->doNo(); });
+    yesButton->mouseClickHandler().add([this](Event::Event* event){ this->doYes(); });
+    noButton->mouseClickHandler().add( [this](Event::Event* event){ this->doNo(); });
 
     // label: Are you sure you want to quit?
     auto font = ResourceManager::getInstance()->font("font1.aaf", 0xb89c28ff);

--- a/src/State/GameMenu.cpp
+++ b/src/State/GameMenu.cpp
@@ -75,9 +75,9 @@ void GameMenu::init()
     auto exitGameButton    = new UI::ImageButton(UI::ImageButton::Type::OPTIONS_BUTTON, backgroundX+14, backgroundY+18+37*3);
     auto doneButton        = new UI::ImageButton(UI::ImageButton::Type::OPTIONS_BUTTON, backgroundX+14, backgroundY+18+37*4);
 
-    preferencesButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doPreferences(); });
-    exitGameButton->addEventHandler("mouseleftclick",    [this](Event::Event* event){ this->doExit(); });
-    doneButton->addEventHandler("mouseleftclick",        [this](Event::Event* event){ this->closeMenu(); });
+    preferencesButton->mouseClickHandler().add([this](Event::Event* event){ this->doPreferences(); });
+    exitGameButton->mouseClickHandler().add(   [this](Event::Event* event){ this->doExit(); });
+    doneButton->mouseClickHandler().add(       [this](Event::Event* event){ this->closeMenu(); });
 
     auto font = ResourceManager::getInstance()->font("font3.aaf", 0xb89c28ff);
 
@@ -86,14 +86,14 @@ void GameMenu::init()
     saveGameButtonLabel->setFont(font);
     saveGameButtonLabel->setSize({150, 0});
     saveGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-    saveGameButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doSaveGame(); });
+    saveGameButton->mouseClickHandler().add([this](Event::Event* event){ this->doSaveGame(); });
 
     // label: load game
     auto loadGameButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 1), backgroundX+8, backgroundY+26+37);
     loadGameButtonLabel->setFont(font);
     loadGameButtonLabel->setSize({150, 0});
     loadGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-    loadGameButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doLoadGame(); });
+    loadGameButton->mouseClickHandler().add([this](Event::Event* event){ this->doLoadGame(); });
 
     // label: preferences
     auto preferencesButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 2), backgroundX+8, backgroundY+26+37*2);

--- a/src/State/Inventory.cpp
+++ b/src/State/Inventory.cpp
@@ -83,15 +83,15 @@ void Inventory::init()
     setPosition((game->renderer()->size() - Point(499, 377 + panelHeight)) / 2); // 499x377 = art/intrface/invbox.frm
 
     addUI("background", new UI::Image("art/intrface/invbox.frm"));
-    getUI("background")->addEventHandler("mouserightclick", [this](Event::Event* event){ this->backgroundRightClick(dynamic_cast<Event::Mouse*>(event)); });
+    getUI("background")->mouseClickHandler().add(std::bind(&backgroundRightClick, this, std::placeholders::_1));
 
     addUI("button_up",   new UI::ImageButton(UI::ImageButton::Type::INVENTORY_UP_ARROW,   128, 40));
     addUI("button_down", new UI::ImageButton(UI::ImageButton::Type::INVENTORY_DOWN_ARROW, 128, 65));
     addUI("button_done", new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 438, 328));
 
-    getUI("button_done")->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    getUI("button_up")->addEventHandler("mouseleftclick",   [this](Event::Event* event){ this->onScrollUpButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    getUI("button_down")->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onScrollDownButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    getUI("button_done")->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    getUI("button_up")->mouseClickHandler().add(  std::bind(&onScrollUpButtonClick, this, std::placeholders::_1));
+    getUI("button_down")->mouseClickHandler().add(std::bind(&onScrollDownButtonClick, this, std::placeholders::_1));
 
     // screen
     auto screenX = 300;
@@ -262,8 +262,8 @@ void Inventory::init()
     {
         auto inventoryItem = new UI::InventoryItem(armorSlot, {154, 183});
         inventoryItem->setType(UI::InventoryItem::Type::SLOT);
-        inventoryItem->addEventHandler("itemdragstop", [inventoryList](Event::Event* event){ inventoryList->onItemDragStop(dynamic_cast<Event::Mouse*>(event)); });
-        inventoryList->addEventHandler("itemdragstop", [inventoryItem](Event::Event* event){ inventoryItem->onArmorDragStop(dynamic_cast<Event::Mouse*>(event)); });
+        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event); });
+        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onArmorDragStop(event); });
         addUI(inventoryItem);
     }
 
@@ -271,8 +271,8 @@ void Inventory::init()
     {
         auto inventoryItem = new UI::InventoryItem(leftHand, {154, 286});
         inventoryItem->setType(UI::InventoryItem::Type::SLOT);
-        inventoryItem->addEventHandler("itemdragstop", [inventoryList](Event::Event* event){ inventoryList->onItemDragStop(dynamic_cast<Event::Mouse*>(event)); });
-        inventoryList->addEventHandler("itemdragstop", [inventoryItem](Event::Event* event){ inventoryItem->onHandDragStop(dynamic_cast<Event::Mouse*>(event)); });
+        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event); });
+        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onHandDragStop(event); });
         addUI(inventoryItem);
     }
 
@@ -280,8 +280,8 @@ void Inventory::init()
     {
         auto inventoryItem = new UI::InventoryItem(rightHand, {247, 286});
         inventoryItem->setType(UI::InventoryItem::Type::SLOT);
-        inventoryItem->addEventHandler("itemdragstop", [inventoryList](Event::Event* event){ inventoryList->onItemDragStop(dynamic_cast<Event::Mouse*>(event)); });
-        inventoryList->addEventHandler("itemdragstop", [inventoryItem](Event::Event* event){ inventoryItem->onHandDragStop(dynamic_cast<Event::Mouse*>(event)); });
+        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event); });
+        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onHandDragStop(event); });
         addUI(inventoryItem);
     }
 

--- a/src/State/Inventory.cpp
+++ b/src/State/Inventory.cpp
@@ -56,17 +56,24 @@ namespace State
 
 Inventory::Inventory() : State()
 {
-    Game::getInstance()->mouse()->pushState(Input::Mouse::Cursor::ACTION);
+    pushHandler().add([this](Event::State* ev)
+        {
+            Game::getInstance()->mouse()->pushState(Input::Mouse::Cursor::ACTION);
+        });
+    popHandler().add([this](Event::State* ev)
+        {
+            // If hand cursor now
+            if (Game::getInstance()->mouse()->state() == Input::Mouse::Cursor::HAND)
+            {
+                Game::getInstance()->mouse()->popState();
+            }
+            Game::getInstance()->mouse()->popState();
+        });
 }
 
 Inventory::~Inventory()
 {
-    // If hand cursor now
-    if (Game::getInstance()->mouse()->state() == Input::Mouse::Cursor::HAND)
-    {
-        Game::getInstance()->mouse()->popState();
-    }
-    Game::getInstance()->mouse()->popState();
+
 }
 
 void Inventory::init()

--- a/src/State/Inventory.cpp
+++ b/src/State/Inventory.cpp
@@ -278,8 +278,8 @@ void Inventory::init()
     {
         auto inventoryItem = new UI::InventoryItem(leftHand, {154, 286});
         inventoryItem->setType(UI::InventoryItem::Type::SLOT);
-        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event); });
-        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onHandDragStop(event); });
+        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event, HAND::LEFT); });
+        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onHandDragStop(event, HAND::LEFT); });
         addUI(inventoryItem);
     }
 
@@ -287,8 +287,8 @@ void Inventory::init()
     {
         auto inventoryItem = new UI::InventoryItem(rightHand, {247, 286});
         inventoryItem->setType(UI::InventoryItem::Type::SLOT);
-        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event); });
-        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onHandDragStop(event); });
+        inventoryItem->itemDragStopHandler().add([inventoryList](Event::Mouse* event){ inventoryList->onItemDragStop(event, HAND::RIGHT); });
+        inventoryList->itemDragStopHandler().add([inventoryItem](Event::Mouse* event){ inventoryItem->onHandDragStop(event, HAND::RIGHT); });
         addUI(inventoryItem);
     }
 

--- a/src/State/Inventory.cpp
+++ b/src/State/Inventory.cpp
@@ -83,15 +83,15 @@ void Inventory::init()
     setPosition((game->renderer()->size() - Point(499, 377 + panelHeight)) / 2); // 499x377 = art/intrface/invbox.frm
 
     addUI("background", new UI::Image("art/intrface/invbox.frm"));
-    getUI("background")->mouseClickHandler().add(std::bind(&backgroundRightClick, this, std::placeholders::_1));
+    getUI("background")->mouseClickHandler().add(std::bind(&Inventory::backgroundRightClick, this, std::placeholders::_1));
 
     addUI("button_up",   new UI::ImageButton(UI::ImageButton::Type::INVENTORY_UP_ARROW,   128, 40));
     addUI("button_down", new UI::ImageButton(UI::ImageButton::Type::INVENTORY_DOWN_ARROW, 128, 65));
     addUI("button_done", new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 438, 328));
 
-    getUI("button_done")->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
-    getUI("button_up")->mouseClickHandler().add(  std::bind(&onScrollUpButtonClick, this, std::placeholders::_1));
-    getUI("button_down")->mouseClickHandler().add(std::bind(&onScrollDownButtonClick, this, std::placeholders::_1));
+    getUI("button_done")->mouseClickHandler().add(std::bind(&Inventory::onDoneButtonClick, this, std::placeholders::_1));
+    getUI("button_up")->mouseClickHandler().add(  std::bind(&Inventory::onScrollUpButtonClick, this, std::placeholders::_1));
+    getUI("button_down")->mouseClickHandler().add(std::bind(&Inventory::onScrollDownButtonClick, this, std::placeholders::_1));
 
     // screen
     auto screenX = 300;

--- a/src/State/LoadGame.cpp
+++ b/src/State/LoadGame.cpp
@@ -80,7 +80,7 @@ void LoadGame::init()
 
     // button: Done
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+391, bgY+349);
-    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(std::bind(&LoadGame::onDoneButtonClick, this, std::placeholders::_1));
     addUI(doneButton);
 
     // button: Cancel

--- a/src/State/LoadGame.cpp
+++ b/src/State/LoadGame.cpp
@@ -80,12 +80,12 @@ void LoadGame::init()
 
     // button: Done
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+391, bgY+349);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
     addUI(doneButton);
 
     // button: Cancel
     auto cancelButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+495, bgY+349);
-    cancelButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doCancel(); });
+    cancelButton->mouseClickHandler().add([this](Event::Event* event){ this->doCancel(); });
     addUI(cancelButton);
 
     // LABELS
@@ -117,8 +117,8 @@ void LoadGame::doCancel()
 {
     if (!Game::getInstance()->locationState())
     {
-        removeEventHandlers("fadedone");
-        addEventHandler("fadedone", [this](Event::Event* event){ this->onCancelFadeDone(dynamic_cast<Event::State*>(event)); });
+        fadeDoneHandler().clear();
+        fadeDoneHandler().add([this](Event::Event* event){ this->onCancelFadeDone(dynamic_cast<Event::State*>(event)); });
         Game::getInstance()->renderer()->fadeOut(255,255,255,1000);
     }
     else
@@ -129,7 +129,7 @@ void LoadGame::doCancel()
 
 void LoadGame::onCancelFadeDone(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->popState();
 }
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -695,11 +695,11 @@ void Location::onMouseMove(Event::Mouse* mouseEvent)
 
     int scrollArea = 8;
     auto renderer = Game::getInstance()->renderer();
-    Point evPos = mouseEvent->position();
-    _scrollLeft = (evPos.x() < scrollArea);
-    _scrollRight = (evPos.x() > renderer->width()- scrollArea);
-    _scrollTop = (evPos.y() < scrollArea);
-    _scrollBottom = (evPos.y() > renderer->height() - scrollArea);
+    Point mpos = mouse->position();
+    _scrollLeft = (mpos.x() < scrollArea);
+    _scrollRight = (mpos.x() > renderer->width() - scrollArea);
+    _scrollTop = (mpos.y() < scrollArea);
+    _scrollBottom = (mpos.y() > renderer->height() - scrollArea);
 
     if (hexagon)
     {

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -306,7 +306,7 @@ std::vector<Input::Mouse::Icon> Location::getCursorIconsForObject(Game::Object* 
 }
 
 
-void Location::onObjectMouseEvent(Event::Event* event, Game::Object* object)
+void Location::onObjectMouseEvent(Event::Mouse* event, Game::Object* object)
 {
     if (!object) return;
     if (event->name() == "mouseleftdown")
@@ -326,7 +326,7 @@ void Location::onObjectMouseEvent(Event::Event* event, Game::Object* object)
     }
 }
 
-void Location::onObjectHover(Event::Event* event, Game::Object* object)
+void Location::onObjectHover(Event::Mouse* event, Game::Object* object)
 {
     if (event->name() == "mouseout")
     {
@@ -905,7 +905,7 @@ void Location::handleAction(Game::Object* object, Input::Mouse::Icon action)
         {
             auto player = Game::getInstance()->player();
             auto animation = player->setActionAnimation("al");
-            animation->addEventHandler("actionFrame", [object, player](Event::Event* event){ object->onUseAnimationActionFrame(event, player); });
+            animation->actionFrameHandler().add([object, player](Event::Event* event){ object->onUseAnimationActionFrame(event, player); });
             break;
         }
         case Input::Mouse::Icon::ROTATE:

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -115,6 +115,13 @@ void Location::init()
 
 void Location::onStateActivate(Event::State* event)
 {
+    // correct position of "red hexagon" after popups
+    auto mouse = Game::getInstance()->mouse();
+    auto hexagon = hexagonGrid()->hexagonAt(mouse->position() + _camera->topLeft());
+    if (mouse->state() == Input::Mouse::Cursor::HEXAGON_RED && hexagon)
+    {
+        mouse->ui()->setPosition(hexagon->position() - _camera->topLeft());
+    }
 }
 
 void Location::onStateDeactivate(Event::State* event)

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -618,11 +618,10 @@ void Location::handle(Event::Event* event)
                             {
                                 game->player()->stopMovement();
                                 game->player()->setRunning((_lastClickedTile != 0 && hexagon->number() == _lastClickedTile) || (mouseEvent->shiftPressed() != game->settings()->running()));
-                                for (auto hexagon : path)
+                                for (auto pathHexagon : path)
                                 {
-                                    game->player()->movementQueue()->push_back(hexagon);
+                                    game->player()->movementQueue()->push_back(pathHexagon);
                                 }
-                                //moveObjectToHexagon(game->player(), hexagon);
                             }
                             event->setHandled(true);
                             _lastClickedTile = hexagon->number();

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -73,6 +73,8 @@ public:
     void handle(Event::Event* event) override;
     void render() override;
 
+    void handleByGameObjects(Event::Mouse* event);
+
     HexagonGrid* hexagonGrid();
     LocationCamera* camera();
 
@@ -94,6 +96,9 @@ public:
     void onObjectMouseEvent(Event::Mouse* event, Game::Object* object);
     void onObjectHover(Event::Mouse* event, Game::Object* object);
     void onKeyDown(Event::Keyboard* event) override;
+    void onMouseUp(Event::Mouse* event);
+    void onMouseDown(Event::Mouse* event);
+    void onMouseMove(Event::Mouse* event);
 
     void onStateActivate(Event::State* event) override;
     void onStateDeactivate(Event::State* event) override;
@@ -126,7 +131,7 @@ protected:
     Game::Object* _objectUnderCursor = NULL;
     Game::Object* _actionCursorLastObject = NULL;
     bool _actionCursorButtonPressed = false;
-    std::unique_ptr<UI::PlayerPanel> _playerPanel;
+    UI::PlayerPanel* _playerPanel;
 
     bool _scrollLeft = false;
     bool _scrollRight = false;
@@ -135,6 +140,8 @@ protected:
 
     std::vector<std::unique_ptr<Game::Object>> _objects;
     std::unique_ptr<UI::TextArea> _hexagonInfo;
+
+    Event::MouseHandler _mouseDownHandler, _mouseUpHandler, _mouseMoveHandler;
     
     std::vector<Input::Mouse::Icon> getCursorIconsForObject(Game::Object* object);
 

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -91,8 +91,8 @@ public:
     void displayMessage(const std::string& message);
 
     void onBackgroundClick(Event::Mouse* event);
-    void onObjectMouseEvent(Event::Event* event, Game::Object* object);
-    void onObjectHover(Event::Event* event, Game::Object* object);
+    void onObjectMouseEvent(Event::Mouse* event, Game::Object* object);
+    void onObjectHover(Event::Mouse* event, Game::Object* object);
     void onKeyDown(Event::Keyboard* event) override;
 
     void onStateActivate(Event::State* event) override;

--- a/src/State/MainMenu.cpp
+++ b/src/State/MainMenu.cpp
@@ -73,27 +73,27 @@ void MainMenu::init()
 
     // intro button
     auto introButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19));
-    introButton->mouseClickHandler().add(std::bind(&onIntroButtonClick, this, std::placeholders::_1));
+    introButton->mouseClickHandler().add(std::bind(&MainMenu::onIntroButtonClick, this, std::placeholders::_1));
 
     // new game button
     auto newGameButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41));
-    newGameButton->mouseClickHandler().add(std::bind(&onNewGameButtonClick, this, std::placeholders::_1));
+    newGameButton->mouseClickHandler().add(std::bind(&MainMenu::onNewGameButtonClick, this, std::placeholders::_1));
 
     // load game button
     auto loadGameButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*2));
-    loadGameButton->mouseClickHandler().add(std::bind(&onLoadGameButtonClick, this, std::placeholders::_1));
+    loadGameButton->mouseClickHandler().add(std::bind(&MainMenu::onLoadGameButtonClick, this, std::placeholders::_1));
 
     // settings button
     auto settingsButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*3));
-    settingsButton->mouseClickHandler().add(std::bind(&onSettingsButtonClick, this, std::placeholders::_1));
+    settingsButton->mouseClickHandler().add(std::bind(&MainMenu::onSettingsButtonClick, this, std::placeholders::_1));
 
     // credits button
     auto creditsButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*4));
-    creditsButton->mouseClickHandler().add(std::bind(&onCreditsButtonClick, this, std::placeholders::_1));
+    creditsButton->mouseClickHandler().add(std::bind(&MainMenu::onCreditsButtonClick, this, std::placeholders::_1));
 
     // exit button
     auto exitButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*5));
-    exitButton->mouseClickHandler().add(std::bind(&onExitButtonClick, this, std::placeholders::_1));
+    exitButton->mouseClickHandler().add(std::bind(&MainMenu::onExitButtonClick, this, std::placeholders::_1));
 
     auto font4 = ResourceManager::getInstance()->font("font4.aaf", 0xb89c28ff);
 

--- a/src/State/MainMenu.cpp
+++ b/src/State/MainMenu.cpp
@@ -73,27 +73,27 @@ void MainMenu::init()
 
     // intro button
     auto introButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19));
-    introButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onIntroButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    introButton->mouseClickHandler().add(std::bind(&onIntroButtonClick, this, std::placeholders::_1));
 
     // new game button
     auto newGameButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41));
-    newGameButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onNewGameButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    newGameButton->mouseClickHandler().add(std::bind(&onNewGameButtonClick, this, std::placeholders::_1));
 
     // load game button
     auto loadGameButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*2));
-    loadGameButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onLoadGameButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    loadGameButton->mouseClickHandler().add(std::bind(&onLoadGameButtonClick, this, std::placeholders::_1));
 
     // settings button
     auto settingsButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*3));
-    settingsButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onSettingsButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    settingsButton->mouseClickHandler().add(std::bind(&onSettingsButtonClick, this, std::placeholders::_1));
 
     // credits button
     auto creditsButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*4));
-    creditsButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onCreditsButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    creditsButton->mouseClickHandler().add(std::bind(&onCreditsButtonClick, this, std::placeholders::_1));
 
     // exit button
     auto exitButton = addUI(new UI::ImageButton(UI::ImageButton::Type::MENU_RED_CIRCLE, 30, 19 + 41*5));
-    exitButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onExitButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    exitButton->mouseClickHandler().add(std::bind(&onExitButtonClick, this, std::placeholders::_1));
 
     auto font4 = ResourceManager::getInstance()->font("font4.aaf", 0xb89c28ff);
 
@@ -144,22 +144,22 @@ void MainMenu::init()
 
 void MainMenu::doExit()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onExitStart(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onExitStart(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
 void MainMenu::doNewGame()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onNewGameStart(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onNewGameStart(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
 void MainMenu::doLoadGame()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onLoadGameStart(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onLoadGameStart(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
@@ -170,15 +170,15 @@ void MainMenu::doSettings()
 
 void MainMenu::doIntro()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onIntroStart(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onIntroStart(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
 void MainMenu::doCredits()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onCreditsStart(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onCreditsStart(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
@@ -189,7 +189,7 @@ void MainMenu::onExitButtonClick(Event::Mouse* event)
 
 void MainMenu::onExitStart(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->mixer()->stopMusic();
     Game::getInstance()->quit();
 }
@@ -201,7 +201,7 @@ void MainMenu::onNewGameButtonClick(Event::Mouse* event)
 
 void MainMenu::onNewGameStart(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->pushState(new NewGame());
 }
 
@@ -212,7 +212,7 @@ void MainMenu::onLoadGameButtonClick(Event::Mouse* event)
 
 void MainMenu::onLoadGameStart(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->pushState(new LoadGame());
 }
 
@@ -228,7 +228,7 @@ void MainMenu::onIntroButtonClick(Event::Mouse* event)
 
 void MainMenu::onIntroStart(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->pushState(new Movie(17));
     Game::getInstance()->pushState(new Movie(1));
 }
@@ -240,7 +240,7 @@ void MainMenu::onCreditsButtonClick(Event::Mouse* event)
 
 void MainMenu::onCreditsStart(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->pushState(new Credits());
 }
 

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -69,22 +69,22 @@ void NewGame::init()
     addUI("background", new UI::Image("art/intrface/pickchar.frm"));
 
     auto beginGameButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 81, 322));
-    beginGameButton->mouseClickHandler().add(std::bind(&onBeginGameButtonClick, this, std::placeholders::_1));
+    beginGameButton->mouseClickHandler().add(std::bind(&NewGame::onBeginGameButtonClick, this, std::placeholders::_1));
 
     auto editButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 436, 319));
-    editButton->mouseClickHandler().add(std::bind(&onEditButtonClick, this, std::placeholders::_1));
+    editButton->mouseClickHandler().add(std::bind(&NewGame::onEditButtonClick, this, std::placeholders::_1));
 
     auto createButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 81, 424));
-    createButton->mouseClickHandler().add(std::bind(&onCreateButtonClick, this, std::placeholders::_1));
+    createButton->mouseClickHandler().add(std::bind(&NewGame::onCreateButtonClick, this, std::placeholders::_1));
 
     auto backButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 461, 424));
-    backButton->mouseClickHandler().add(std::bind(&onBackButtonClick, this, std::placeholders::_1));
+    backButton->mouseClickHandler().add(std::bind(&NewGame::onBackButtonClick, this, std::placeholders::_1));
 
     auto prevCharacterButton = addUI(new UI::ImageButton(UI::ImageButton::Type::LEFT_ARROW, 292, 320));
-    prevCharacterButton->mouseClickHandler().add(std::bind(&onPrevCharacterButtonClick, this, std::placeholders::_1));
+    prevCharacterButton->mouseClickHandler().add(std::bind(&NewGame::onPrevCharacterButtonClick, this, std::placeholders::_1));
 
     auto nextCharacterButton = addUI(new UI::ImageButton(UI::ImageButton::Type::RIGHT_ARROW, 318, 320));
-    nextCharacterButton->mouseClickHandler().add(std::bind(&onNextCharacterButtonClick, this, std::placeholders::_1));
+    nextCharacterButton->mouseClickHandler().add(std::bind(&NewGame::onNextCharacterButtonClick, this, std::placeholders::_1));
 
     addUI("images", new UI::ImageList({
                                     "art/intrface/combat.frm",

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -69,22 +69,22 @@ void NewGame::init()
     addUI("background", new UI::Image("art/intrface/pickchar.frm"));
 
     auto beginGameButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 81, 322));
-    beginGameButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onBeginGameButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    beginGameButton->mouseClickHandler().add(std::bind(&onBeginGameButtonClick, this, std::placeholders::_1));
 
     auto editButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 436, 319));
-    editButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onEditButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    editButton->mouseClickHandler().add(std::bind(&onEditButtonClick, this, std::placeholders::_1));
 
     auto createButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 81, 424));
-    createButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onCreateButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    createButton->mouseClickHandler().add(std::bind(&onCreateButtonClick, this, std::placeholders::_1));
 
     auto backButton = addUI(new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, 461, 424));
-    backButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onBackButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    backButton->mouseClickHandler().add(std::bind(&onBackButtonClick, this, std::placeholders::_1));
 
     auto prevCharacterButton = addUI(new UI::ImageButton(UI::ImageButton::Type::LEFT_ARROW, 292, 320));
-    prevCharacterButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onPrevCharacterButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    prevCharacterButton->mouseClickHandler().add(std::bind(&onPrevCharacterButtonClick, this, std::placeholders::_1));
 
     auto nextCharacterButton = addUI(new UI::ImageButton(UI::ImageButton::Type::RIGHT_ARROW, 318, 320));
-    nextCharacterButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onNextCharacterButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    nextCharacterButton->mouseClickHandler().add(std::bind(&onNextCharacterButtonClick, this, std::placeholders::_1));
 
     addUI("images", new UI::ImageList({
                                     "art/intrface/combat.frm",
@@ -137,8 +137,8 @@ void NewGame::doCreate()
 
 void NewGame::doBack()
 {
-    removeEventHandlers("fadedone");
-    addEventHandler("fadedone", [this](Event::Event* event){ this->onBackFadeDone(dynamic_cast<Event::State*>(event)); });
+    fadeDoneHandler().clear();
+    fadeDoneHandler().add([this](Event::Event* event){ this->onBackFadeDone(dynamic_cast<Event::State*>(event)); });
     Game::getInstance()->renderer()->fadeOut(0,0,0,1000);
 }
 
@@ -175,7 +175,7 @@ void NewGame::onBackButtonClick(Event::Mouse* event)
 
 void NewGame::onBackFadeDone(Event::State* event)
 {
-    removeEventHandlers("fadedone");
+    fadeDoneHandler().clear();
     Game::getInstance()->popState();
 }
 

--- a/src/State/PipBoy.cpp
+++ b/src/State/PipBoy.cpp
@@ -71,7 +71,7 @@ void PipBoy::init()
     auto automapsButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+53, backgroundY+394);
     auto archivesButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+53, backgroundY+423);
     auto closeButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+53, backgroundY+448);
-    closeButton->mouseClickHandler().add(std::bind(&onCloseButtonClick, this, std::placeholders::_1));
+    closeButton->mouseClickHandler().add(std::bind(&PipBoy::onCloseButtonClick, this, std::placeholders::_1));
     // Date and time
 
     // Date

--- a/src/State/PipBoy.cpp
+++ b/src/State/PipBoy.cpp
@@ -71,7 +71,7 @@ void PipBoy::init()
     auto automapsButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+53, backgroundY+394);
     auto archivesButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+53, backgroundY+423);
     auto closeButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+53, backgroundY+448);
-    closeButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onCloseButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    closeButton->mouseClickHandler().add(std::bind(&onCloseButtonClick, this, std::placeholders::_1));
     // Date and time
 
     // Date

--- a/src/State/PlayerCreate.cpp
+++ b/src/State/PlayerCreate.cpp
@@ -211,7 +211,7 @@ void PlayerCreate::init()
     // add buttons to the state
     for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
     {
-        it->second->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+        it->second->mouseClickHandler().add(std::bind(&onButtonClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -219,7 +219,7 @@ void PlayerCreate::init()
     // reverse iterator to change drawing order
     for(auto it = _labels.rbegin(); it != _labels.rend(); ++it)
     {
-        it->second->addEventHandler("mouseleftdown", [this](Event::Event* event){ this->onLabelClick(dynamic_cast<Event::Mouse*>(event)); });
+        it->second->mouseDownHandler().add(std::bind(&onLabelClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -232,7 +232,7 @@ void PlayerCreate::init()
     // add hidden masks
     for(auto it = _masks.begin(); it != _masks.end(); ++it)
     {
-        it->second->addEventHandler("mouseleftdown", [this](Event::Event* event){ this->onMaskClick(dynamic_cast<Event::Mouse*>(event)); });
+        it->second->mouseDownHandler().add(std::bind(&onMaskClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 

--- a/src/State/PlayerCreate.cpp
+++ b/src/State/PlayerCreate.cpp
@@ -211,7 +211,7 @@ void PlayerCreate::init()
     // add buttons to the state
     for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
     {
-        it->second->mouseClickHandler().add(std::bind(&onButtonClick, this, std::placeholders::_1));
+        it->second->mouseClickHandler().add(std::bind(&PlayerCreate::onButtonClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -219,7 +219,7 @@ void PlayerCreate::init()
     // reverse iterator to change drawing order
     for(auto it = _labels.rbegin(); it != _labels.rend(); ++it)
     {
-        it->second->mouseDownHandler().add(std::bind(&onLabelClick, this, std::placeholders::_1));
+        it->second->mouseDownHandler().add(std::bind(&PlayerCreate::onLabelClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -232,7 +232,7 @@ void PlayerCreate::init()
     // add hidden masks
     for(auto it = _masks.begin(); it != _masks.end(); ++it)
     {
-        it->second->mouseDownHandler().add(std::bind(&onMaskClick, this, std::placeholders::_1));
+        it->second->mouseDownHandler().add(std::bind(&PlayerCreate::onMaskClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 

--- a/src/State/PlayerCreateOptions.cpp
+++ b/src/State/PlayerCreateOptions.cpp
@@ -72,11 +72,11 @@ void PlayerCreateOptions::init()
     auto eraseButton = new UI::ImageButton(UI::ImageButton::Type::OPTIONS_BUTTON, backgroundX+14, backgroundY+18+37*3);
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::OPTIONS_BUTTON, backgroundX+14, backgroundY+18+37*4);
 
-    saveButton->mouseClickHandler().add(   std::bind(&onSaveButtonClick, this, std::placeholders::_1));
-    loadButton->mouseClickHandler().add(   std::bind(&onLoadButtonClick, this, std::placeholders::_1));
-    printToFileButton->mouseClickHandler().add(std::bind(&onPrintToFileButtonClick, this, std::placeholders::_1));
-    eraseButton->mouseClickHandler().add(      std::bind(&onEraseButtonClick, this, std::placeholders::_1));
-    doneButton->mouseClickHandler().add(       std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    saveButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onSaveButtonClick, this, std::placeholders::_1));
+    loadButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onLoadButtonClick, this, std::placeholders::_1));
+    printToFileButton->mouseClickHandler().add(std::bind(&PlayerCreateOptions::onPrintToFileButtonClick, this, std::placeholders::_1));
+    eraseButton->mouseClickHandler().add(      std::bind(&PlayerCreateOptions::onEraseButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(       std::bind(&PlayerCreateOptions::onDoneButtonClick, this, std::placeholders::_1));
 
     auto font = ResourceManager::getInstance()->font("font3.aaf", 0xb89c28ff);
 

--- a/src/State/PlayerCreateOptions.cpp
+++ b/src/State/PlayerCreateOptions.cpp
@@ -72,11 +72,11 @@ void PlayerCreateOptions::init()
     auto eraseButton = new UI::ImageButton(UI::ImageButton::Type::OPTIONS_BUTTON, backgroundX+14, backgroundY+18+37*3);
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::OPTIONS_BUTTON, backgroundX+14, backgroundY+18+37*4);
 
-    saveButton->addEventHandler("mouseleftclick",    [this](Event::Event* event){ this->onSaveButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    loadButton->addEventHandler("mouseleftclick",    [this](Event::Event* event){ this->onLoadButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    printToFileButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onPrintToFileButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    eraseButton->addEventHandler("mouseleftclick",       [this](Event::Event* event){ this->onEraseButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    doneButton->addEventHandler("mouseleftclick",        [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    saveButton->mouseClickHandler().add(   std::bind(&onSaveButtonClick, this, std::placeholders::_1));
+    loadButton->mouseClickHandler().add(   std::bind(&onLoadButtonClick, this, std::placeholders::_1));
+    printToFileButton->mouseClickHandler().add(std::bind(&onPrintToFileButtonClick, this, std::placeholders::_1));
+    eraseButton->mouseClickHandler().add(      std::bind(&onEraseButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(       std::bind(&onDoneButtonClick, this, std::placeholders::_1));
 
     auto font = ResourceManager::getInstance()->font("font3.aaf", 0xb89c28ff);
 

--- a/src/State/PlayerEdit.cpp
+++ b/src/State/PlayerEdit.cpp
@@ -244,7 +244,7 @@ void PlayerEdit::init()
     // add buttons to the state
     for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
     {
-        it->second->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+        it->second->mouseClickHandler().add(std::bind(&onButtonClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -252,7 +252,7 @@ void PlayerEdit::init()
     // reverse iterator to change drawing order
     for(auto it = _labels.rbegin(); it != _labels.rend(); ++it)
     {
-        it->second->addEventHandler("mouseleftdown", [this](Event::Event* event){ this->onLabelClick(dynamic_cast<Event::Mouse*>(event)); });
+        it->second->mouseDownHandler().add(std::bind(&onLabelClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -265,7 +265,7 @@ void PlayerEdit::init()
     // add hidden masks
     for(auto it = _masks.begin(); it != _masks.end(); ++it)
     {
-        it->second->addEventHandler("mouseleftdown", [this](Event::Event* event){ this->onMaskClick(dynamic_cast<Event::Mouse*>(event)); });
+        it->second->mouseDownHandler().add(std::bind(&onMaskClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 

--- a/src/State/PlayerEdit.cpp
+++ b/src/State/PlayerEdit.cpp
@@ -244,7 +244,7 @@ void PlayerEdit::init()
     // add buttons to the state
     for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
     {
-        it->second->mouseClickHandler().add(std::bind(&onButtonClick, this, std::placeholders::_1));
+        it->second->mouseClickHandler().add(std::bind(&PlayerEdit::onButtonClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -252,7 +252,7 @@ void PlayerEdit::init()
     // reverse iterator to change drawing order
     for(auto it = _labels.rbegin(); it != _labels.rend(); ++it)
     {
-        it->second->mouseDownHandler().add(std::bind(&onLabelClick, this, std::placeholders::_1));
+        it->second->mouseDownHandler().add(std::bind(&PlayerEdit::onLabelClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 
@@ -265,7 +265,7 @@ void PlayerEdit::init()
     // add hidden masks
     for(auto it = _masks.begin(); it != _masks.end(); ++it)
     {
-        it->second->mouseDownHandler().add(std::bind(&onMaskClick, this, std::placeholders::_1));
+        it->second->mouseDownHandler().add(std::bind(&PlayerEdit::onMaskClick, this, std::placeholders::_1));
         addUI(it->second);
     }
 

--- a/src/State/PlayerEditAge.cpp
+++ b/src/State/PlayerEditAge.cpp
@@ -68,13 +68,13 @@ void PlayerEditAge::init()
     doneBox->setPosition(backgroundPos + Point(175, 40));
 
     auto decButton = new UI::ImageButton(UI::ImageButton::Type::LEFT_ARROW, backgroundX+178, backgroundY+14);
-    decButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDecButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    decButton->mouseClickHandler().add(std::bind(&onDecButtonClick, this, std::placeholders::_1));
 
     auto incButton = new UI::ImageButton(UI::ImageButton::Type::RIGHT_ARROW, backgroundX+262, backgroundY+14);
-    incButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onIncButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    incButton->mouseClickHandler().add(std::bind(&onIncButtonClick, this, std::placeholders::_1));
 
     auto doneButton= new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+188, backgroundY+43);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
 
     auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), backgroundX+210, backgroundY+43);
 

--- a/src/State/PlayerEditAge.cpp
+++ b/src/State/PlayerEditAge.cpp
@@ -68,13 +68,13 @@ void PlayerEditAge::init()
     doneBox->setPosition(backgroundPos + Point(175, 40));
 
     auto decButton = new UI::ImageButton(UI::ImageButton::Type::LEFT_ARROW, backgroundX+178, backgroundY+14);
-    decButton->mouseClickHandler().add(std::bind(&onDecButtonClick, this, std::placeholders::_1));
+    decButton->mouseClickHandler().add(std::bind(&PlayerEditAge::onDecButtonClick, this, std::placeholders::_1));
 
     auto incButton = new UI::ImageButton(UI::ImageButton::Type::RIGHT_ARROW, backgroundX+262, backgroundY+14);
-    incButton->mouseClickHandler().add(std::bind(&onIncButtonClick, this, std::placeholders::_1));
+    incButton->mouseClickHandler().add(std::bind(&PlayerEditAge::onIncButtonClick, this, std::placeholders::_1));
 
     auto doneButton= new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+188, backgroundY+43);
-    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(std::bind(&PlayerEditAge::onDoneButtonClick, this, std::placeholders::_1));
 
     auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), backgroundX+210, backgroundY+43);
 

--- a/src/State/PlayerEditAlert.cpp
+++ b/src/State/PlayerEditAlert.cpp
@@ -76,9 +76,9 @@ void PlayerEditAlert::init()
     doneBox->setPosition(bgPos + Point(254, 270));
 
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX + 264, bgY + 273);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event)
+    doneButton->mouseClickHandler().add([this](Event::Mouse* event)
     {
-        this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event));
+        this->onDoneButtonClick(event);
     });
 
     auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), bgX + 284, bgY + 273);

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -128,8 +128,8 @@ void PlayerEditGender::onKeyDown(Event::Keyboard* event)
 void PlayerEditGender::setGender(GENDER gender)
 {
     _gender = gender;
-    _maleImage->setCurrentImage(gender == GENDER::MALE ? 0 : 1);
-    _femaleImage->setCurrentImage(gender == GENDER::FEMALE ? 0 : 1);
+    _maleImage->setCurrentImage(gender == GENDER::MALE ? 1 : 0);
+    _femaleImage->setCurrentImage(gender == GENDER::FEMALE ? 1 : 0);
 }
 
 }

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -129,7 +129,7 @@ void PlayerEditGender::setGender(GENDER gender)
 {
     _gender = gender;
     _maleImage->setCurrentImage(gender == GENDER::MALE ? 0 : 1);
-    _femaleImage->setCurrentImage(gender == GENDER::FEMALE ? 1 : 0);
+    _femaleImage->setCurrentImage(gender == GENDER::FEMALE ? 0 : 1);
 }
 
 }

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -65,13 +65,13 @@ void PlayerEditGender::init()
                                     "art/intrface/maleoff.frm",
                                     "art/intrface/maleon.frm"
                                 }, bgX+260, bgY+2);
-    _maleImage->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onMaleButtonPress(dynamic_cast<Event::Mouse*>(event)); });
+    _maleImage->mouseClickHandler().add(std::bind(&onMaleButtonPress, this, std::placeholders::_1));
 
     _femaleImage = new UI::ImageList((std::vector<std::string>){
                                                             "art/intrface/femoff.frm",
                                                             "art/intrface/femon.frm"
                                                             }, bgX+310, bgY+2);
-    _femaleImage->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onFemaleButtonPress(dynamic_cast<Event::Mouse*>(event)); });
+    _femaleImage->mouseClickHandler().add(std::bind(&onFemaleButtonPress, this, std::placeholders::_1));
 
     auto doneBox = new UI::Image("art/intrface/donebox.frm");
     doneBox->setPosition(bgPos + Point(250, 42));
@@ -81,7 +81,7 @@ void PlayerEditGender::init()
     doneLabel->setFont(font3_b89c28ff);
 
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+260, bgY+45);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
 
     addUI(bg);
     addUI(doneBox);

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -65,13 +65,13 @@ void PlayerEditGender::init()
                                     "art/intrface/maleoff.frm",
                                     "art/intrface/maleon.frm"
                                 }, bgX+260, bgY+2);
-    _maleImage->mouseClickHandler().add(std::bind(&onMaleButtonPress, this, std::placeholders::_1));
+    _maleImage->mouseClickHandler().add(std::bind(&PlayerEditGender::onMaleButtonPress, this, std::placeholders::_1));
 
     _femaleImage = new UI::ImageList((std::vector<std::string>){
                                                             "art/intrface/femoff.frm",
                                                             "art/intrface/femon.frm"
                                                             }, bgX+310, bgY+2);
-    _femaleImage->mouseClickHandler().add(std::bind(&onFemaleButtonPress, this, std::placeholders::_1));
+    _femaleImage->mouseClickHandler().add(std::bind(&PlayerEditGender::onFemaleButtonPress, this, std::placeholders::_1));
 
     auto doneBox = new UI::Image("art/intrface/donebox.frm");
     doneBox->setPosition(bgPos + Point(250, 42));
@@ -81,7 +81,7 @@ void PlayerEditGender::init()
     doneLabel->setFont(font3_b89c28ff);
 
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+260, bgY+45);
-    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(std::bind(&PlayerEditGender::onDoneButtonClick, this, std::placeholders::_1));
 
     addUI(bg);
     addUI(doneBox);

--- a/src/State/PlayerEditName.cpp
+++ b/src/State/PlayerEditName.cpp
@@ -112,10 +112,10 @@ void PlayerEditName::init()
     doneLabel->setFont(font3_b89c28ff);
 
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+45, bgY+43);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
 
     _name = new UI::TextArea(Game::getInstance()->player()->name(), bgX+43, bgY+15);
-    _name->addEventHandler("keydown", [this](Event::Event* event){ this->onTextAreaKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
+    _name->keyDownHandler().add([this](Event::Event* event){ this->onTextAreaKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
 
     _cursor = new UI::Image(5, 8);
     _cursor->setPosition(bgPos + Point(83, 15));

--- a/src/State/PlayerEditName.cpp
+++ b/src/State/PlayerEditName.cpp
@@ -112,7 +112,7 @@ void PlayerEditName::init()
     doneLabel->setFont(font3_b89c28ff);
 
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+45, bgY+43);
-    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(std::bind(&PlayerEditName::onDoneButtonClick, this, std::placeholders::_1));
 
     _name = new UI::TextArea(Game::getInstance()->player()->name(), bgX+43, bgY+15);
     _name->keyDownHandler().add([this](Event::Event* event){ this->onTextAreaKeyDown(dynamic_cast<Event::Keyboard*>(event)); });

--- a/src/State/SaveGame.cpp
+++ b/src/State/SaveGame.cpp
@@ -76,12 +76,12 @@ void SaveGame::init()
 
     // button: Done
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+391, bgY+349);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDoneButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
     addUI(doneButton);
 
     // button: Cancel
     auto cancelButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+495, bgY+349);
-    cancelButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onCancelButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    cancelButton->mouseClickHandler().add(std::bind(&onCancelButtonClick, this, std::placeholders::_1));
     addUI(cancelButton);
 
     // LABELS

--- a/src/State/SaveGame.cpp
+++ b/src/State/SaveGame.cpp
@@ -76,12 +76,12 @@ void SaveGame::init()
 
     // button: Done
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+391, bgY+349);
-    doneButton->mouseClickHandler().add(std::bind(&onDoneButtonClick, this, std::placeholders::_1));
+    doneButton->mouseClickHandler().add(std::bind(&SaveGame::onDoneButtonClick, this, std::placeholders::_1));
     addUI(doneButton);
 
     // button: Cancel
     auto cancelButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, bgX+495, bgY+349);
-    cancelButton->mouseClickHandler().add(std::bind(&onCancelButtonClick, this, std::placeholders::_1));
+    cancelButton->mouseClickHandler().add(std::bind(&SaveGame::onCancelButtonClick, this, std::placeholders::_1));
     addUI(cancelButton);
 
     // LABELS

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -308,7 +308,7 @@ void SettingsMenu::init()
 
     // button: Default
     auto defaultButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+23, backgroundY+450);
-    defaultButton->mouseClickHandler().add(std::bind(&onDefaultButtonClick, this, std::placeholders::_1));
+    defaultButton->mouseClickHandler().add(std::bind(&SettingsMenu::onDefaultButtonClick, this, std::placeholders::_1));
     addUI(defaultButton);
 
     // button: Done

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -308,17 +308,17 @@ void SettingsMenu::init()
 
     // button: Default
     auto defaultButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+23, backgroundY+450);
-    defaultButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onDefaultButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    defaultButton->mouseClickHandler().add(std::bind(&onDefaultButtonClick, this, std::placeholders::_1));
     addUI(defaultButton);
 
     // button: Done
     auto doneButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+148, backgroundY+450);
-    doneButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doSave(); });
+    doneButton->mouseClickHandler().add([this](Event::Event* event){ this->doSave(); });
     addUI(doneButton);
 
     // button: Cancel
     auto cancelButton = new UI::ImageButton(UI::ImageButton::Type::SMALL_RED_CIRCLE, backgroundX+263, backgroundY+450);
-    cancelButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->doCancel(); });
+    cancelButton->mouseClickHandler().add([this](Event::Event* event){ this->doCancel(); });
     addUI(cancelButton);
 
     // button: Affect player speed

--- a/src/State/Skilldex.cpp
+++ b/src/State/Skilldex.cpp
@@ -99,7 +99,7 @@ void Skilldex::init()
     repairCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::REPAIR));
 
     // events
-    cancelButton->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->onCancelButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    cancelButton->mouseClickHandler().add(std::bind(&onCancelButtonClick, this, std::placeholders::_1));
 
     // LABELS
     auto font = ResourceManager::getInstance()->font("font3.aaf", 0xb89c28ff);

--- a/src/State/Skilldex.cpp
+++ b/src/State/Skilldex.cpp
@@ -99,7 +99,7 @@ void Skilldex::init()
     repairCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::REPAIR));
 
     // events
-    cancelButton->mouseClickHandler().add(std::bind(&onCancelButtonClick, this, std::placeholders::_1));
+    cancelButton->mouseClickHandler().add(std::bind(&Skilldex::onCancelButtonClick, this, std::placeholders::_1));
 
     // LABELS
     auto font = ResourceManager::getInstance()->font("font3.aaf", 0xb89c28ff);

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -173,9 +173,17 @@ UI::Base* State::getUI(const std::string& name)
 void State::handle(Event::Event* event)
 {
     if (event->handled()) return;
+    // TODO: maybe make handle() a template function to get rid of dynamic_casts?
     if (auto keyboardEvent = dynamic_cast<Event::Keyboard*>(event))
     {
-        emitEvent(make_unique<Event::Keyboard>(*keyboardEvent));
+        if (keyboardEvent->name() == "keyup")
+        {
+            emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyUpHandler());
+        }
+        else if (keyboardEvent->name() == "keydown")
+        {
+            emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyDownHandler());
+        }
     }
     for (auto it = _ui.rbegin(); it != _ui.rend(); ++it)
     {
@@ -223,6 +231,31 @@ bool State::active()
 void State::setActive(bool value)
 {
     _active = value;
+}
+
+Event::StateHandler& State::activateHandler() const
+{
+    return _activateHandler;
+}
+
+Event::StateHandler& State::deactivateHandler() const
+{
+    return _deactivateHandler;
+}
+
+Event::StateHandler& State::fadeDoneHandler() const
+{
+    return _fadeDoneHandler;
+}
+
+Event::KeyboardHandler& State::keyDownHandler() const
+{
+    return _keyDownHandler;
+}
+
+Event::KeyboardHandler& State::keyUpHandler() const
+{
+    return _keyUpHandler;
 }
 
 }

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -238,6 +238,16 @@ void State::setActive(bool value)
     _active = value;
 }
 
+Event::StateHandler& State::pushHandler()
+{
+    return _pushHandler;
+}
+
+Event::StateHandler& State::popHandler()
+{
+    return _popHandler;
+}
+
 Event::StateHandler& State::activateHandler()
 {
     return _activateHandler;

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -43,8 +43,10 @@ using namespace Base;
 
 State::State() : Event::EventTarget(Game::getInstance()->eventDispatcher())
 {
-    activateHandler().add([this](Event::Event* event){ this->onStateActivate(dynamic_cast<Event::State*>(event)); });
-    deactivateHandler().add([this](Event::Event* event){ this->onStateDeactivate(dynamic_cast<Event::State*>(event)); });
+    activateHandler().add([this](Event::State* event){ this->onStateActivate(event); });
+    deactivateHandler().add([this](Event::State* event){ this->onStateDeactivate(event); });
+
+    keyDownHandler().add([this](Event::Keyboard* event) { this->onKeyDown(event); });
 }
 
 State::~State()
@@ -54,8 +56,6 @@ State::~State()
 void State::init()
 {
     _initialized = true;
-
-    keyDownHandler().add([this](Event::Event* event) { this->onKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
 }
 
 void State::think()
@@ -138,7 +138,7 @@ UI::Base* State::addUI(const std::string& name, UI::Base* ui)
     return ui;
 }
 
-void State::addUI(std::vector<UI::Base*> uis)
+void State::addUI(const std::vector<UI::Base*>& uis)
 {
     for (auto ui : uis)
     {

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -176,13 +176,18 @@ void State::handle(Event::Event* event)
     // TODO: maybe make handle() a template function to get rid of dynamic_casts?
     if (auto keyboardEvent = dynamic_cast<Event::Keyboard*>(event))
     {
-        if (keyboardEvent->name() == "keyup")
+        switch (keyboardEvent->originalType())
         {
-            emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyUpHandler());
-        }
-        else if (keyboardEvent->name() == "keydown")
-        {
-            emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyDownHandler());
+            case Event::Keyboard::Type::KEY_UP:
+            {
+                emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyUpHandler());
+                break;
+            }
+            case Event::Keyboard::Type::KEY_DOWN:
+            {
+                emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyDownHandler());
+                break;
+            }
         }
     }
     for (auto it = _ui.rbegin(); it != _ui.rend(); ++it)

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -43,8 +43,8 @@ using namespace Base;
 
 State::State() : Event::EventTarget(Game::getInstance()->eventDispatcher())
 {
-    addEventHandler("activate",   [this](Event::Event* event){ this->onStateActivate(dynamic_cast<Event::State*>(event)); });
-    addEventHandler("deactivate", [this](Event::Event* event){ this->onStateDeactivate(dynamic_cast<Event::State*>(event)); });
+    activateHandler().add([this](Event::Event* event){ this->onStateActivate(dynamic_cast<Event::State*>(event)); });
+    deactivateHandler().add([this](Event::Event* event){ this->onStateDeactivate(dynamic_cast<Event::State*>(event)); });
 }
 
 State::~State()
@@ -55,7 +55,7 @@ void State::init()
 {
     _initialized = true;
 
-    addEventHandler("keydown", [this](Event::Event* event) { this->onKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
+    keyDownHandler().add([this](Event::Event* event) { this->onKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
 }
 
 void State::think()
@@ -233,27 +233,27 @@ void State::setActive(bool value)
     _active = value;
 }
 
-Event::StateHandler& State::activateHandler() const
+Event::StateHandler& State::activateHandler()
 {
     return _activateHandler;
 }
 
-Event::StateHandler& State::deactivateHandler() const
+Event::StateHandler& State::deactivateHandler()
 {
     return _deactivateHandler;
 }
 
-Event::StateHandler& State::fadeDoneHandler() const
+Event::StateHandler& State::fadeDoneHandler()
 {
     return _fadeDoneHandler;
 }
 
-Event::KeyboardHandler& State::keyDownHandler() const
+Event::KeyboardHandler& State::keyDownHandler()
 {
     return _keyDownHandler;
 }
 
-Event::KeyboardHandler& State::keyUpHandler() const
+Event::KeyboardHandler& State::keyUpHandler()
 {
     return _keyUpHandler;
 }

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -61,9 +61,17 @@ public:
     State();
     virtual ~State();
 
+    template <class TUi, class ...TCtorArgs>
+    TUi* makeUI(TCtorArgs&&... args)
+    {
+        TUi* ptr = new TUi(std::forward<TCtorArgs>(args)...);
+        _ui.emplace_back(ptr);
+        return ptr;
+    }
+
     UI::Base* addUI(UI::Base* ui);
     UI::Base* addUI(const std::string& name, UI::Base* ui);
-    void addUI(std::vector<UI::Base*> uis);
+    void addUI(const std::vector<UI::Base*>& uis);
     void popUI();
 
     UI::Base* getUI(const std::string& name);
@@ -120,6 +128,7 @@ public:
     Event::StateHandler& fadeDoneHandler();
     Event::KeyboardHandler& keyDownHandler();
     Event::KeyboardHandler& keyUpHandler();
+
 
 protected:
     std::vector<std::unique_ptr<UI::Base>> _ui;

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -115,11 +115,11 @@ public:
     virtual void onStateDeactivate(Event::State* event);
     virtual void onKeyDown(Event::Keyboard* event);
 
-    Event::StateHandler& activateHandler() const;
-    Event::StateHandler& deactivateHandler() const;
-    Event::StateHandler& fadeDoneHandler() const;
-    Event::KeyboardHandler& keyDownHandler() const;
-    Event::KeyboardHandler& keyUpHandler() const;
+    Event::StateHandler& activateHandler();
+    Event::StateHandler& deactivateHandler();
+    Event::StateHandler& fadeDoneHandler();
+    Event::KeyboardHandler& keyDownHandler();
+    Event::KeyboardHandler& keyUpHandler();
 
 protected:
     std::vector<std::unique_ptr<UI::Base>> _ui;

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -123,8 +123,25 @@ public:
     virtual void onStateDeactivate(Event::State* event);
     virtual void onKeyDown(Event::Keyboard* event);
 
+    /**
+     * Invoked when state becomes active to receive events (when first pushed and after other modal states are removed from "above").
+     */
     Event::StateHandler& activateHandler();
+    /**
+     * Invoked when state becomes inactive and won't receive any more events (when popped and also when other modal state is pushed on top of it).
+     */
     Event::StateHandler& deactivateHandler();
+    /**
+     * Invoked when state is pushed to the stack, right before the first "activate".
+     */
+    Event::StateHandler& pushHandler();
+    /**
+     * Invoked when state is popped from the stack, right after last "deactivate".
+     */
+    Event::StateHandler& popHandler();
+    /**
+     * Invoked when Renderer has finished fadein/fadeout process.
+     */
     Event::StateHandler& fadeDoneHandler();
     Event::KeyboardHandler& keyDownHandler();
     Event::KeyboardHandler& keyUpHandler();
@@ -143,7 +160,7 @@ protected:
     bool _fullscreen = true; // prevents render all states before this one
     bool _initialized = false;
 
-    Event::StateHandler _activateHandler, _deactivateHandler, _fadeDoneHandler;
+    Event::StateHandler _activateHandler, _deactivateHandler, _fadeDoneHandler, _pushHandler, _popHandler;
     Event::KeyboardHandler _keyDownHandler, _keyUpHandler;
 };
 

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -115,6 +115,12 @@ public:
     virtual void onStateDeactivate(Event::State* event);
     virtual void onKeyDown(Event::Keyboard* event);
 
+    Event::StateHandler& activateHandler() const;
+    Event::StateHandler& deactivateHandler() const;
+    Event::StateHandler& fadeDoneHandler() const;
+    Event::KeyboardHandler& keyDownHandler() const;
+    Event::KeyboardHandler& keyUpHandler() const;
+
 protected:
     std::vector<std::unique_ptr<UI::Base>> _ui;
     std::vector<std::unique_ptr<UI::Base>> _uiToDelete;
@@ -128,6 +134,8 @@ protected:
     bool _fullscreen = true; // prevents render all states before this one
     bool _initialized = false;
 
+    Event::StateHandler _activateHandler, _deactivateHandler, _fadeDoneHandler;
+    Event::KeyboardHandler _keyDownHandler, _keyUpHandler;
 };
 
 }

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -238,14 +238,14 @@ void Animation::think()
             _currentFrame = _reverse ? _animationFrames.size() - _progress - 1 : _progress;
             if (_actionFrame == _currentFrame)
             {
-                emitEvent(make_unique<Event::Event>("actionFrame"));
+                emitEvent(make_unique<Event::Event>("actionFrame"), actionFrameHandler());
             }
         }
         else
         {
             _ended = true;
             _playing = false;
-            emitEvent(make_unique<Event::Event>("animationEnded"));
+            emitEvent(make_unique<Event::Event>("animationEnded"), animationEndedHandler());
         }
     }
 }
@@ -457,5 +457,14 @@ void Animation::setActionFrame(unsigned int value)
     _actionFrame = value;
 }
 
+Event::Handler& Animation::actionFrameHandler() const
+{
+    return _actionFrameHandler;
+}
+
+Event::Handler& Animation::animationEndedHandler() const
+{
+    return _animationEndedHandler;
+}
 }
 }

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -457,12 +457,12 @@ void Animation::setActionFrame(unsigned int value)
     _actionFrame = value;
 }
 
-Event::Handler& Animation::actionFrameHandler() const
+Event::Handler& Animation::actionFrameHandler()
 {
     return _actionFrameHandler;
 }
 
-Event::Handler& Animation::animationEndedHandler() const
+Event::Handler& Animation::animationEndedHandler()
 {
     return _animationEndedHandler;
 }

--- a/src/UI/Animation.h
+++ b/src/UI/Animation.h
@@ -68,9 +68,9 @@ public:
     bool ended() const;
     bool playing() const;
 
-    Event::Handler& animationEndedHandler() const;
+    Event::Handler& animationEndedHandler();
 
-    Event::Handler& actionFrameHandler() const;
+    Event::Handler& actionFrameHandler();
 
 protected:
     bool _playing = false;

--- a/src/UI/Animation.h
+++ b/src/UI/Animation.h
@@ -68,6 +68,10 @@ public:
     bool ended() const;
     bool playing() const;
 
+    Event::Handler& animationEndedHandler() const;
+
+    Event::Handler& actionFrameHandler() const;
+
 protected:
     bool _playing = false;
     bool _ended = false;
@@ -85,6 +89,7 @@ protected:
     std::vector<Graphics::Texture*> _monitorTextures;
     std::vector<Graphics::Texture*> _reddotTextures;
 
+    Event::Handler _actionFrameHandler, _animationEndedHandler;
 };
 
 }

--- a/src/UI/AnimationQueue.cpp
+++ b/src/UI/AnimationQueue.cpp
@@ -144,7 +144,7 @@ Point AnimationQueue::offset() const
     return currentAnimation()->offset();
 }
 
-Event::Handler& AnimationQueue::animationEndedHandler() const
+Event::Handler& AnimationQueue::animationEndedHandler()
 {
     return _animationEndedHandler;
 }

--- a/src/UI/AnimationQueue.cpp
+++ b/src/UI/AnimationQueue.cpp
@@ -97,7 +97,7 @@ void AnimationQueue::think()
             {
                 if (!_repeat)
                 {
-                    emitEvent(make_unique<Event::Event>("animationEnded"));
+                    emitEvent(make_unique<Event::Event>("animationEnded"), animationEndedHandler());
                     _playing = false;
                     return;
                 }
@@ -143,5 +143,11 @@ Point AnimationQueue::offset() const
 {
     return currentAnimation()->offset();
 }
+
+Event::Handler& AnimationQueue::animationEndedHandler() const
+{
+    return _animationEndedHandler;
+}
+
 }
 }

--- a/src/UI/AnimationQueue.h
+++ b/src/UI/AnimationQueue.h
@@ -57,11 +57,15 @@ public:
     Size size() const override;
     Point offset() const override;
 
+    Event::Handler& animationEndedHandler() const;
+
 protected:
     bool _playing = false;
     bool _repeat = false;
     unsigned int _currentAnimation = 0;
     std::vector<std::unique_ptr<Animation>> _animations;
+
+    Event::Handler _animationEndedHandler;
 };
 
 }

--- a/src/UI/AnimationQueue.h
+++ b/src/UI/AnimationQueue.h
@@ -57,7 +57,7 @@ public:
     Size size() const override;
     Point offset() const override;
 
-    Event::Handler& animationEndedHandler() const;
+    Event::Handler& animationEndedHandler();
 
 protected:
     bool _playing = false;

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -209,17 +209,17 @@ void Base::handle(Event::Event* event)
             {
                 if (_leftButtonPressed)
                 {
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, _drag ? "mousedrag" : "mousedragstart"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, _drag ? "mousedrag" : "mousedragstart"), _drag ? mouseDragHandler() : mouseDragStartHandler());
                     if (!_drag) _drag = true;
                 }
                 if (!_hovered)
                 {
                     _hovered = true;
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousein"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousein"), mouseInHandler());
                 }
                 else
                 {
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousemove"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousemove"), mouseMoveHandler());
                 }
             }
             else if (mouseEvent->name() == "mousedown")
@@ -227,12 +227,12 @@ void Base::handle(Event::Event* event)
                 if (mouseEvent->leftButton())
                 {
                     _leftButtonPressed = true;
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseleftdown"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseleftdown"), mouseDownHandler());
                 }
                 else if (mouseEvent->rightButton())
                 {
                     _rightButtonPressed = true;
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouserightdown"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouserightdown"), mouseDownHandler());
                 }
                 // mousedown event can not be "interesting" for any other UI's that "behind" this UI,
                 // so we can safely stop event capturing now
@@ -242,24 +242,24 @@ void Base::handle(Event::Event* event)
             {
                 if (mouseEvent->leftButton())
                 {
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseleftup"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseleftup"), mouseUpHandler());
                     if (_leftButtonPressed)
                     {
                         if (_drag)
                         {
                             _drag = false;
-                            emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousedragstop"));
+                            emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousedragstop"), mouseDragStopHandler());
                         }
-                        emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseleftclick"));
+                        emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseleftclick"), mouseClickHandler());
                     }
                     _leftButtonPressed = false;
                 }
                 else if (mouseEvent->rightButton())
                 {
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouserightup"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouserightup"), mouseUpHandler());
                     if (_rightButtonPressed)
                     {
-                        emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouserightclick"));
+                        emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouserightclick"), mouseClickHandler());
                     }
                     _rightButtonPressed = false;
                 }
@@ -277,12 +277,12 @@ void Base::handle(Event::Event* event)
             {
                 if (_drag)
                 {
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousedrag"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousedrag"), mouseDragHandler());
                 }
                 if (_hovered)
                 {
                     _hovered = false;
-                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseout"));
+                    emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mouseout"), mouseOutHandler());
                 }
             }
             else if (mouseEvent->name() == "mouseup")
@@ -294,7 +294,7 @@ void Base::handle(Event::Event* event)
                         if (_drag)
                         {
                             _drag = false;
-                            emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousedragstop"));
+                            emitEvent(make_unique<Event::Mouse>(*mouseEvent, "mousedragstop"), mouseDragStopHandler());
                         }
                         _leftButtonPressed = false;
                     }
@@ -313,7 +313,14 @@ void Base::handle(Event::Event* event)
 
     if (auto keyboardEvent = dynamic_cast<Event::Keyboard*>(event))
     {
-        emitEvent(make_unique<Event::Keyboard>(*keyboardEvent));
+        if (keyboardEvent->name() == "keyup")
+        {
+            emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyUpHandler());
+        }
+        else if (keyboardEvent->name() == "keydown")
+        {
+            emitEvent(make_unique<Event::Keyboard>(*keyboardEvent), keyDownHandler());
+        }
     }
 }
 
@@ -334,6 +341,62 @@ unsigned Base::width() const
 unsigned Base::height() const
 {
     return size().height();
+}
+
+
+Event::KeyboardHandler& Base::keyDownHandler() const
+{
+    return _keyDownHandler;
+}
+
+Event::KeyboardHandler& Base::keyUpHandler() const
+{
+    return _keyUpHandler;
+}
+
+Event::MouseHandler& Base::mouseDragStartHandler() const
+{
+    return _mouseDragStartHandler;
+}
+
+Event::MouseHandler& Base::mouseDragHandler() const
+{
+    return _mouseDragHandler;
+}
+
+Event::MouseHandler& Base::mouseDragStopHandler() const
+{
+    return _mouseDragStopHandler;
+}
+
+Event::MouseHandler& Base::mouseInHandler() const
+{
+    return _mouseInHandler;
+}
+
+Event::MouseHandler& Base::mouseMoveHandler() const
+{
+    return _mouseMoveHandler;
+}
+
+Event::MouseHandler& Base::mouseOutHandler() const
+{
+    return _mouseOutHandler;
+}
+
+Event::MouseHandler& Base::mouseClickHandler() const
+{
+    return _mouseClickHandler;
+}
+
+Event::MouseHandler& Base::mouseDownHandler() const
+{
+    return _mouseDownHandler;
+}
+
+Event::MouseHandler& Base::mouseUpHandler() const
+{
+    return _mouseUpHandler;
 }
 
 }

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -344,57 +344,57 @@ unsigned Base::height() const
 }
 
 
-Event::KeyboardHandler& Base::keyDownHandler() const
+Event::KeyboardHandler& Base::keyDownHandler()
 {
     return _keyDownHandler;
 }
 
-Event::KeyboardHandler& Base::keyUpHandler() const
+Event::KeyboardHandler& Base::keyUpHandler()
 {
     return _keyUpHandler;
 }
 
-Event::MouseHandler& Base::mouseDragStartHandler() const
+Event::MouseHandler& Base::mouseDragStartHandler()
 {
     return _mouseDragStartHandler;
 }
 
-Event::MouseHandler& Base::mouseDragHandler() const
+Event::MouseHandler& Base::mouseDragHandler()
 {
     return _mouseDragHandler;
 }
 
-Event::MouseHandler& Base::mouseDragStopHandler() const
+Event::MouseHandler& Base::mouseDragStopHandler()
 {
     return _mouseDragStopHandler;
 }
 
-Event::MouseHandler& Base::mouseInHandler() const
+Event::MouseHandler& Base::mouseInHandler()
 {
     return _mouseInHandler;
 }
 
-Event::MouseHandler& Base::mouseMoveHandler() const
+Event::MouseHandler& Base::mouseMoveHandler()
 {
     return _mouseMoveHandler;
 }
 
-Event::MouseHandler& Base::mouseOutHandler() const
+Event::MouseHandler& Base::mouseOutHandler()
 {
     return _mouseOutHandler;
 }
 
-Event::MouseHandler& Base::mouseClickHandler() const
+Event::MouseHandler& Base::mouseClickHandler()
 {
     return _mouseClickHandler;
 }
 
-Event::MouseHandler& Base::mouseDownHandler() const
+Event::MouseHandler& Base::mouseDownHandler()
 {
     return _mouseDownHandler;
 }
 
-Event::MouseHandler& Base::mouseUpHandler() const
+Event::MouseHandler& Base::mouseUpHandler()
 {
     return _mouseUpHandler;
 }

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -265,6 +265,8 @@ void Base::handle(Event::Mouse* mouseEvent)
                         _rightButtonPressed = true;
                         break;
                     }
+                    default:
+                        break;
                 }
                 // mousedown event can not be "interesting" for any other UI's that "behind" this UI,
                 // so we can safely stop event capturing now
@@ -299,6 +301,8 @@ void Base::handle(Event::Mouse* mouseEvent)
                         _rightButtonPressed = false;
                         break;
                     }
+                    default:
+                        break;
                 }
                 break;
             }
@@ -352,9 +356,13 @@ void Base::handle(Event::Mouse* mouseEvent)
                         }
                         break;
                     }
+                    default:
+                        break;
                 }
                 break;
             }
+            default:
+                break;
         }
     }
     return;

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -225,9 +225,9 @@ void Base::handle(Event::Event* event)
 void Base::handle(Event::Mouse* mouseEvent)
 {
     using Mouse = Event::Mouse;
-    Point pos = mouseEvent->position() - this->position();
+    Point relPos = mouseEvent->position() - this->position();
 
-    if (!mouseEvent->obstacle() && this->pixel(pos)) // mouse cursor is over the element
+    if (!mouseEvent->obstacle() && this->pixel(relPos)) // mouse cursor is over the element
     {
         switch (mouseEvent->originalType())
         {

--- a/src/UI/Base.h
+++ b/src/UI/Base.h
@@ -130,9 +130,6 @@ protected:
     bool _drag = false;
     bool _hovered = false;
     bool _visible = true;
-    // @todo Should it really be here?
-    std::string _downSound = "";
-    std::string _upSound = "";
 
     Event::KeyboardHandler _keyDownHandler, _keyUpHandler;
     Event::MouseHandler _mouseDragStartHandler, _mouseDragHandler, _mouseDragStopHandler,

--- a/src/UI/Base.h
+++ b/src/UI/Base.h
@@ -93,18 +93,18 @@ public:
     virtual unsigned int pixel(const Point& pos);
     unsigned int pixel(unsigned int x, unsigned int y);
 
-    Event::KeyboardHandler& keyDownHandler() const;
-    Event::KeyboardHandler& keyUpHandler() const;
+    Event::KeyboardHandler& keyDownHandler();
+    Event::KeyboardHandler& keyUpHandler();
 
-    Event::MouseHandler& mouseDragStartHandler() const;
-    Event::MouseHandler& mouseDragHandler() const;
-    Event::MouseHandler& mouseDragStopHandler() const;
-    Event::MouseHandler& mouseInHandler() const;
-    Event::MouseHandler& mouseMoveHandler() const;
-    Event::MouseHandler& mouseOutHandler() const;
-    Event::MouseHandler& mouseClickHandler() const;
-    Event::MouseHandler& mouseDownHandler() const;
-    Event::MouseHandler& mouseUpHandler() const;
+    Event::MouseHandler& mouseDragStartHandler();
+    Event::MouseHandler& mouseDragHandler();
+    Event::MouseHandler& mouseDragStopHandler();
+    Event::MouseHandler& mouseInHandler();
+    Event::MouseHandler& mouseMoveHandler();
+    Event::MouseHandler& mouseOutHandler();
+    Event::MouseHandler& mouseClickHandler();
+    Event::MouseHandler& mouseDownHandler();
+    Event::MouseHandler& mouseUpHandler();
     // TODO: mouse hover? (will require additional hoverDelay property)
 
 protected:

--- a/src/UI/Base.h
+++ b/src/UI/Base.h
@@ -93,6 +93,20 @@ public:
     virtual unsigned int pixel(const Point& pos);
     unsigned int pixel(unsigned int x, unsigned int y);
 
+    Event::KeyboardHandler& keyDownHandler() const;
+    Event::KeyboardHandler& keyUpHandler() const;
+
+    Event::MouseHandler& mouseDragStartHandler() const;
+    Event::MouseHandler& mouseDragHandler() const;
+    Event::MouseHandler& mouseDragStopHandler() const;
+    Event::MouseHandler& mouseInHandler() const;
+    Event::MouseHandler& mouseMoveHandler() const;
+    Event::MouseHandler& mouseOutHandler() const;
+    Event::MouseHandler& mouseClickHandler() const;
+    Event::MouseHandler& mouseDownHandler() const;
+    Event::MouseHandler& mouseUpHandler() const;
+    // TODO: mouse hover? (will require additional hoverDelay property)
+
 protected:
     Point _position;
     Point _offset;
@@ -112,6 +126,11 @@ protected:
     // @todo Should it really be here?
     std::string _downSound = "";
     std::string _upSound = "";
+
+    Event::KeyboardHandler _keyDownHandler, _keyUpHandler;
+    Event::MouseHandler _mouseDragStartHandler, _mouseDragHandler, _mouseDragStopHandler,
+                        _mouseInHandler, _mouseMoveHandler, _mouseOutHandler,
+                        _mouseClickHandler, _mouseDownHandler, _mouseUpHandler;
 
 private:
     std::unique_ptr<Graphics::Texture> _generatedTexture;

--- a/src/UI/Base.h
+++ b/src/UI/Base.h
@@ -88,6 +88,11 @@ public:
      */
     virtual void render(bool eggTransparency = false);
 
+    /**
+     * @brief Handles mouse events from OS.
+     */
+    virtual void handle(Event::Mouse* mouseEvent);
+
     virtual Size size() const;
 
     virtual unsigned int pixel(const Point& pos);
@@ -96,6 +101,7 @@ public:
     Event::KeyboardHandler& keyDownHandler();
     Event::KeyboardHandler& keyUpHandler();
 
+    // TODO: maybe not all elements should have drag events?
     Event::MouseHandler& mouseDragStartHandler();
     Event::MouseHandler& mouseDragHandler();
     Event::MouseHandler& mouseDragStopHandler();
@@ -118,6 +124,7 @@ protected:
 
     Graphics::Texture* _texture = nullptr;
     std::unique_ptr<Graphics::Texture> _tmptex;
+    
     bool _leftButtonPressed = false;
     bool _rightButtonPressed = false;
     bool _drag = false;

--- a/src/UI/ImageButton.cpp
+++ b/src/UI/ImageButton.cpp
@@ -218,9 +218,9 @@ void ImageButton::_init(Type type)
         default:
             throw Exception("ImageButton::Imagebutton() - wrong button type");
     }
-    mouseClickHandler().add(std::bind(&_onMouseClick, this, std::placeholders::_1));
-    mouseDownHandler().add(std::bind(&_onMouseDown, this, std::placeholders::_1));
-    mouseOutHandler().add(std::bind(&_onMouseOut, this, std::placeholders::_1));
+    mouseClickHandler().add(std::bind(&ImageButton::_onMouseClick, this, std::placeholders::_1));
+    mouseDownHandler().add(std::bind(&ImageButton::_onMouseDown, this, std::placeholders::_1));
+    mouseOutHandler().add(std::bind(&ImageButton::_onMouseOut, this, std::placeholders::_1));
 }
 
 Graphics::Texture* ImageButton::texture() const

--- a/src/UI/ImageButton.cpp
+++ b/src/UI/ImageButton.cpp
@@ -218,9 +218,9 @@ void ImageButton::_init(Type type)
         default:
             throw Exception("ImageButton::Imagebutton() - wrong button type");
     }
-    addEventHandler("mouseleftclick", [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mouseleftdown", [this](Event::Event* event){ this->_onLeftButtonDown(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mouseout", [this](Event::Event* event){ this->_onMouseOut(dynamic_cast<Event::Mouse*>(event)); });
+    mouseClickHandler().add(std::bind(&_onLeftButtonClick, this, std::placeholders::_1));
+    mouseDownHandler().add(std::bind(&_onLeftButtonDown, this, std::placeholders::_1));
+    mouseOutHandler().add(std::bind(&_onMouseOut, this, std::placeholders::_1));
 }
 
 Graphics::Texture* ImageButton::texture() const

--- a/src/UI/ImageButton.cpp
+++ b/src/UI/ImageButton.cpp
@@ -218,8 +218,8 @@ void ImageButton::_init(Type type)
         default:
             throw Exception("ImageButton::Imagebutton() - wrong button type");
     }
-    mouseClickHandler().add(std::bind(&_onLeftButtonClick, this, std::placeholders::_1));
-    mouseDownHandler().add(std::bind(&_onLeftButtonDown, this, std::placeholders::_1));
+    mouseClickHandler().add(std::bind(&_onMouseClick, this, std::placeholders::_1));
+    mouseDownHandler().add(std::bind(&_onMouseDown, this, std::placeholders::_1));
     mouseOutHandler().add(std::bind(&_onMouseOut, this, std::placeholders::_1));
 }
 
@@ -232,7 +232,7 @@ Graphics::Texture* ImageButton::texture() const
     return _textures.at(0);
 }
 
-void ImageButton::_onLeftButtonClick(Event::Mouse* event)
+void ImageButton::_onMouseClick(Event::Mouse* event)
 {
     auto sender = dynamic_cast<ImageButton*>(event->target());
     if (sender->_checkboxMode)
@@ -245,8 +245,10 @@ void ImageButton::_onLeftButtonClick(Event::Mouse* event)
     }
 }
 
-void ImageButton::_onLeftButtonDown(Event::Mouse* event)
+void ImageButton::_onMouseDown(Event::Mouse* event)
 {
+    if (!event->leftButton()) return;
+
     auto sender = dynamic_cast<ImageButton*>(event->target());
     if (!sender->_downSound.empty())
     {
@@ -273,6 +275,13 @@ bool ImageButton::checked()
 void ImageButton::setChecked(bool _checked)
 {
     this->_checked = _checked;
+}
+
+void ImageButton::handle(Event::Mouse* mouseEvent)
+{
+    // disable right button clicks
+    _rightButtonPressed = false;
+    Base::handle(mouseEvent);
 }
 
 }

--- a/src/UI/ImageButton.h
+++ b/src/UI/ImageButton.h
@@ -21,6 +21,7 @@
 #define FALLTERGEIST_UI_IMAGEBUTTON_H
 
 // C++ standard includes
+#include <string>
 #include <vector>
 
 // Falltergeist includes
@@ -90,7 +91,10 @@ public:
 
 protected:
     bool _checkboxMode = false; // remember new state after click
-    bool _checked = false;
+    bool _checked = false;    
+    
+    std::string _downSound;
+    std::string _upSound;
 
     std::vector<Graphics::Texture*> _textures;
     void _onMouseClick(Event::Mouse* event);

--- a/src/UI/ImageButton.h
+++ b/src/UI/ImageButton.h
@@ -86,13 +86,15 @@ public:
     bool checked();
     void setChecked(bool _checked);
 
+    virtual void handle(Event::Mouse* mouseEvent) override;
+
 protected:
     bool _checkboxMode = false; // remember new state after click
     bool _checked = false;
 
     std::vector<Graphics::Texture*> _textures;
-    void _onLeftButtonClick(Event::Mouse* event);
-    void _onLeftButtonDown(Event::Mouse* event);
+    void _onMouseClick(Event::Mouse* event);
+    void _onMouseDown(Event::Mouse* event);
     void _onMouseOut(Event::Mouse* event);
     void _init(Type type);
 

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -127,6 +127,7 @@ void InventoryItem::onMouseDragStart(Event::Mouse* event)
     Game::getInstance()->mixer()->playACMSound("sound/sfx/ipickup1.acm");
     _oldType = type();
     setType(Type::DRAG);
+    setOffset((event->position() - _position) - size() / 2);
 }
 
 void InventoryItem::onMouseDrag(Event::Mouse* event)
@@ -174,7 +175,7 @@ void InventoryItem::onArmorDragStop(Event::Mouse* event)
     }
 }
 
-void InventoryItem::onHandDragStop(Event::Mouse* event)
+void InventoryItem::onHandDragStop(Event::Mouse* event, HAND hand)
 {
     // Check if mouse is over this item
     if (!Rect::inRect(event->position(), position(), size()))
@@ -193,6 +194,15 @@ void InventoryItem::onHandDragStop(Event::Mouse* event)
             itemsList->addItem(this, 1);
         }
         this->setItem(item);
+        auto player = Game::getInstance()->player();
+        if (hand == HAND::LEFT)
+        {
+            player->setLeftHandSlot(item);
+        }
+        else
+        {
+            player->setRightHandSlot(item);
+        }
     }
 }
 

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -144,7 +144,7 @@ void InventoryItem::onMouseDragStop(Event::Mouse* event)
     auto itemevent = make_unique<Event::Mouse>("itemdragstop");
     itemevent->setPosition(event->position());
     itemevent->setTarget(this);
-    emitEvent(std::move(itemevent));
+    emitEvent(std::move(itemevent), itemDragStopHandler());
 }
 
 void InventoryItem::onArmorDragStop(Event::Mouse* event)
@@ -209,5 +209,9 @@ Size InventoryItem::size() const
     }
 }
 
+Event::MouseHandler& InventoryItem::itemDragStopHandler()
+{
+    return _itemDragStopHandler;
+}
 }
 }

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -49,10 +49,10 @@ using namespace Base;
 InventoryItem::InventoryItem(Game::ItemObject *item, const Point& pos) : Falltergeist::UI::Base(pos)
 {
     _item = item;
-    addEventHandler("mouseleftdown", [this](Event::Event* event){ this->onMouseLeftDown(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mousedragstart", [this](Event::Event* event){ this->onMouseDragStart(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mousedrag", [this](Event::Event* event){ this->onMouseDrag(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mousedragstop", [this](Event::Event* event){ this->onMouseDragStop(dynamic_cast<Event::Mouse*>(event)); });
+    mouseDownHandler().add(std::bind(&onMouseLeftDown, this, std::placeholders::_1));
+    mouseDragStartHandler().add(std::bind(&onMouseDragStart, this, std::placeholders::_1));
+    mouseDragHandler().add(std::bind(&onMouseDrag, this, std::placeholders::_1));
+    mouseDragStopHandler().add(std::bind(&onMouseDragStop, this, std::placeholders::_1));
 }
 
 InventoryItem::~InventoryItem()

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -49,10 +49,10 @@ using namespace Base;
 InventoryItem::InventoryItem(Game::ItemObject *item, const Point& pos) : Falltergeist::UI::Base(pos)
 {
     _item = item;
-    mouseDownHandler().add(std::bind(&onMouseLeftDown, this, std::placeholders::_1));
-    mouseDragStartHandler().add(std::bind(&onMouseDragStart, this, std::placeholders::_1));
-    mouseDragHandler().add(std::bind(&onMouseDrag, this, std::placeholders::_1));
-    mouseDragStopHandler().add(std::bind(&onMouseDragStop, this, std::placeholders::_1));
+    mouseDownHandler().add(std::bind(&InventoryItem::onMouseLeftDown, this, std::placeholders::_1));
+    mouseDragStartHandler().add(std::bind(&InventoryItem::onMouseDragStart, this, std::placeholders::_1));
+    mouseDragHandler().add(std::bind(&InventoryItem::onMouseDrag, this, std::placeholders::_1));
+    mouseDragStopHandler().add(std::bind(&InventoryItem::onMouseDragStop, this, std::placeholders::_1));
 }
 
 InventoryItem::~InventoryItem()

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -141,7 +141,7 @@ void InventoryItem::onMouseDragStop(Event::Mouse* event)
     setOffset({0, 0});
     setType(_oldType);
 
-    auto itemevent = make_unique<Event::Mouse>("itemdragstop");
+    auto itemevent = make_unique<Event::Mouse>(*event, "itemdragstop");
     itemevent->setPosition(event->position());
     itemevent->setTarget(this);
     emitEvent(std::move(itemevent), itemDragStopHandler());

--- a/src/UI/InventoryItem.h
+++ b/src/UI/InventoryItem.h
@@ -26,6 +26,7 @@
 #include "../UI/Base.h"
 
 // Third party includes
+#include <libfalltergeist/Enums.h>
 
 namespace Falltergeist
 {
@@ -70,7 +71,7 @@ public:
     void onMouseDragStop(Event::Mouse* event);
 
     void onArmorDragStop(Event::Mouse* event);
-    void onHandDragStop(Event::Mouse* event);
+    void onHandDragStop(Event::Mouse* event, HAND hand);
 
     Event::MouseHandler& itemDragStopHandler();
 

--- a/src/UI/InventoryItem.h
+++ b/src/UI/InventoryItem.h
@@ -72,11 +72,14 @@ public:
     void onArmorDragStop(Event::Mouse* event);
     void onHandDragStop(Event::Mouse* event);
 
+    Event::MouseHandler& itemDragStopHandler();
+
 protected:
     Game::ItemObject* _item = nullptr;
     Type _type = Type::INVENTORY;
     Type _oldType = Type::INVENTORY;
 
+    Event::MouseHandler _itemDragStopHandler;
 };
 
 }

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -137,7 +137,7 @@ void ItemsList::onMouseDrag(Event::Mouse* event)
     {
         _draggedItem->setOffset(_draggedItem->offset() + event->offset());
     }
-    Logger::critical() << "mousedrag " << event->position() << ", " << event->offset() << std::endl;
+    //Logger::critical() << "mousedrag " << event->position() << ", " << event->offset() << std::endl;
 }
 
 void ItemsList::onMouseDragStop(Event::Mouse* event)
@@ -152,12 +152,12 @@ void ItemsList::onMouseDragStop(Event::Mouse* event)
         itemevent->setTarget(this);
         emitEvent(std::move(itemevent), itemDragStopHandler());
     }
-    Logger::critical() << "mousedragstop" << std::endl;
+    //Logger::critical() << "mousedragstop" << std::endl;
 }
 
 void ItemsList::onItemDragStop(Event::Mouse* event)
 {
-    Logger::critical() << "itemdragstop" << std::endl;
+    //Logger::critical() << "itemdragstop" << std::endl;
 
     // check if mouse is in this item list
     if (!Rect::inRect(event->position(), position(), Size(_slotWidth, _slotHeight*_slotsNumber)))
@@ -186,7 +186,28 @@ void ItemsList::onItemDragStop(Event::Mouse* event)
         inventoryItem->setItem(0);
     }
 
-    Logger::critical() << "IN!" << std::endl;
+    //Logger::critical() << "IN!" << std::endl;
+}
+
+void ItemsList::onItemDragStop(Event::Mouse* event, HAND hand)
+{
+    // check if mouse is in this item list
+    if (Rect::inRect(event->position(), position(), Size(_slotWidth, _slotHeight*_slotsNumber)))
+    {
+        if (auto inventoryItem = dynamic_cast<UI::InventoryItem*>(event->target()))
+        {
+            this->addItem(inventoryItem, 1);
+            if (hand == HAND::LEFT)
+            {
+                Game::getInstance()->player()->setLeftHandSlot(nullptr);
+            }
+            else
+            {
+                Game::getInstance()->player()->setRightHandSlot(nullptr);
+            }
+            inventoryItem->setItem(0);
+        }
+    }
 }
 
 InventoryItem* ItemsList::draggedItem()

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -52,10 +52,10 @@ ItemsList::ItemsList(const Point& pos) : Falltergeist::UI::Base(pos)
     _generateTexture(_slotWidth, _slotHeight * _slotsNumber);
     _texture->fill(0x000000FF);
 
-    mouseDownHandler().add( std::bind(&onMouseLeftDown, this, std::placeholders::_1));
-    mouseDragStartHandler().add(std::bind(&onMouseDragStart, this, std::placeholders::_1));
-    mouseDragHandler().add(     std::bind(&onMouseDrag, this, std::placeholders::_1));
-    mouseDragStopHandler().add( std::bind(&onMouseDragStop, this, std::placeholders::_1));
+    mouseDownHandler().add( std::bind(&ItemsList::onMouseLeftDown, this, std::placeholders::_1));
+    mouseDragStartHandler().add(std::bind(&ItemsList::onMouseDragStart, this, std::placeholders::_1));
+    mouseDragHandler().add(     std::bind(&ItemsList::onMouseDrag, this, std::placeholders::_1));
+    mouseDragStopHandler().add( std::bind(&ItemsList::onMouseDragStop, this, std::placeholders::_1));
 }
 
 void ItemsList::setItems(std::vector<Game::ItemObject*>* items)

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -148,7 +148,7 @@ void ItemsList::onMouseDragStop(Event::Mouse* event)
         Game::getInstance()->mixer()->playACMSound("sound/sfx/iputdown.acm");
         _draggedItem->setOffset(0, 0);
         _draggedItem->setType(_type);
-        auto itemevent = make_unique<Event::Mouse>("itemdragstop");
+        auto itemevent = make_unique<Event::Mouse>(*event, "itemdragstop");
         itemevent->setPosition(event->position());
         itemevent->setTarget(this);
         emitEvent(std::move(itemevent), itemDragStopHandler());

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -149,7 +149,6 @@ void ItemsList::onMouseDragStop(Event::Mouse* event)
         _draggedItem->setOffset(0, 0);
         _draggedItem->setType(_type);
         auto itemevent = make_unique<Event::Mouse>(*event, "itemdragstop");
-        itemevent->setPosition(event->position());
         itemevent->setTarget(this);
         emitEvent(std::move(itemevent), itemDragStopHandler());
     }

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -52,10 +52,10 @@ ItemsList::ItemsList(const Point& pos) : Falltergeist::UI::Base(pos)
     _generateTexture(_slotWidth, _slotHeight * _slotsNumber);
     _texture->fill(0x000000FF);
 
-    addEventHandler("mouseleftdown",  [this](Event::Event* event){ this->onMouseLeftDown(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mousedragstart", [this](Event::Event* event){ this->onMouseDragStart(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mousedrag",      [this](Event::Event* event){ this->onMouseDrag(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mousedragstop",  [this](Event::Event* event){ this->onMouseDragStop(dynamic_cast<Event::Mouse*>(event)); });
+    mouseDownHandler().add( std::bind(&onMouseLeftDown, this, std::placeholders::_1));
+    mouseDragStartHandler().add(std::bind(&onMouseDragStart, this, std::placeholders::_1));
+    mouseDragHandler().add(     std::bind(&onMouseDrag, this, std::placeholders::_1));
+    mouseDragStopHandler().add( std::bind(&onMouseDragStop, this, std::placeholders::_1));
 }
 
 void ItemsList::setItems(std::vector<Game::ItemObject*>* items)

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -151,7 +151,7 @@ void ItemsList::onMouseDragStop(Event::Mouse* event)
         auto itemevent = make_unique<Event::Mouse>("itemdragstop");
         itemevent->setPosition(event->position());
         itemevent->setTarget(this);
-        emitEvent(std::move(itemevent));
+        emitEvent(std::move(itemevent), itemDragStopHandler());
     }
     Logger::critical() << "mousedragstop" << std::endl;
 }
@@ -235,6 +235,11 @@ void ItemsList::scrollDown()
 {
     _slotOffset++;
     this->update();
+}
+
+Event::MouseHandler& ItemsList::itemDragStopHandler()
+{
+    return _itemDragStopHandler;
 }
 
 }

--- a/src/UI/ItemsList.h
+++ b/src/UI/ItemsList.h
@@ -79,6 +79,8 @@ public:
     void addItem(InventoryItem* item, unsigned int ammount);
     void removeItem(InventoryItem* item, unsigned int ammount);
 
+    Event::MouseHandler& itemDragStopHandler();
+
 protected:
     std::vector<Game::ItemObject*>* _items = nullptr;
     InventoryItem* _draggedItem = nullptr;
@@ -89,6 +91,7 @@ protected:
     unsigned int _slotWidth = 77;
     unsigned int _slotHeight = 40;
 
+    Event::MouseHandler _itemDragStopHandler;
 };
 
 }

--- a/src/UI/ItemsList.h
+++ b/src/UI/ItemsList.h
@@ -74,6 +74,7 @@ public:
     void onMouseDragStart(Event::Mouse* event);
     void onMouseDrag(Event::Mouse* event);
     void onMouseDragStop(Event::Mouse* event);
+    void onItemDragStop(Event::Mouse* event, HAND hand);
     void onItemDragStop(Event::Mouse* event);
 
     void addItem(InventoryItem* item, unsigned int ammount);

--- a/src/UI/MultistateImageButton.cpp
+++ b/src/UI/MultistateImageButton.cpp
@@ -40,12 +40,12 @@ namespace UI
 
 MultistateImageButton::MultistateImageButton(const Point& pos) : Falltergeist::UI::Base(pos)
 {
-    addEventHandler("mouseleftclick", [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    onMouseLeftClick() += [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); };
 }
 
 MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Falltergeist::UI::Base(Point(x, y))
 {
-    addEventHandler("mouseleftclick", [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    onMouseLeftClick() += [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); };
     addEventHandler("mouseleftup", [this](Event::Event* event){ this->_onLeftButtonUp(dynamic_cast<Event::Mouse*>(event)); });
     switch (type)
     {
@@ -91,7 +91,7 @@ MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Fallterg
 
 MultistateImageButton::MultistateImageButton(ImageList* imageList, const Point& pos) : Falltergeist::UI::Base(pos)
 {
-    addEventHandler("mouseleftclick", [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); });
+    onMouseLeftClick() += [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); };
     for (auto& image : imageList->images())
     {
         _imageList.addImage(std::unique_ptr<Image>(new Image(*image)));
@@ -214,6 +214,11 @@ void MultistateImageButton::setMinState(unsigned int value)
 unsigned int MultistateImageButton::minState() const
 {
     return _minState;
+}
+
+Event::Handler& MultistateImageButton::onMouseLeftClick()
+{
+    return _getEventHandlerRef("mouseleftclick");
 }
 
 }

--- a/src/UI/MultistateImageButton.cpp
+++ b/src/UI/MultistateImageButton.cpp
@@ -46,7 +46,7 @@ MultistateImageButton::MultistateImageButton(const Point& pos) : Falltergeist::U
 MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Falltergeist::UI::Base(Point(x, y))
 {
     mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
-    mouseUpHandler().add(std::bind(&_onLeftButtonUp, this, std::placeholders::_1));
+    mouseUpHandler().add(std::bind(&_onMouseUp, this, std::placeholders::_1));
     switch (type)
     {
         case Type::BIG_SWITCH:
@@ -158,7 +158,7 @@ void MultistateImageButton::_onMouseClick(Event::Mouse* event)
     }
 }
 
-void MultistateImageButton::_onLeftButtonUp(Event::Mouse* event)
+void MultistateImageButton::_onMouseUp(Event::Mouse* event)
 {
     if (!event->leftButton()) return;
 
@@ -216,6 +216,13 @@ void MultistateImageButton::setMinState(unsigned int value)
 unsigned int MultistateImageButton::minState() const
 {
     return _minState;
+}
+
+void MultistateImageButton::handle(Event::Mouse* mouseEvent)
+{
+    // disable right button clicks
+    _rightButtonPressed = false;
+    Base::handle(mouseEvent);
 }
 
 }

--- a/src/UI/MultistateImageButton.cpp
+++ b/src/UI/MultistateImageButton.cpp
@@ -40,13 +40,13 @@ namespace UI
 
 MultistateImageButton::MultistateImageButton(const Point& pos) : Falltergeist::UI::Base(pos)
 {
-    mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
+    mouseClickHandler() += std::bind(&MultistateImageButton::_onMouseClick, this, std::placeholders::_1);
 }
 
 MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Falltergeist::UI::Base(Point(x, y))
 {
-    mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
-    mouseUpHandler().add(std::bind(&_onMouseUp, this, std::placeholders::_1));
+    mouseClickHandler() += std::bind(&MultistateImageButton::_onMouseClick, this, std::placeholders::_1);
+    mouseUpHandler().add(std::bind(&MultistateImageButton::_onMouseUp, this, std::placeholders::_1));
     switch (type)
     {
         case Type::BIG_SWITCH:
@@ -91,7 +91,7 @@ MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Fallterg
 
 MultistateImageButton::MultistateImageButton(ImageList* imageList, const Point& pos) : Falltergeist::UI::Base(pos)
 {
-    mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
+    mouseClickHandler() += std::bind(&MultistateImageButton::_onMouseClick, this, std::placeholders::_1);
     for (auto& image : imageList->images())
     {
         _imageList.addImage(std::unique_ptr<Image>(new Image(*image)));

--- a/src/UI/MultistateImageButton.cpp
+++ b/src/UI/MultistateImageButton.cpp
@@ -40,13 +40,13 @@ namespace UI
 
 MultistateImageButton::MultistateImageButton(const Point& pos) : Falltergeist::UI::Base(pos)
 {
-    onMouseLeftClick() += [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); };
+    mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
 }
 
 MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Falltergeist::UI::Base(Point(x, y))
 {
-    onMouseLeftClick() += [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); };
-    addEventHandler("mouseleftup", [this](Event::Event* event){ this->_onLeftButtonUp(dynamic_cast<Event::Mouse*>(event)); });
+    mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
+    mouseUpHandler().add(std::bind(&_onLeftButtonUp, this, std::placeholders::_1));
     switch (type)
     {
         case Type::BIG_SWITCH:
@@ -91,7 +91,7 @@ MultistateImageButton::MultistateImageButton(Type type, int x, int y) : Fallterg
 
 MultistateImageButton::MultistateImageButton(ImageList* imageList, const Point& pos) : Falltergeist::UI::Base(pos)
 {
-    onMouseLeftClick() += [this](Event::Event* event){ this->_onLeftButtonClick(dynamic_cast<Event::Mouse*>(event)); };
+    mouseClickHandler() += std::bind(&_onMouseClick, this, std::placeholders::_1);
     for (auto& image : imageList->images())
     {
         _imageList.addImage(std::unique_ptr<Image>(new Image(*image)));
@@ -129,7 +129,7 @@ MultistateImageButton::Mode MultistateImageButton::mode() const
     return _mode;
 }
 
-void MultistateImageButton::_onLeftButtonClick(Event::Mouse* event)
+void MultistateImageButton::_onMouseClick(Event::Mouse* event)
 {
     auto sender = dynamic_cast<MultistateImageButton*>(event->target());
 
@@ -160,6 +160,8 @@ void MultistateImageButton::_onLeftButtonClick(Event::Mouse* event)
 
 void MultistateImageButton::_onLeftButtonUp(Event::Mouse* event)
 {
+    if (!event->leftButton()) return;
+
     auto sender = dynamic_cast<MultistateImageButton*>(event->target());
 
     if (!sender->_downSound.empty())
@@ -214,11 +216,6 @@ void MultistateImageButton::setMinState(unsigned int value)
 unsigned int MultistateImageButton::minState() const
 {
     return _minState;
-}
-
-Event::Handler& MultistateImageButton::onMouseLeftClick()
-{
-    return _getEventHandlerRef("mouseleftclick");
 }
 
 }

--- a/src/UI/MultistateImageButton.h
+++ b/src/UI/MultistateImageButton.h
@@ -78,8 +78,6 @@ public:
 
     Graphics::Texture* texture() const override;
 
-    Event::Handler& onMouseLeftClick();
-
 protected:
     ImageList _imageList;
     unsigned int _currentState = 0;
@@ -87,7 +85,7 @@ protected:
     int _modeFactor = 1; // or -1
     unsigned int _maxState = 0;
     unsigned int _minState = 0;
-    void _onLeftButtonClick(Event::Mouse* event);
+    void _onMouseClick(Event::Mouse* event);
     void _onLeftButtonUp(Event::Mouse* event);
 
 };

--- a/src/UI/MultistateImageButton.h
+++ b/src/UI/MultistateImageButton.h
@@ -78,6 +78,8 @@ public:
 
     Graphics::Texture* texture() const override;
 
+    virtual void handle(Event::Mouse* mouseEvent) override;
+
 protected:
     ImageList _imageList;
     unsigned int _currentState = 0;
@@ -86,7 +88,7 @@ protected:
     unsigned int _maxState = 0;
     unsigned int _minState = 0;
     void _onMouseClick(Event::Mouse* event);
-    void _onLeftButtonUp(Event::Mouse* event);
+    void _onMouseUp(Event::Mouse* event);
 
 };
 

--- a/src/UI/MultistateImageButton.h
+++ b/src/UI/MultistateImageButton.h
@@ -78,6 +78,8 @@ public:
 
     Graphics::Texture* texture() const override;
 
+    Event::Handler& onMouseLeftClick();
+
 protected:
     ImageList _imageList;
     unsigned int _currentState = 0;

--- a/src/UI/MultistateImageButton.h
+++ b/src/UI/MultistateImageButton.h
@@ -21,6 +21,7 @@
 #define	FALLTERGEIST_UI_MULTISTATEIMAGEBUTTON_H
 
 // C++ standard includes
+#include <string>
 #include <vector>
 
 // Falltergeist includes
@@ -87,6 +88,9 @@ protected:
     int _modeFactor = 1; // or -1
     unsigned int _maxState = 0;
     unsigned int _minState = 0;
+    std::string _downSound;
+    std::string _upSound;
+    
     void _onMouseClick(Event::Mouse* event);
     void _onMouseUp(Event::Mouse* event);
 

--- a/src/UI/PlayerPanel.cpp
+++ b/src/UI/PlayerPanel.cpp
@@ -64,12 +64,12 @@ PlayerPanel::PlayerPanel() : UI::Base()
 
     _background->setPosition(this->position());
 
-    addEventHandler("mousein", [this, mouse](Event::Event* event)
+    mouseInHandler().add([this, mouse](Event::Event* event)
     {
         mouse->pushState(Input::Mouse::Cursor::BIG_ARROW);
     });
 
-    addEventHandler("mouseout", [this, mouse](Event::Event* event)
+    mouseOutHandler().add([this, mouse](Event::Event* event)
     {
         if (mouse->scrollState())
         {
@@ -87,15 +87,15 @@ PlayerPanel::PlayerPanel() : UI::Base()
 
     // Change hand button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::BIG_RED_CIRCLE, position() + Point(218, 5)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->changeHand(); });
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){ this->changeHand(); });
 
     // Inventory button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::PANEL_INVENTORY, position() + Point(211, 40)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->openInventory(); });
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){ this->openInventory(); });
 
     // Options button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::PANEL_OPTIONS, position() + Point(210, 61)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){ this->openGameMenu(); });
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){ this->openGameMenu(); });
 
     // Attack button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::PANEL_ATTACK, position() + Point(267, 25)));
@@ -114,29 +114,29 @@ PlayerPanel::PlayerPanel() : UI::Base()
 
     // Skilldex button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::BIG_RED_CIRCLE, position() + Point(523, 5)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){
         this->openSkilldex();
     });
 
     // MAP button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::PANEL_MAP, position() + Point(526, 39)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){
         this->openMap();
     });
 
     // CHA button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::PANEL_CHA, position() + Point(526, 58)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){
         this->openCharacterScreen();
     });
 
     // PIP button
     _ui.push_back(std::make_shared<ImageButton>(ImageButton::Type::PANEL_PIP, position() + Point(526, 77)));
-    _ui.back()->addEventHandler("mouseleftclick", [this](Event::Event* event){
+    _ui.back()->mouseClickHandler().add([this](Event::Event* event){
         this->openPipBoy();
     });
 
-    addEventHandler("keydown", [this](Event::Event* event) {
+    keyDownHandler().add([this](Event::Event* event) {
         this->onKeyDown(dynamic_cast<Event::Keyboard*>(event));
     });
 }

--- a/src/UI/PlayerPanel.cpp
+++ b/src/UI/PlayerPanel.cpp
@@ -175,13 +175,6 @@ void PlayerPanel::handle(Event::Event *event)
         mouseEvent->setHandled(false);
     }
 
-    // object in hand
-    if (auto item = Game::getInstance()->player()->currentHandSlot())
-    {
-        auto itemUi = item->inventoryDragUi();
-        itemUi->handle(event);
-    }
-
     for (auto it = _ui.rbegin(); it != _ui.rend(); ++it)
     {
         if (event->handled()) return;

--- a/src/UI/Slider.cpp
+++ b/src/UI/Slider.cpp
@@ -43,9 +43,9 @@ Slider::Slider(const Point& pos) : Base(pos)
 
 Slider::Slider(int x, int y) : Falltergeist::UI::Base(Point(x, y))
 {
-    addEventHandler("mousedrag", [this](Event::Event* event){ this->_onDrag(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mouseleftdown", [this](Event::Event* event){ this->_onLeftButtonDown(dynamic_cast<Event::Mouse*>(event)); });
-    addEventHandler("mouseleftup", [this](Event::Event* event){ this->_onLeftButtonUp(dynamic_cast<Event::Mouse*>(event)); });
+    mouseDragHandler().add(std::bind(&_onDrag, this, std::placeholders::_1));
+    mouseDownHandler().add(std::bind(&_onLeftButtonDown, this, std::placeholders::_1));
+    mouseUpHandler().add(std::bind(&_onLeftButtonUp, this, std::placeholders::_1));
     _imageList.addImage("art/intrface/prfsldon.frm");
     _imageList.addImage("art/intrface/prfsldof.frm");
     _downSound = "sound/sfx/ib1p1xx1.acm";

--- a/src/UI/Slider.cpp
+++ b/src/UI/Slider.cpp
@@ -43,9 +43,9 @@ Slider::Slider(const Point& pos) : Base(pos)
 
 Slider::Slider(int x, int y) : Falltergeist::UI::Base(Point(x, y))
 {
-    mouseDragHandler().add(std::bind(&_onDrag, this, std::placeholders::_1));
-    mouseDownHandler().add(std::bind(&_onLeftButtonDown, this, std::placeholders::_1));
-    mouseUpHandler().add(std::bind(&_onLeftButtonUp, this, std::placeholders::_1));
+    mouseDragHandler().add(std::bind(&Slider::_onDrag, this, std::placeholders::_1));
+    mouseDownHandler().add(std::bind(&Slider::_onLeftButtonDown, this, std::placeholders::_1));
+    mouseUpHandler().add(std::bind(&Slider::_onLeftButtonUp, this, std::placeholders::_1));
     _imageList.addImage("art/intrface/prfsldon.frm");
     _imageList.addImage("art/intrface/prfsldof.frm");
     _downSound = "sound/sfx/ib1p1xx1.acm";

--- a/src/UI/Slider.h
+++ b/src/UI/Slider.h
@@ -21,6 +21,7 @@
 #define FALLTERGEIST_UI_SLIDER_H
 
 // C++ standard includes
+#include <string>
 
 // Falltergeist includes
 #include "../UI/Base.h"
@@ -64,6 +65,9 @@ protected:
     double _minValue = 0.0;
     double _maxValue = 1.0;
     double _value = 0.0;
+    std::string _downSound;
+    std::string _upSound;
+    
     void _onDrag(Event::Mouse* event);
     void _onLeftButtonDown(Event::Mouse* event);
     void _onLeftButtonUp(Event::Mouse* event);


### PR DESCRIPTION
- Implemented typed event handlers (no need to dynamic_cast Event* to Event::Mouse*, less space for bugs).
- Replaced attaching event handlers by event name (like "mouseleftdown") with multicast delegate properties, somewhat similar to C# MulticastDelegate, but without ability to remove specific handlers from the list (too hard to implement).
