### PR TITLE
Walking animations rewrite

### DIFF
--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -21,6 +21,7 @@
 #include "../Game/CritterObject.h"
 
 // C++ standard includes
+#include <array>
 #include <string>
 
 // Falltergeist includes

--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -527,8 +527,7 @@ void CritterObject::onMovementAnimationFrame(Event::Event* event)
 {
     auto animation = dynamic_cast<UI::Animation*>(ui());
     auto curFrame = animation->frames().at(animation->currentFrame()).get();
-    Point curFrameOfs(curFrame->xOffset(), curFrame->yOffset());
-    if (isOutsideOfHexForDirection(curFrameOfs, _orientation))
+    if (isOutsideOfHexForDirection(curFrame->offset(), _orientation))
     {
         auto hexagon = movementQueue()->back();
         movementQueue()->pop_back();
@@ -555,24 +554,22 @@ void CritterObject::onMovementAnimationFrame(Event::Event* event)
                 animation = newAnimation.get();
                 _ui = move(newAnimation);
                 curFrame = animation->frames().at(animation->currentFrame()).get();
-                curFrameOfs = Point(curFrame->xOffset(), curFrame->yOffset());
             }
             // calculate offset to position animation correctly relative to current hex
-            Point ofs;
+            Point ofs, oldOfs = curFrame->offset();
             do
             {
                 ofs -= Point(xTileOffsets[_orientation], yTileOffsets[_orientation]);
-            } while (isOutsideOfHexForDirection(curFrameOfs + ofs, _orientation));
+            } while (isOutsideOfHexForDirection(curFrame->offset() + ofs, _orientation));
             // adjust offsets of all following frames
             for (auto it = animation->frames().rbegin(); it != animation->frames().rend(); ++it)
             {
                 auto frame = (*it).get();
-                frame->setXOffset(frame->xOffset() + ofs.x());
-                frame->setYOffset(frame->yOffset() + ofs.y());
+                frame->setOffset(frame->offset() + ofs);
                 if (frame == curFrame) break;
             }
             //animation->setOffset(animation->rawOffset() - Point(xThreshold, yThreshold));
-            Logger::critical("Critter") << "Offset at " << animation->currentFrame() << " by " << ofs << " from " << curFrameOfs << std::endl;
+            Logger::critical("Critter") << "Offset at " << animation->currentFrame() << " by " << ofs << " from " << oldOfs << std::endl;
         }
     }
 }

--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -617,6 +617,18 @@ UI::Animation* CritterObject::setActionAnimation(const string& action)
     return animation;
 }
 
+UI::Animation* CritterObject::setWeaponAnimation(char animCode)
+{
+    animCode = tolower(animCode);
+    if (animCode < 'c' || animCode > 'l') throw Exception(std::string("Invalid weapon anim code: ") + animCode);
+    auto anim = setActionAnimation(_generateWeaponFrmString() + animCode);
+    anim->animationEndedHandler().add([this](Event::Event* evt)
+        {
+            setActionAnimation("aa")->stop();
+        });
+    return anim;
+}
+
 void CritterObject::_generateUi()
 {
     setActionAnimation("aa")->stop();

--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -27,16 +27,17 @@
 // Falltergeist includes
 #include "../Base/StlFeatures.h"
 #include "../Exception.h"
+#include "../Game/ArmorItemObject.h"
 #include "../Game/Defines.h"
 #include "../Game/DudeObject.h"
 #include "../Game/Game.h"
 #include "../Game/WeaponItemObject.h"
 #include "../Logger.h"
+#include "../PathFinding/Hexagon.h"
 #include "../ResourceManager.h"
 #include "../State/Location.h"
 #include "../UI/Animation.h"
 #include "../UI/AnimationFrame.h"
-#include "../UI/AnimationQueue.h"
 #include "../VM/VM.h"
 
 // Third party includes
@@ -530,7 +531,7 @@ bool isOutsideOfHexForDirection(Point offset, Orientation orient)
 void CritterObject::onMovementAnimationFrame(Event::Event* event)
 {
     auto animation = dynamic_cast<UI::Animation*>(ui());
-    auto curFrameOfs = animation->offset() + animation->currentFramePtr()->offset();
+    auto curFrameOfs = animation->frameOffset();
     if (isOutsideOfHexForDirection(curFrameOfs, _orientation))
     {
         // if we stepped too much away from current hex center, switch to the next hex
@@ -559,7 +560,7 @@ void CritterObject::onMovementAnimationFrame(Event::Event* event)
                 newAnimation->play();
                 animation = newAnimation.get();
                 _ui = move(newAnimation);
-                curFrameOfs = animation->currentFramePtr()->offset();
+                curFrameOfs = animation->frameOffset();
                             
                 // on turns, center frames on current hex
                 ofs -= curFrameOfs;
@@ -610,10 +611,6 @@ UI::Animation* CritterObject::setActionAnimation(const string& action)
         animation->setCurrentFrame(0);
     });
     animation->play();
-    /*auto queue = new AnimationQueue();
-    queue->setRepeat(true);
-    queue->animations()->push_back(animation);
-    queue->start();*/
     setUI(animation);
     return animation;
 }
@@ -737,12 +734,7 @@ void CritterObject::setRunning(bool value)
 void CritterObject::stopMovement()
 {
     _movementQueue.clear();
-    // @TODO: _ui probably needs to be always one type
-    if (auto queue = dynamic_cast<UI::AnimationQueue*>(_ui.get()))
-    {
-        queue->stop();
-    }
-    else if (auto animation = dynamic_cast<UI::Animation*>(_ui.get()))
+    if (auto animation = dynamic_cast<UI::Animation*>(_ui.get()))
     {
         animation->stop();
     }
@@ -764,6 +756,10 @@ void CritterObject::setAge(unsigned value)
     _age = value;
 }
 
+UI::Animation* CritterObject::animation()
+{
+    return dynamic_cast<UI::Animation*>(ui());
+}
 
 }
 }

--- a/src/Game/CritterObject.h
+++ b/src/Game/CritterObject.h
@@ -24,9 +24,7 @@
 #include <vector>
 
 // Falltergeist includes
-#include "../Game/ArmorItemObject.h"
 #include "../Game/Object.h"
-#include "../PathFinding/Hexagon.h"
 
 // Third party includes
 #include <libfalltergeist/Enums.h>
@@ -41,6 +39,7 @@ namespace UI
 namespace Game
 {
 class ItemObject;
+class ArmorItemObject;
 
 /**
  * Critter refers to player, all NPCs, creatures, robots, etc - all movable and shootable objects.
@@ -160,6 +159,8 @@ public:
     virtual UI::Animation* setActionAnimation(const std::string& action);
     UI::Animation* setWeaponAnimation(char animCode);
 
+    UI::Animation* animation();
+
 protected:
     bool _moving  = false;
     bool _running = false;
@@ -192,7 +193,7 @@ protected:
     std::vector<int> _damageThreshold = {0, 0, 0, 0, 0, 0, 0, 0, 0};
     std::vector<ItemObject*> _inventory;
     std::vector<Hexagon*> _movementQueue;
-    Point _moveAnimShift;
+
     ArmorItemObject* _armorSlot = 0;
     ItemObject* _leftHandSlot = 0;
     ItemObject* _rightHandSlot = 0;

--- a/src/Game/CritterObject.h
+++ b/src/Game/CritterObject.h
@@ -158,6 +158,7 @@ public:
     virtual void stopMovement();
 
     virtual UI::Animation* setActionAnimation(const std::string& action);
+    UI::Animation* setWeaponAnimation(char animCode);
 
 protected:
     bool _moving  = false;

--- a/src/Game/CritterObject.h
+++ b/src/Game/CritterObject.h
@@ -150,6 +150,7 @@ public:
 
     virtual void think();
     virtual void onMovementAnimationEnded(Event::Event* event);
+    virtual void onMovementAnimationFrame(Event::Event* event);
 
     virtual bool running() const;
     virtual void setRunning(bool value);
@@ -190,6 +191,7 @@ protected:
     std::vector<int> _damageThreshold = {0, 0, 0, 0, 0, 0, 0, 0, 0};
     std::vector<ItemObject*> _inventory;
     std::vector<Hexagon*> _movementQueue;
+    Point _moveAnimShift;
     ArmorItemObject* _armorSlot = 0;
     ItemObject* _leftHandSlot = 0;
     ItemObject* _rightHandSlot = 0;
@@ -198,6 +200,8 @@ protected:
     virtual std::string _generateArmorFrmString();
     virtual std::string _generateWeaponFrmString();
     void _setupNextIdleAnim();
+    virtual void _generateUi();
+
 
 };
 

--- a/src/Game/DudeObject.cpp
+++ b/src/Game/DudeObject.cpp
@@ -268,5 +268,10 @@ void DudeObject::_generateUi()
     CritterObject::_generateUi();
 }
 
+Point DudeObject::eggOffset()
+{
+    return animation()->frameOffset() + animation()->shift() - Point(63, 78);
+}
+
 }
 }

--- a/src/Game/DudeObject.h
+++ b/src/Game/DudeObject.h
@@ -24,6 +24,7 @@
 
 // Falltergeist includes
 #include "../Game/CritterObject.h"
+#include "../Point.h"
 
 // Third party includes
 #include <libfalltergeist/Gcd/File.h>
@@ -71,6 +72,11 @@ public:
     int healingRate() const override;
     int criticalChance() const override;
     unsigned int carryWeightMax() const override;
+
+    /**
+     * Offset where to draw egg relative to dude hex.
+     */
+    Point eggOffset();
 
 protected:
     int _level = 1;

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -158,7 +158,7 @@ void Game::run()
         handle();
         think();
         render();
-        SDL_Delay(100);
+        SDL_Delay(1);
         _statesForDelete.clear();
         _frame++;
     }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -158,7 +158,7 @@ void Game::run()
         handle();
         think();
         render();
-        SDL_Delay(1);
+        SDL_Delay(100);
         _statesForDelete.clear();
         _frame++;
     }

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -287,7 +287,7 @@ void Object::renderText()
 
 void Object::render()
 {
-    if (!_ui) return;
+    if (!_ui || !_hexagon) return;
 
     auto camera = Game::getInstance()->locationState()->camera();
     _ui->setPosition(

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -411,12 +411,6 @@ void Location::render()
     //_roof->render();
     if (active())
     {
-        auto plAnim = dynamic_cast<UI::Animation*>(Game::getInstance()->player()->ui());
-        auto plCurFr = plAnim->frames().at(plAnim->currentFrame()).get();
-        _hexagonInfo->setText(
-          "\nFrame: " + std::to_string(plAnim->currentFrame()) 
-        + "\nOffset: " + to_string(plAnim->offset()) 
-        + "\nFr. Ofs: "  + std::to_string((int)plCurFr->xOffset()) + ", " + std::to_string((int)plCurFr->yOffset()));
         _hexagonInfo->render();
     }
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -206,6 +206,22 @@ void Location::setLocation(const std::string& name)
             }
         }
 
+        // TODO: use common interface...
+        if (auto critter = dynamic_cast<Game::CritterObject*>(object))
+        {
+            for (auto child : *mapObject->children())
+            {
+                auto item = dynamic_cast<Game::ItemObject*>(Game::ObjectFactory::getInstance()->createObject(child->PID()));
+                if (!item)
+                {
+                    Logger::error() << "Location::setLocation() - can't create object with PID: " << child->PID() << std::endl;
+                    continue;
+                }
+                item->setAmount(child->ammount());
+                critter->inventory()->push_back(item);
+            }
+        }
+
         if (mapObject->scriptId() > 0)
         {
             auto intFile = ResourceManager::getInstance()->intFileType(mapObject->scriptId());
@@ -856,7 +872,10 @@ void Location::moveObjectToHexagon(Game::Object* object, Hexagon* hexagon)
     }
 
     object->setHexagon(hexagon);
-    hexagon->objects()->push_back(object);
+    if (hexagon)
+    {
+        hexagon->objects()->push_back(object);
+    }
 }
 
 void Location::destroyObject(Game::Object* object)

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -238,6 +238,7 @@ void Location::setLocation(const std::string& name)
             player->setLeftHandSlot(dynamic_cast<Game::WeaponItemObject*>(leftHand));
             auto rightHand = Game::ObjectFactory::getInstance()->createObject(0x00000007); // spear
             player->setRightHandSlot(dynamic_cast<Game::WeaponItemObject*>(rightHand));
+            player->setActionAnimation("aa")->stop();
         }
         player->setPID(0x01000001);
         player->setOrientation(mapFile->defaultOrientation());

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -414,9 +414,9 @@ void Location::render()
         auto plAnim = dynamic_cast<UI::Animation*>(Game::getInstance()->player()->ui());
         auto plCurFr = plAnim->frames().at(plAnim->currentFrame()).get();
         _hexagonInfo->setText(
-        "\nFrame: " + std::to_string(plAnim->currentFrame()) 
-        + "\nShift: " + to_string(plAnim->offset()) 
-        + "\nOffs: " + std::to_string(plCurFr->xOffset()) + ", " + std::to_string(plCurFr->yOffset()));
+          "\nFrame: " + std::to_string(plAnim->currentFrame()) 
+        + "\nOffset: " + to_string(plAnim->offset()) 
+        + "\nFr. Ofs: "  + std::to_string((int)plCurFr->xOffset()) + ", " + std::to_string((int)plCurFr->yOffset()));
         _hexagonInfo->render();
     }
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -53,6 +53,7 @@
 #include "../State/ExitConfirm.h"
 #include "../State/MainMenu.h"
 #include "../UI/Animation.h"
+#include "../UI/AnimationFrame.h"
 #include "../UI/AnimationQueue.h"
 #include "../UI/Image.h"
 #include "../UI/ImageButton.h"
@@ -410,6 +411,12 @@ void Location::render()
     //_roof->render();
     if (active())
     {
+        auto plAnim = dynamic_cast<UI::Animation*>(Game::getInstance()->player()->ui());
+        auto plCurFr = plAnim->frames().at(plAnim->currentFrame()).get();
+        _hexagonInfo->setText(
+        "\nFrame: " + std::to_string(plAnim->currentFrame()) 
+        + "\nShift: " + to_string(plAnim->offset()) 
+        + "\nOffs: " + std::to_string(plCurFr->xOffset()) + ", " + std::to_string(plCurFr->yOffset()));
         _hexagonInfo->render();
     }
 

--- a/src/UI/AnimatedImage.cpp
+++ b/src/UI/AnimatedImage.cpp
@@ -30,6 +30,7 @@
 #include "../Graphics/Renderer.h"
 #include "../Graphics/Texture.h"
 #include "../LocationCamera.h"
+#include "../PathFinding/Hexagon.h"
 #include "../Point.h"
 #include "../ResourceManager.h"
 #include "../State/Location.h"
@@ -202,7 +203,7 @@ void AnimatedImage::render(bool eggTransparency)
 
         auto camera = Game::getInstance()->locationState()->camera();
 
-        Point eggPos = dude->hexagon()->position() - camera->topLeft() - Point(63, 78) + dude->ui()->offset();
+        Point eggPos = dude->hexagon()->position() - camera->topLeft() + dude->eggOffset();
 
         Point eggDelta = position() - eggPos;
 

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -256,8 +256,8 @@ void Animation::render(bool eggTransparency)
     auto& frame = _animationFrames.at(_currentFrame);
     Point framePos = frame->position();
     Size frameSize = frame->size();
-    Point offsetPosition = position() + offset();
-    Point offsetFramePos = framePos + offset();
+    Point offsetPosition = position() + shift() + frame->offset();
+    Point offsetFramePos = framePos + shift() + frame->offset();
     Graphics::AnimatedPalette* pal = Game::getInstance()->animatedPalette();
 
     if (eggTransparency)
@@ -381,17 +381,6 @@ Size Animation::size() const
     return _animationFrames.at(_currentFrame)->size();
 }
 
-Point Animation::offset() const
-{
-    auto& frame = _animationFrames.at(_currentFrame);
-    return _offset + frame->offset() + shift();
-}
-
-Point Animation::rawOffset() const
-{
-    return _offset;
-}
-
 const Point& Animation::shift() const
 {
     return _shift;
@@ -454,6 +443,11 @@ void Animation::setCurrentFrame(unsigned int value)
     _progress = _reverse ? _animationFrames.size() - _currentFrame - 1 : _currentFrame;
 }
 
+AnimationFrame* Animation::currentFramePtr() const
+{
+    return _animationFrames.at(_currentFrame).get();
+}
+
 unsigned int Animation::actionFrame() const
 {
     return _actionFrame;
@@ -462,6 +456,11 @@ unsigned int Animation::actionFrame() const
 void Animation::setActionFrame(unsigned int value)
 {
     _actionFrame = value;
+}
+
+AnimationFrame* Animation::actionFramePtr() const
+{
+    return _animationFrames.at(_actionFrame).get();
 }
 
 Event::Handler& Animation::frameHandler()

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -93,7 +93,7 @@ Animation::Animation(const std::string& frmName, unsigned int direction) : Fallt
         }
         else
         {
-            frame->setDuration((unsigned)std::round(1000.0/static_cast<double>(frm->framesPerSecond())));
+            frame->setDuration((unsigned)std::round(10000.0/static_cast<double>(frm->framesPerSecond())));
         }
 
         x += frame->width();
@@ -421,6 +421,7 @@ void Animation::play()
 {
     _playing = true;
     _ended = false;
+    _frameTicks = SDL_GetTicks();
 }
 
 void Animation::stop()

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -405,9 +405,12 @@ unsigned int Animation::pixel(const Point& pos)
 
 void Animation::play()
 {
-    _playing = true;
-    _ended = false;
-    _frameTicks = SDL_GetTicks();
+    if (!_playing)
+    {
+        _playing = true;
+        _ended = false;
+        _frameTicks = SDL_GetTicks();
+    }
 }
 
 void Animation::stop()

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -79,12 +79,10 @@ Animation::Animation(const std::string& frmName, unsigned int direction) : Fallt
         yOffset += frm->offsetY(direction, f);
 
         auto frame = make_unique<AnimationFrame>();
-        frame->setWidth(frm->directions()->at(direction)->frames()->at(f)->width());
-        frame->setHeight(frm->directions()->at(direction)->frames()->at(f)->height());
-        frame->setXOffset((unsigned)xOffset);
-        frame->setYOffset((unsigned)yOffset);
-        frame->setY(y);
-        frame->setX(x);
+        auto srcFrame = frm->directions()->at(direction)->frames()->at(f);
+        frame->setSize(Size(srcFrame->width(), srcFrame->height()));
+        frame->setOffset({xOffset, yOffset});
+        frame->setPosition(Point(x, y));
 
         auto fps = frm->framesPerSecond();
         if (fps == 0)

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -228,11 +228,15 @@ void Animation::think()
 {
     if (!_playing) return;
 
+    // TODO: handle cases when main loop FPS is lower than animation FPS
     if (SDL_GetTicks() - _frameTicks >= _animationFrames.at(_currentFrame)->duration())
     {
         _frameTicks = SDL_GetTicks();
 
         _progress += 1;
+        
+        emitEvent(make_unique<Event::Event>("frame"), frameHandler());
+        
         if (_progress < _animationFrames.size())
         {
             _currentFrame = _reverse ? _animationFrames.size() - _progress - 1 : _progress;
@@ -457,6 +461,11 @@ void Animation::setActionFrame(unsigned int value)
     _actionFrame = value;
 }
 
+Event::Handler& Animation::frameHandler()
+{
+    return _frameHandler;
+}
+
 Event::Handler& Animation::actionFrameHandler()
 {
     return _actionFrameHandler;
@@ -466,5 +475,6 @@ Event::Handler& Animation::animationEndedHandler()
 {
     return _animationEndedHandler;
 }
+
 }
 }

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -235,11 +235,10 @@ void Animation::think()
 
         _progress += 1;
         
-        emitEvent(make_unique<Event::Event>("frame"), frameHandler());
-        
         if (_progress < _animationFrames.size())
         {
             _currentFrame = _reverse ? _animationFrames.size() - _progress - 1 : _progress;
+            emitEvent(make_unique<Event::Event>("frame"), frameHandler());
             if (_actionFrame == _currentFrame)
             {
                 emitEvent(make_unique<Event::Event>("actionFrame"), actionFrameHandler());
@@ -388,7 +387,7 @@ Size Animation::size() const
 Point Animation::offset() const
 {
     auto& frame = _animationFrames.at(_currentFrame);
-    return Point(frame->xOffset(), frame->yOffset()) + shift();
+    return _offset + Point(frame->xOffset(), frame->yOffset()) + shift();
 }
 
 const Point& Animation::shift() const
@@ -416,6 +415,7 @@ unsigned int Animation::pixel(const Point& pos)
 void Animation::play()
 {
     _playing = true;
+    _ended = false;
 }
 
 void Animation::stop()

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -390,6 +390,11 @@ Point Animation::offset() const
     return _offset + Point(frame->xOffset(), frame->yOffset()) + shift();
 }
 
+Point Animation::rawOffset() const
+{
+    return _offset;
+}
+
 const Point& Animation::shift() const
 {
     return _shift;

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -30,6 +30,7 @@
 #include "../Graphics/AnimatedPalette.h"
 #include "../Graphics/Renderer.h"
 #include "../Graphics/Texture.h"
+#include "../PathFinding/Hexagon.h"
 #include "../LocationCamera.h"
 #include "../ResourceManager.h"
 #include "../State/Location.h"
@@ -290,7 +291,7 @@ void Animation::render(bool eggTransparency)
         }
 
         auto camera = Game::getInstance()->locationState()->camera();
-        Point eggPos = dude->hexagon()->position() - camera->topLeft() - Point(63, 78) + dude->ui()->offset();
+        Point eggPos = dude->hexagon()->position() - camera->topLeft() + dude->eggOffset();
 
         Point eggDelta = position() - eggPos;
 
@@ -449,6 +450,11 @@ void Animation::setCurrentFrame(unsigned int value)
 AnimationFrame* Animation::currentFramePtr() const
 {
     return _animationFrames.at(_currentFrame).get();
+}
+
+Point Animation::frameOffset() const
+{
+    return offset() + currentFramePtr()->offset();
 }
 
 unsigned int Animation::actionFrame() const

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -91,7 +91,7 @@ Animation::Animation(const std::string& frmName, unsigned int direction) : Fallt
         }
         else
         {
-            frame->setDuration((unsigned)std::round(10000.0/static_cast<double>(frm->framesPerSecond())));
+            frame->setDuration((unsigned)std::round(1000.0 / static_cast<double>(frm->framesPerSecond())));
         }
 
         x += frame->width();
@@ -254,8 +254,8 @@ void Animation::think()
 void Animation::render(bool eggTransparency)
 {
     auto& frame = _animationFrames.at(_currentFrame);
-    Point framePos = Point(frame->x(), frame->y());
-    Size frameSize = Size(frame->width(), frame->height());
+    Point framePos = frame->position();
+    Size frameSize = frame->size();
     Point offsetPosition = position() + offset();
     Point offsetFramePos = framePos + offset();
     Graphics::AnimatedPalette* pal = Game::getInstance()->animatedPalette();
@@ -378,14 +378,13 @@ void Animation::render(bool eggTransparency)
 
 Size Animation::size() const
 {
-    auto& frame = _animationFrames.at(_currentFrame);
-    return Size(frame->width(), frame->height());
+    return _animationFrames.at(_currentFrame)->size();
 }
 
 Point Animation::offset() const
 {
     auto& frame = _animationFrames.at(_currentFrame);
-    return _offset + Point(frame->xOffset(), frame->yOffset()) + shift();
+    return _offset + frame->offset() + shift();
 }
 
 Point Animation::rawOffset() const
@@ -408,11 +407,11 @@ unsigned int Animation::pixel(const Point& pos)
     const auto& frame = _animationFrames.at(_currentFrame);
 
     Point offsetPos = pos - offset();
-    if (!Rect::inRect(offsetPos, Size(frame->width(), frame->height())))
+    if (!Rect::inRect(offsetPos, frame->size()))
     {
         return 0;
     }
-    return Base::pixel(offsetPos + Point(frame->x(), frame->y()));
+    return Base::pixel(offsetPos + frame->position());
 }
 
 void Animation::play()

--- a/src/UI/Animation.h
+++ b/src/UI/Animation.h
@@ -68,9 +68,18 @@ public:
     bool ended() const;
     bool playing() const;
 
+    /**
+     * Invoked when animation has ended.
+     */
     Event::Handler& animationEndedHandler();
-
+    /**
+     * Invoked when animation "action" frame is reached
+     */
     Event::Handler& actionFrameHandler();
+    /**
+     * Invoked on every frame of animation
+     */
+    Event::Handler& frameHandler();
 
 protected:
     bool _playing = false;
@@ -89,7 +98,7 @@ protected:
     std::vector<Graphics::Texture*> _monitorTextures;
     std::vector<Graphics::Texture*> _reddotTextures;
 
-    Event::Handler _actionFrameHandler, _animationEndedHandler;
+    Event::Handler _frameHandler, _actionFrameHandler, _animationEndedHandler;
 };
 
 }

--- a/src/UI/Animation.h
+++ b/src/UI/Animation.h
@@ -65,6 +65,11 @@ public:
     void setCurrentFrame(unsigned int value);
     AnimationFrame* currentFramePtr() const;
 
+    /**
+     * Offset of the current frame.
+     */
+    Point frameOffset() const;
+
     unsigned int actionFrame() const;
     void setActionFrame(unsigned int value);
     AnimationFrame* actionFramePtr() const;

--- a/src/UI/Animation.h
+++ b/src/UI/Animation.h
@@ -47,12 +47,13 @@ public:
     void think() override;
     void render(bool eggTransparency = false) override;
 
+    /**
+     * Additional offset, specific to current direction and taken from source FRM file.
+     */
     const Point& shift() const;
     void setShift(const Point& value);
 
     Size size() const override;
-    Point offset() const override;
-    Point rawOffset() const;
 
     unsigned int pixel(const Point& pos) override;
 
@@ -62,9 +63,11 @@ public:
 
     unsigned int currentFrame() const;
     void setCurrentFrame(unsigned int value);
+    AnimationFrame* currentFramePtr() const;
 
     unsigned int actionFrame() const;
     void setActionFrame(unsigned int value);
+    AnimationFrame* actionFramePtr() const;
 
     bool ended() const;
     bool playing() const;

--- a/src/UI/Animation.h
+++ b/src/UI/Animation.h
@@ -52,6 +52,7 @@ public:
 
     Size size() const override;
     Point offset() const override;
+    Point rawOffset() const;
 
     unsigned int pixel(const Point& pos) override;
 

--- a/src/UI/AnimationFrame.cpp
+++ b/src/UI/AnimationFrame.cpp
@@ -39,64 +39,64 @@ AnimationFrame::~AnimationFrame()
 {
 }
 
-void AnimationFrame::setX(unsigned int x)
+Point AnimationFrame::position() const
 {
-    _x = x;
+    return _position;
+}
+
+void AnimationFrame::setPosition(const Point& pos)
+{
+    _position = pos;
 }
 
 unsigned int AnimationFrame::x() const
 {
-    return _x;
-}
-
-void AnimationFrame::setY(unsigned int y)
-{
-    _y = y;
+    return _position.x();
 }
 
 unsigned int AnimationFrame::y() const
 {
-    return _y;
+    return _position.y();
 }
 
-void AnimationFrame::setWidth(unsigned int width)
+Size AnimationFrame::size() const
 {
-    _width = width;
+    return _size;
+}
+
+void AnimationFrame::setSize(const Size& size)
+{
+    _size = size;
 }
 
 unsigned int AnimationFrame::width() const
 {
-    return _width;
-}
-
-void AnimationFrame::setHeight(unsigned int height)
-{
-    _height = height;
+    return _size.width();
 }
 
 unsigned int AnimationFrame::height() const
 {
-    return _height;
+    return _size.height();
 }
 
-void AnimationFrame::setXOffset(unsigned int xOffset)
+Point AnimationFrame::offset() const
 {
-    _xOffset = xOffset;
+    return _offset;
 }
 
-unsigned int AnimationFrame::xOffset() const
+void AnimationFrame::setOffset(const Point& ofs)
 {
-    return _xOffset;
+    _offset = ofs;
 }
 
-void AnimationFrame::setYOffset(unsigned int yOffset)
+int AnimationFrame::xOffset() const
 {
-    _yOffset = yOffset;
+    return _offset.x();
 }
 
-unsigned int AnimationFrame::yOffset() const
+int AnimationFrame::yOffset() const
 {
-    return _yOffset;
+    return _offset.y();
 }
 
 void AnimationFrame::setDuration(unsigned int duration)

--- a/src/UI/AnimationFrame.h
+++ b/src/UI/AnimationFrame.h
@@ -49,11 +49,11 @@ public:
     unsigned int height() const;
     void setHeight(unsigned int height);
 
-    unsigned int xOffset() const;
-    void setXOffset(unsigned int xOffset);
+    int xOffset() const;
+    void setXOffset(int xOffset);
 
-    unsigned int yOffset() const;
-    void setYOffset(unsigned int yOffset);
+    int yOffset() const;
+    void setYOffset(int yOffset);
 
     unsigned int duration() const;
     void setDuration(unsigned int duration);
@@ -68,8 +68,8 @@ protected:
     unsigned int _width = 0;
 
     // Offset of animation frame on screen relative to first animation frame
-    unsigned int _xOffset = 0;
-    unsigned int _yOffset = 0;
+    int _xOffset = 0;
+    int _yOffset = 0;
 
     // Duration of animation frame in milliseconds
     unsigned int _duration = 0;

--- a/src/UI/AnimationFrame.h
+++ b/src/UI/AnimationFrame.h
@@ -23,6 +23,7 @@
 // C++ standard includes
 
 // Falltergeist includes
+#include "../Point.h"
 
 // Third party includes
 
@@ -36,40 +37,38 @@ class AnimationFrame
 public:
     AnimationFrame();
     ~AnimationFrame();
+    
+    Point position() const;
+    void setPosition(const Point&);
 
     unsigned int x() const;
-    void setX(unsigned int x);
-
     unsigned int y() const;
-    void setY(unsigned int y);
-
+    
+    
+    Size size() const;
+    void setSize(const Size&);
+    
     unsigned int width() const;
-    void setWidth(unsigned int width);
-
     unsigned int height() const;
-    void setHeight(unsigned int height);
+    
+    Point offset() const;
+    void setOffset(const Point&);
 
     int xOffset() const;
-    void setXOffset(int xOffset);
-
     int yOffset() const;
-    void setYOffset(int yOffset);
-
+    
     unsigned int duration() const;
     void setDuration(unsigned int duration);
 
 protected:
     // Offset of animation frame position relative to sprite position
-    unsigned int _x = 0;
-    unsigned int _y = 0;
+    Point _position;
 
     // Animation frame width and height
-    unsigned int _height = 0;
-    unsigned int _width = 0;
+    Size _size;
 
     // Offset of animation frame on screen relative to first animation frame
-    int _xOffset = 0;
-    int _yOffset = 0;
+    Point _offset;
 
     // Duration of animation frame in milliseconds
     unsigned int _duration = 0;

--- a/src/UI/AnimationQueue.cpp
+++ b/src/UI/AnimationQueue.cpp
@@ -109,7 +109,7 @@ void AnimationQueue::think()
                 }
             }
         }
-        else
+        else if (!currentAnimation()->playing())
         {
             currentAnimation()->play();
         }

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -30,6 +30,7 @@
 #include "../Graphics/Renderer.h"
 #include "../Graphics/Texture.h"
 #include "../LocationCamera.h"
+#include "../PathFinding/Hexagon.h"
 #include "../ResourceManager.h"
 #include "../State/Location.h"
 
@@ -104,7 +105,7 @@ void Base::render(bool eggTransparency)
 
         auto camera = Game::getInstance()->locationState()->camera();
 
-        Point eggPos = dude->hexagon()->position() - camera->topLeft() - Point(63, 78) + dude->ui()->offset();
+        Point eggPos = dude->hexagon()->position() - camera->topLeft() + dude->eggOffset();
 
         Point eggDelta = position() - eggPos;
 

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -27,6 +27,7 @@
 #include "../Base/StlFeatures.h"
 #include "../Event/Event.h"
 #include "../Event/Mouse.h"
+#include "../Game/ArmorItemObject.h"
 #include "../Game/DudeObject.h"
 #include "../Game/Game.h"
 #include "../Game/ItemObject.h"

--- a/src/UI/PlayerPanel.cpp
+++ b/src/UI/PlayerPanel.cpp
@@ -26,6 +26,7 @@
 #include "../Audio/Mixer.h"
 #include "../Event/Event.h"
 #include "../Event/Keyboard.h"
+#include "../Game/ItemObject.h"
 #include "../Game/Game.h"
 #include "../Game/DudeObject.h"
 #include "../Graphics/Renderer.h"

--- a/src/UI/PlayerPanel.cpp
+++ b/src/UI/PlayerPanel.cpp
@@ -39,6 +39,7 @@
 #include "../State/SaveGame.h"
 #include "../State/Skilldex.h"
 #include "../State/WorldMap.h"
+#include "../UI/Animation.h"
 #include "../UI/Image.h"
 #include "../UI/ImageButton.h"
 #include "../UI/SmallCounter.h"
@@ -210,7 +211,28 @@ void PlayerPanel::playWindowOpenSfx()
 void PlayerPanel::changeHand()
 {
     auto player = Game::getInstance()->player();
+    auto lastSlot = player->currentHandSlot();
+    auto takeOut = [player](Event::Event* evt)
+        {
+            if (player->currentHandSlot())
+            {
+                player->setWeaponAnimation('C'); // takeout
+            }
+        };
+    if (lastSlot)
+    {
+        // put away
+        auto anim = player->setWeaponAnimation('D');
+        Event::Handler origHandler = anim->animationEndedHandler();
+        anim->animationEndedHandler().clear();
+        anim->animationEndedHandler().add(takeOut);
+        anim->animationEndedHandler().add(origHandler);
+    }
     player->setCurrentHand(player->currentHand() == HAND::RIGHT ? HAND::LEFT : HAND::RIGHT);
+    if (!lastSlot)
+    {
+        takeOut(nullptr);
+    }    
     playWindowOpenSfx();
 
 }
@@ -223,7 +245,13 @@ void PlayerPanel::openGameMenu()
 
 void PlayerPanel::openInventory()
 {
-    Game::getInstance()->pushState(new State::Inventory());
+    auto state = new State::Inventory();
+    state->popHandler().add([this](Event::State* evt)
+        {
+            // update player frame
+            Game::getInstance()->player()->setActionAnimation("aa")->stop();
+        });
+    Game::getInstance()->pushState(state);
     playWindowOpenSfx();
 }
 

--- a/src/VM/Handlers/Opcode80D9Handler.cpp
+++ b/src/VM/Handlers/Opcode80D9Handler.cpp
@@ -18,8 +18,11 @@
  */
 
 // C++ standard includes
+#include <algorithm>
 
 // Falltergeist includes
+#include "../../Game/ContainerItemObject.h"
+#include "../../Game/CritterObject.h"
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode80D9Handler.h"
 #include "../../VM/VM.h"
@@ -38,8 +41,29 @@ Opcode80D9Handler::Opcode80D9Handler(VM* vm) : OpcodeHandler(vm)
 void Opcode80D9Handler::_run()
 {
     Logger::debug("SCRIPT") << "[80D9] [=] void rm_obj_from_inven(void* who, void* obj)" << std::endl;
-    _vm->dataStack()->popObject();
-    _vm->dataStack()->popObject();
+    auto item = dynamic_cast<Game::ItemObject*>(_vm->dataStack()->popObject());
+    auto invenObj = _vm->dataStack()->popObject();
+
+    if (!item) _error("rm_obj_from_inven - item not instanceof GameItemObject");
+
+    std::vector<Game::ItemObject*>* inven;
+    if (auto critterObj = dynamic_cast<Game::CritterObject*>(invenObj))
+    {
+        inven = critterObj->inventory();
+    }
+    else if (auto contObj = dynamic_cast<Game::ContainerItemObject*>(invenObj))
+    {
+        inven = contObj->inventory();
+    }
+    else
+    {
+        _error("rm_obj_from_inven - wrong WHO parameter");
+    }
+    auto it = std::find(inven->begin(), inven->end(), item);
+    if (it != inven->end())
+    {
+        inven->erase(it);
+    }
 }
 
 }

--- a/src/VM/Handlers/Opcode8106Handler.cpp
+++ b/src/VM/Handlers/Opcode8106Handler.cpp
@@ -22,6 +22,7 @@
 // Falltergeist includes
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode8106Handler.h"
+#include "../../Game/ArmorItemObject.h"
 #include "../../Game/Game.h"
 #include "../../Game/Object.h"
 #include "../../Game/CritterObject.h"

--- a/src/VM/Handlers/Opcode810DHandler.cpp
+++ b/src/VM/Handlers/Opcode810DHandler.cpp
@@ -24,6 +24,7 @@
 #include "../../Logger.h"
 #include "../../VM/Handlers/Opcode810DHandler.h"
 #include "../../VM/VM.h"
+#include "../../Game/ItemObject.h"
 #include "../../Game/CritterObject.h"
 
 // Third party includes


### PR DESCRIPTION
A rewrite of walking/running animations. Previous implementation used guessed frame numbers for tile switching. This one uses offset-based approach: 
* After _every_ frame, offset of current animation frame is compared to distance to the next hex in pixels, if it is greater, hex switch is performed and animation offset is subtracted (by value equal to distance between this hex and the next one).
* At turns (when direction is changed before animation cycle ended), current animation frame is "centered" at current hex (this way it is more realistic and matches original).
* At the end of animation cycle, next cycle is offset by value equal to offset of the last frame (this is to achieve seamless walking animation, prevents "limping").

As a bonus, fixed visible weapon in player hands and added take out animation when switching active hands.