### PR TITLE
Fix minor Clang compiler warnings

### DIFF
--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -510,8 +510,8 @@ void CritterObject::think()
     Object::think();
 }
 
-static const std::array<int, 6> xTileOffsets = {16, 32, 16, -16, -32, -16};
-static const std::array<int, 6> yTileOffsets = {-12, 0, 12,  12,   0, -12};
+static const std::array<int, 6> xTileOffsets = {{ 16, 32, 16, -16, -32, -16 }};
+static const std::array<int, 6> yTileOffsets = {{ -12, 0, 12,  12,   0, -12 }};
 
 // TODO: move somewhere appropriate
 bool isOutsideOfHexForDirection(Point offset, Orientation orient)
@@ -525,9 +525,9 @@ bool isOutsideOfHexForDirection(Point offset, Orientation orient)
 }
 
 // TODO: refactor
-// I suggest processing all frames beforehand - adjusting positions to remain within hex boundaries 
-// and defining "action frames" (multiple frames per animation). This will allow to re-use Animation object 
-// for different animation cycles. 
+// I suggest processing all frames beforehand - adjusting positions to remain within hex boundaries
+// and defining "action frames" (multiple frames per animation). This will allow to re-use Animation object
+// for different animation cycles.
 void CritterObject::onMovementAnimationFrame(Event::Event* event)
 {
     auto animation = dynamic_cast<UI::Animation*>(ui());
@@ -561,7 +561,7 @@ void CritterObject::onMovementAnimationFrame(Event::Event* event)
                 animation = newAnimation.get();
                 _ui = move(newAnimation);
                 curFrameOfs = animation->frameOffset();
-                            
+
                 // on turns, center frames on current hex
                 ofs -= curFrameOfs;
             }

--- a/src/Graphics/AnimatedPalette.cpp
+++ b/src/Graphics/AnimatedPalette.cpp
@@ -33,45 +33,45 @@ namespace Falltergeist
 namespace Graphics
 {
 
-const std::array<unsigned int, 5> AnimatedPalette::_monitorsPalette = {
+const std::array<unsigned int, 5> AnimatedPalette::_monitorsPalette = {{
     0x6B6B6FFF,
     0x63677FFF,
     0x576B8FFF,
     0x0093A3FF,
     0x6BBBFFFF
-};
+}};
 
-const std::array<unsigned int, 4> AnimatedPalette::_slimePalette = {
+const std::array<unsigned int, 4> AnimatedPalette::_slimePalette = {{
     0x006C00FF,
     0x0B7307FF,
     0x1B7B0FFF,
     0x2B831BFF
-};
+}};
 
-const std::array<unsigned int, 6> AnimatedPalette::_shorePalette = {
+const std::array<unsigned int, 6> AnimatedPalette::_shorePalette = {{
     0x533F2BFF,
     0x4B3B2BFF,
     0x433727FF,
     0x3F3327FF,
     0x372F23FF,
     0x332B23FF
-};
+}};
 
-const std::array<unsigned int, 5> AnimatedPalette::_fireSlowPalette = {
+const std::array<unsigned int, 5> AnimatedPalette::_fireSlowPalette = {{
     0xFF0000FF,
     0xD70000FF,
     0x932B0BFF,
     0xFF7700FF,
     0xFF3B00FF
-};
+}};
 
-const std::array<unsigned int, 5> AnimatedPalette::_fireFastPalette = {
+const std::array<unsigned int, 5> AnimatedPalette::_fireFastPalette = {{
     0x470000FF,
     0x7B0000FF,
     0xB30000FF,
     0x7B0000FF,
     0x470000FF
-};
+}};
 
 AnimatedPalette::AnimatedPalette()
 {

--- a/src/VM/OpcodeHandler.h
+++ b/src/VM/OpcodeHandler.h
@@ -27,6 +27,15 @@
 
 // Third party includes
 
+#if defined(_MSC_VER)
+#define NORETURN __declspec(noreturn)
+#elif defined(__clang__) || defined(__GNUC__)
+// Use C++11 attribute, supported by Clang and g++ >= 4.8
+#define NORETURN [[noreturn]]
+#else
+#define NORETURN
+#endif
+
 namespace Falltergeist
 {
 class VM;
@@ -41,7 +50,7 @@ protected:
     // print warning message to log
     void _warning(const std::string& message);
     // prints error message to logs and throws VMErrorException
-    void _error(const std::string& message);
+    NORETURN void _error(const std::string& message);
 public:
     OpcodeHandler(VM* vm);
     virtual ~OpcodeHandler();


### PR DESCRIPTION
Forcing double braces is a kind of bug in Clang, both { and {{ should work due to C++ standard, but single brace generates a warning.
noreturn attribute is a hint for a compiler to not generate a warnings for uninitialized variables.

Please take a look.