### PR TITLE
Reset dialog line offset when selecting an answer.

### DIFF
--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -134,6 +134,7 @@ void CritterDialog::setQuestion(const std::string& value)
 {
     auto question = getTextArea("question");
     question->setText(std::string("  ") + value);
+    question->setLineOffset(0);
 }
 
 void CritterDialog::onAnswerIn(Event::Mouse* event)


### PR DESCRIPTION
This prevents a bad alloc segfault when transitioning
from a multi-scroll dialog question to single scroll
while the line offset > 0.

To test, talk to Slim Picket in klamall.map, and press "1" two times. Scroll to the bottom of the response text, then press "1" again.