### PR TITLE
Lighting

### DIFF
--- a/data/shaders/lightmap.fp
+++ b/data/shaders/lightmap.fp
@@ -1,0 +1,14 @@
+#version 330
+
+uniform vec4 fade;
+in float fLight;
+out vec4 fragColor;
+
+void main(void)
+{
+   vec4 origColor = vec4(0.4,0.4,0.3,fLight*0.3);
+
+
+   fragColor = mix(origColor, fade, fade.a);
+   fragColor.a = origColor.a;
+}

--- a/data/shaders/lightmap.fp
+++ b/data/shaders/lightmap.fp
@@ -6,8 +6,7 @@ out vec4 fragColor;
 
 void main(void)
 {
-   vec4 origColor = vec4(0.4,0.4,0.3,fLight*0.3);
-
+   vec4 origColor = vec4(fLight/2.+0.5,fLight/2.+0.5,fLight/2.2+0.5, 1.0);
 
    fragColor = mix(origColor, fade, fade.a);
    fragColor.a = origColor.a;

--- a/data/shaders/lightmap.vp
+++ b/data/shaders/lightmap.vp
@@ -1,0 +1,13 @@
+#version 330
+
+uniform mat4 MVP;
+in vec2 Position;
+in float lights;
+uniform vec2 offset;
+out float fLight;
+
+void main(void)
+{
+  fLight = lights;
+  gl_Position = MVP*vec4(Position-offset, 0.0, 1.0);
+}

--- a/src/Game/DoorSceneryObject.cpp
+++ b/src/Game/DoorSceneryObject.cpp
@@ -27,6 +27,7 @@
 #include "../Event/Event.h"
 #include "../Game/Game.h"
 #include "../Logger.h"
+#include "../State/Location.h"
 #include "../UI/Animation.h"
 #include "../UI/AnimationQueue.h"
 #include "../VM/VM.h"
@@ -55,6 +56,7 @@ bool DoorSceneryObject::opened() const
 void DoorSceneryObject::setOpened(bool value)
 {
     _opened = value;
+    setCanLightThru(_opened);
 }
 
 bool DoorSceneryObject::locked() const
@@ -105,6 +107,7 @@ void DoorSceneryObject::onOpeningAnimationEnded(Event::Event* event)
     setOpened(true);
     queue->animationEndedHandler().clear();
     queue->stop();
+    Game::getInstance()->locationState()->initLight();
     Logger::info() << "Door opened: " << opened() << std::endl;
 }
 
@@ -114,6 +117,7 @@ void DoorSceneryObject::onClosingAnimationEnded(Event::Event* event)
     setOpened(false);
     queue->animationEndedHandler().clear();
     queue->stop();
+    Game::getInstance()->locationState()->initLight();
     Logger::info() << "Door opened: " << opened() << std::endl;
 }
 

--- a/src/Game/DudeObject.cpp
+++ b/src/Game/DudeObject.cpp
@@ -45,6 +45,8 @@ namespace Game
 DudeObject::DudeObject() : CritterObject()
 {
     _type = Type::DUDE;
+    setLightIntensity(65536);
+    setLightRadius(4);
 }
 
 DudeObject::~DudeObject()

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -192,7 +192,6 @@ void Object::_generateUi()
             _ui =  make_unique<UI::Image>(frm, orientation());
 
         }
-        _ui->setLight(true);
     }
 
     addUIEventHandlers();
@@ -307,7 +306,8 @@ void Object::render()
     }
 
     setInRender(true);
-
+    _ui->setLight(true);
+    _ui->setLightLevel(hexagon()->light());
     _ui->render(_useEggTransparency() && _isIntersectsWithEgg());
 }
 
@@ -559,10 +559,10 @@ unsigned int Object::lightRadius() const
 
 void Object::setFlags(unsigned int flags)
 {
-    setFlat((flags & 0x00000008) != 0);
-    setCanWalkThru((flags & 0x00000010) != 0);
-    setCanLightThru((flags & 0x20000000) != 0);
-    setCanShootThru((flags & 0x80000000) != 0);
+    setFlat((flags & 0x00000008));
+    setCanWalkThru((flags & 0x00000010));
+    setCanLightThru((flags & 0x20000000));
+    setCanShootThru((flags & 0x80000000));
 
     if (flags & 0x00004000) setTrans(Falltergeist::TransFlags::Trans::RED);
     if (flags & 0x00008000) setTrans(Falltergeist::TransFlags::Trans::NONE);

--- a/src/Game/Object.h
+++ b/src/Game/Object.h
@@ -238,7 +238,7 @@ public:
 
 protected:
     bool _canWalkThru = true;
-    bool _canLightThru = true;
+    bool _canLightThru = false;
     bool _canShootThru = true;
     bool _wallTransEnd = false;
     bool _flat = false;

--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -147,7 +147,19 @@ void Animation::render(int x, int y, unsigned int direction, unsigned int frame,
     {
         if (auto state = Game::getInstance()->locationState())
         {
-            lightLevel = state->lightLevel();
+            if ( state->lightLevel() < 0xA000 )
+            {
+                lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
+
+            }
+            else if ( state->lightLevel() == 0xA000 )
+            {
+                lightLevel = 50;
+            }
+            else
+            {
+                lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
+            }
         }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));

--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -24,6 +24,7 @@
 #include <Game/Game.h>
 #include <SDL_image.h>
 #include <TransFlags.h>
+#include <iostream>
 #include "Animation.h"
 #include "../Format/Frm/File.h"
 #include "../Format/Frm/Direction.h"
@@ -116,7 +117,7 @@ Animation::~Animation()
 
 }
 
-void Animation::render(int x, int y, unsigned int direction, unsigned int frame, bool transparency, bool light, int outline)
+void Animation::render(int x, int y, unsigned int direction, unsigned int frame, bool transparency, bool light, int outline, unsigned int lightValue)
 {
     int pos = direction*_stride+frame;
 
@@ -147,19 +148,8 @@ void Animation::render(int x, int y, unsigned int direction, unsigned int frame,
     {
         if (auto state = Game::getInstance()->locationState())
         {
-            if ( state->lightLevel() < 0xA000 )
-            {
-                lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
-
-            }
-            else if ( state->lightLevel() == 0xA000 )
-            {
-                lightLevel = 50;
-            }
-            else
-            {
-                lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
-            }
+            if (lightValue<=state->lightLevel()) lightValue=state->lightLevel();
+            lightLevel = lightValue / ((65536-655)/100);
         }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));

--- a/src/Graphics/Animation.h
+++ b/src/Graphics/Animation.h
@@ -32,7 +32,8 @@ class Animation
 public:
     Animation(const std::string& filename);
     ~Animation();
-    void render(int x, int y, unsigned int direction, unsigned int frame, bool transparency = false, bool light = false, int outline = 0);
+    void render(int x, int y, unsigned int direction, unsigned int frame, bool transparency = false, bool light = false, int outline = 0,
+                unsigned int lightValue=0);
     bool opaque(unsigned int x, unsigned int y);
     void trans(Falltergeist::TransFlags::Trans _trans);
 private:

--- a/src/Graphics/Lightmap.cpp
+++ b/src/Graphics/Lightmap.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2012-2016 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <ResourceManager.h>
+#include "Lightmap.h"
+#include <ResourceManager.h>
+#include <Game/Game.h>
+#include <iostream>
+#include "Shader.h"
+#include "../State/Location.h"
+
+namespace Falltergeist {
+namespace Graphics {
+
+
+Lightmap::Lightmap(std::vector<glm::vec2> coords)
+{
+    GL_CHECK(glGenVertexArrays(1, &_vao));
+    GL_CHECK(glBindVertexArray(_vao));
+
+    // generate VBOs for verts and tex
+    GL_CHECK(glGenBuffers(1, &_coords));
+    GL_CHECK(glGenBuffers(1, &_lights));
+    GL_CHECK(glGenBuffers(1, &_ebo));
+
+    if (coords.size()<=0) return;
+
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, _coords));
+    //update coords
+    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, coords.size() * sizeof(glm::vec2), &coords[0], GL_STATIC_DRAW));
+
+
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, _lights));
+    //update texcoords
+//    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, textureCoords.size() * sizeof(glm::vec2), &textureCoords[0], GL_STATIC_DRAW));
+
+    GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _ebo));
+    GL_CHECK(glBindVertexArray(0));
+
+    auto shader = ResourceManager::getInstance()->shader("lightmap");
+
+    _uniformFade = shader->getUniform("fade");
+    _uniformMVP = shader->getUniform("MVP");
+    _uniformOffset = shader->getUniform("offset");
+
+    _attribPos = shader->getAttrib("Position");
+    _attribLights = shader->getAttrib("lights");
+}
+
+Lightmap::~Lightmap()
+{
+
+}
+
+void Lightmap::render(const Falltergeist::Point &pos, std::vector<GLuint> indexes)
+{
+    if (indexes.size()<=0) return;
+
+    GL_CHECK(glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_SRC_ALPHA, GL_ONE));
+    auto shader = ResourceManager::getInstance()->shader("lightmap");
+
+    GL_CHECK(shader->use());
+
+    GL_CHECK(shader->setUniform(_uniformMVP, Game::getInstance()->renderer()->getMVP()));
+
+    // set camera offset
+    GL_CHECK(shader->setUniform(_uniformOffset, glm::vec2((float)pos.x(), (float)pos.y()) ));
+
+    GL_CHECK(shader->setUniform(_uniformFade,Game::getInstance()->renderer()->fadeColor()));
+
+
+    GL_CHECK(glBindVertexArray(_vao));
+
+
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, _coords));
+    GL_CHECK(glVertexAttribPointer(_attribPos, 2, GL_FLOAT, GL_FALSE, 0, (void*)0 ));
+
+
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, _lights));
+
+    GL_CHECK(glVertexAttribPointer(_attribLights, 1, GL_FLOAT, GL_FALSE, 0, (void*)0 ));
+
+    GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _ebo));
+
+    // update indexes
+    GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexes.size() * sizeof(GLuint), &indexes[0], GL_DYNAMIC_DRAW));
+
+    GL_CHECK(glEnableVertexAttribArray(_attribPos));
+
+    GL_CHECK(glEnableVertexAttribArray(_attribLights));
+
+    GL_CHECK(glDrawElements(GL_TRIANGLES, indexes.size(), GL_UNSIGNED_INT, 0 ));
+
+    GL_CHECK(glDisableVertexAttribArray(_attribPos));
+
+    GL_CHECK(glDisableVertexAttribArray(_attribLights));
+
+    GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0));
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, 0));
+    GL_CHECK(glBindVertexArray(0));
+
+    GL_CHECK(shader->unuse());
+    GL_CHECK(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+}
+
+void Lightmap::update(std::vector<float> lights)
+{
+    GL_CHECK(glBindVertexArray(_vao));
+    GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, _lights));
+    //update lights
+    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, lights.size() * sizeof(float), &lights[0], GL_STATIC_DRAW));
+    GL_CHECK(glBindVertexArray(0));
+
+}
+}
+}

--- a/src/Graphics/Lightmap.cpp
+++ b/src/Graphics/Lightmap.cpp
@@ -29,7 +29,7 @@ namespace Falltergeist {
 namespace Graphics {
 
 
-Lightmap::Lightmap(std::vector<glm::vec2> coords)
+Lightmap::Lightmap(std::vector<glm::vec2> coords,std::vector<GLuint> indexes)
 {
     GL_CHECK(glGenVertexArrays(1, &_vao));
     GL_CHECK(glBindVertexArray(_vao));
@@ -51,6 +51,10 @@ Lightmap::Lightmap(std::vector<glm::vec2> coords)
 //    GL_CHECK(glBufferData(GL_ARRAY_BUFFER, textureCoords.size() * sizeof(glm::vec2), &textureCoords[0], GL_STATIC_DRAW));
 
     GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _ebo));
+    // update indexes
+    GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexes.size() * sizeof(GLuint), &indexes[0], GL_DYNAMIC_DRAW));
+    _indexes = indexes.size();
+
     GL_CHECK(glBindVertexArray(0));
 
     auto shader = ResourceManager::getInstance()->shader("lightmap");
@@ -68,9 +72,9 @@ Lightmap::~Lightmap()
 
 }
 
-void Lightmap::render(const Falltergeist::Point &pos, std::vector<GLuint> indexes)
+void Lightmap::render(const Falltergeist::Point &pos)
 {
-    if (indexes.size()<=0) return;
+    //if (indexes.size()<=0) return;
 
     GL_CHECK(glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_SRC_ALPHA, GL_ONE));
     auto shader = ResourceManager::getInstance()->shader("lightmap");
@@ -98,14 +102,12 @@ void Lightmap::render(const Falltergeist::Point &pos, std::vector<GLuint> indexe
 
     GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _ebo));
 
-    // update indexes
-    GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexes.size() * sizeof(GLuint), &indexes[0], GL_DYNAMIC_DRAW));
 
     GL_CHECK(glEnableVertexAttribArray(_attribPos));
 
     GL_CHECK(glEnableVertexAttribArray(_attribLights));
 
-    GL_CHECK(glDrawElements(GL_TRIANGLES, indexes.size(), GL_UNSIGNED_INT, 0 ));
+    GL_CHECK(glDrawElements(GL_TRIANGLES, _indexes, GL_UNSIGNED_INT, 0 ));
 
     GL_CHECK(glDisableVertexAttribArray(_attribPos));
 

--- a/src/Graphics/Lightmap.cpp
+++ b/src/Graphics/Lightmap.cpp
@@ -74,9 +74,9 @@ Lightmap::~Lightmap()
 
 void Lightmap::render(const Falltergeist::Point &pos)
 {
-    //if (indexes.size()<=0) return;
+    if (_indexes<=0) return;
 
-    GL_CHECK(glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE, GL_SRC_ALPHA, GL_ONE));
+    GL_CHECK(glBlendFunc(GL_DST_COLOR, GL_SRC_COLOR));
     auto shader = ResourceManager::getInstance()->shader("lightmap");
 
     GL_CHECK(shader->use());

--- a/src/Graphics/Lightmap.h
+++ b/src/Graphics/Lightmap.h
@@ -29,9 +29,9 @@ namespace Graphics {
 class Lightmap
 {
 public:
-    Lightmap(std::vector<glm::vec2> coords);
+    Lightmap(std::vector<glm::vec2> coords, std::vector<GLuint> indexes);
     ~Lightmap();
-    void render(const Point &pos, std::vector<GLuint> indexes);
+    void render(const Point &pos);
     void update(std::vector<float> lights);
 
 private:
@@ -46,6 +46,7 @@ private:
 
     GLint _attribPos;
     GLint _attribLights;
+    unsigned int _indexes;
 
 };
 

--- a/src/Graphics/Lightmap.h
+++ b/src/Graphics/Lightmap.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2016 Falltergeist Developers.
+ *
+ * This file is part of Falltergeist.
+ *
+ * Falltergeist is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Falltergeist is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FALLTERGEIST_GRAPHICS_LIGHTMAP_H
+#define FALLTERGEIST_GRAPHICS_LIGHTMAP_H
+
+#include "../Point.h"
+#include "Renderer.h"
+
+namespace Falltergeist {
+namespace Graphics {
+
+class Lightmap
+{
+public:
+    Lightmap(std::vector<glm::vec2> coords);
+    ~Lightmap();
+    void render(const Point &pos, std::vector<GLuint> indexes);
+    void update(std::vector<float> lights);
+
+private:
+    GLuint _vao;
+    GLuint _coords;
+    GLuint _lights;
+    GLuint _ebo;
+
+    GLint _uniformFade;
+    GLint _uniformMVP;
+    GLint _uniformOffset;
+
+    GLint _attribPos;
+    GLint _attribLights;
+
+};
+
+}
+}
+
+#endif //FALLTERGEIST_GRAPHICS_LIGHTMAP_H

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -176,6 +176,7 @@ void Renderer::init()
     ResourceManager::getInstance()->shader("font");
     ResourceManager::getInstance()->shader("animation");
     ResourceManager::getInstance()->shader("tilemap");
+    ResourceManager::getInstance()->shader("lightmap");
     Logger::info("RENDERER") << "[OK]" << std::endl;
 
     Logger::info("RENDERER") << "Generating buffers" << std::endl;

--- a/src/Graphics/Sprite.cpp
+++ b/src/Graphics/Sprite.cpp
@@ -76,7 +76,7 @@ unsigned int Sprite::height() const
 }
 
 // render, optionally scaled
-void Sprite::renderScaled(int x, int y, unsigned int width, unsigned int height, bool transparency, bool light, int outline)
+void Sprite::renderScaled(int x, int y, unsigned int width, unsigned int height, bool transparency, bool light, int outline, unsigned int lightValue)
 {
     std::vector<glm::vec2> vertices;
     std::vector<glm::vec2> UV;
@@ -158,19 +158,8 @@ void Sprite::renderScaled(int x, int y, unsigned int width, unsigned int height,
     {
         if (auto state = Game::getInstance()->locationState())
         {
-            if ( state->lightLevel() < 0xA000 )
-            {
-                lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
-
-            }
-            else if ( state->lightLevel() == 0xA000 )
-            {
-                lightLevel = 50;
-            }
-            else
-            {
-                lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
-            }
+            if (lightValue<=state->lightLevel()) lightValue=state->lightLevel();
+            lightLevel = lightValue / ((65536-655)/100);
         }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));
@@ -215,14 +204,14 @@ void Sprite::renderScaled(int x, int y, unsigned int width, unsigned int height,
 
 }
 
-void Sprite::render(int x, int y, bool transparency, bool light, int outline)
+void Sprite::render(int x, int y, bool transparency, bool light, int outline, unsigned int lightValue)
 {
-    renderScaled(x, y, _texture->width(), _texture->height(), transparency, light, outline);
+    renderScaled(x, y, _texture->width(), _texture->height(), transparency, light, outline, lightValue);
 }
 
 // render just a part of texture, unscaled
 void Sprite::renderCropped(int x, int y, int dx, int dy, unsigned int width, unsigned int height, bool transparency,
-                           bool light)
+                           bool light, unsigned int lightValue)
 {
     std::vector<glm::vec2> vertices;
     std::vector<glm::vec2> UV;
@@ -295,19 +284,8 @@ void Sprite::renderCropped(int x, int y, int dx, int dy, unsigned int width, uns
     {
         if (auto state = Game::getInstance()->locationState())
         {
-            if ( state->lightLevel() < 0xA000 )
-            {
-                lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
-
-            }
-            else if ( state->lightLevel() == 0xA000 )
-            {
-                lightLevel = 50;
-            }
-            else
-            {
-                lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
-            }
+            if (lightValue<=state->lightLevel()) lightValue=state->lightLevel();
+            lightLevel = lightValue / ((65536-655)/100);
         }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));

--- a/src/Graphics/Sprite.cpp
+++ b/src/Graphics/Sprite.cpp
@@ -158,7 +158,19 @@ void Sprite::renderScaled(int x, int y, unsigned int width, unsigned int height,
     {
         if (auto state = Game::getInstance()->locationState())
         {
-            lightLevel = state->lightLevel();
+            if ( state->lightLevel() < 0xA000 )
+            {
+                lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
+
+            }
+            else if ( state->lightLevel() == 0xA000 )
+            {
+                lightLevel = 50;
+            }
+            else
+            {
+                lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
+            }
         }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));
@@ -283,7 +295,19 @@ void Sprite::renderCropped(int x, int y, int dx, int dy, unsigned int width, uns
     {
         if (auto state = Game::getInstance()->locationState())
         {
-            lightLevel = state->lightLevel();
+            if ( state->lightLevel() < 0xA000 )
+            {
+                lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
+
+            }
+            else if ( state->lightLevel() == 0xA000 )
+            {
+                lightLevel = 50;
+            }
+            else
+            {
+                lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
+            }
         }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));

--- a/src/Graphics/Sprite.h
+++ b/src/Graphics/Sprite.h
@@ -38,10 +38,10 @@ public:
     Sprite(const std::string& filename);
     Sprite(Format::Frm::File* frm);
     void renderScaled(int x, int y, unsigned int width, unsigned int height, bool transparency = false,
-                      bool light = false, int outline = 0);
-    void render(int x, int y, bool transparency = false, bool light = false, int outline = 0);
+                      bool light = false, int outline = 0, unsigned int lightValue=0);
+    void render(int x, int y, bool transparency = false, bool light = false, int outline = 0, unsigned int lightValue=0);
     void renderCropped(int x, int y, int dx, int dy, unsigned int width, unsigned int height, bool transparency = false,
-                       bool light = false);
+                       bool light = false, unsigned int lightValue=0);
     unsigned int width() const;
     unsigned int height() const;
     Size size() const;

--- a/src/Graphics/Tilemap.cpp
+++ b/src/Graphics/Tilemap.cpp
@@ -101,8 +101,21 @@ void Tilemap::render(const Point &pos, std::vector<GLuint> indexes, uint32_t atl
     GL_CHECK(shader->setUniform(_uniformCnt, Game::getInstance()->animatedPalette()->counters()));
 
     int lightLevel = 100;
-    if (auto state = Game::getInstance()->locationState()) {
-        lightLevel = state->lightLevel();
+    if (auto state = Game::getInstance()->locationState())
+    {
+        if ( state->lightLevel() < 0xA000 )
+        {
+            lightLevel = (state->lightLevel() - 0x4000) * 100 / 0x6000;
+
+        }
+        else if ( state->lightLevel() == 0xA000 )
+        {
+            lightLevel = 50;
+        }
+        else
+        {
+            lightLevel = (state->lightLevel() - 0xA000) * 100 / 0x6000;
+        }
     }
     GL_CHECK(shader->setUniform(_uniformLight, lightLevel));
 

--- a/src/PathFinding/Hexagon.cpp
+++ b/src/PathFinding/Hexagon.cpp
@@ -179,7 +179,7 @@ unsigned int Hexagon::addLight(unsigned int light)
 unsigned int Hexagon::subLight(unsigned int light)
 {
     _light-=light;
-    if ((int)_light < 0) _light = 0;
+    if ((int)_light < 655) _light = 655;
     return _light;
 }
 

--- a/src/PathFinding/Hexagon.cpp
+++ b/src/PathFinding/Hexagon.cpp
@@ -166,7 +166,7 @@ Game::Orientation Hexagon::orientationTo(Hexagon *hexagon)
         result = 2;
     }
 
-    return Game::Orientation(result);
+    return Game::Orientation(result); // TODO: this is wrong. orientation!=direction
 }
 
 unsigned int Hexagon::addLight(unsigned int light)

--- a/src/PathFinding/Hexagon.cpp
+++ b/src/PathFinding/Hexagon.cpp
@@ -188,4 +188,9 @@ unsigned int Hexagon::light()
     return _light;
 }
 
+unsigned int Hexagon::setLight(unsigned int light)
+{
+    _light = light;
+    return _light;
+}
 }

--- a/src/PathFinding/Hexagon.cpp
+++ b/src/PathFinding/Hexagon.cpp
@@ -147,7 +147,7 @@ Game::Orientation Hexagon::orientationTo(Hexagon *hexagon)
     {
         // trigonometry magic.
         // basically, we try to find angle to second hex in circle, where first hex is center
-        // and then find out to which of 60º slices it belongs
+        // and then find out to which of 60ï¿½ slices it belongs
 
         double degree = atan2((double)-dy, (double)dx) * 180.0 * 0.3183098862851122; //  180 * 1/PI
 
@@ -167,6 +167,25 @@ Game::Orientation Hexagon::orientationTo(Hexagon *hexagon)
     }
 
     return Game::Orientation(result);
+}
+
+unsigned int Hexagon::addLight(unsigned int light)
+{
+    _light+=light;
+    if (_light > 65536) _light = 65536;
+    return _light;
+}
+
+unsigned int Hexagon::subLight(unsigned int light)
+{
+    _light-=light;
+    if ((int)_light < 0) _light = 0;
+    return _light;
+}
+
+unsigned int Hexagon::light()
+{
+    return _light;
 }
 
 }

--- a/src/PathFinding/Hexagon.h
+++ b/src/PathFinding/Hexagon.h
@@ -72,6 +72,10 @@ public:
 
     Game::Orientation orientationTo(Hexagon *hexagon);
 
+    unsigned int addLight(unsigned int light);
+    unsigned int subLight(unsigned int light);
+    unsigned int light();
+
 protected:
     std::vector<Hexagon*> _neighbors;
     std::list<Game::Object*> _objects;
@@ -86,6 +90,8 @@ protected:
     unsigned int _heuristic = 0;
 
     bool _inRender = false;
+
+    unsigned int _light;
 };
 
 }

--- a/src/PathFinding/Hexagon.h
+++ b/src/PathFinding/Hexagon.h
@@ -74,6 +74,7 @@ public:
 
     unsigned int addLight(unsigned int light);
     unsigned int subLight(unsigned int light);
+    unsigned int setLight(unsigned int light);
     unsigned int light();
 
 protected:

--- a/src/PathFinding/Hexagon.h
+++ b/src/PathFinding/Hexagon.h
@@ -91,7 +91,7 @@ protected:
 
     bool _inRender = false;
 
-    unsigned int _light;
+    unsigned int _light = 655;
 };
 
 }

--- a/src/PathFinding/HexagonGrid.cpp
+++ b/src/PathFinding/HexagonGrid.cpp
@@ -20,12 +20,13 @@
 // C++ standard includes
 #include <functional>
 #include <queue>
+#include <array>
 #include <cstdlib>
 #include <iostream>
-#include <Game/WallObject.h>
 
 // Falltergeist includes
 #include "../Base/StlFeatures.h"
+#include "../Game/WallObject.h"
 #include "../PathFinding/Hexagon.h"
 #include "../PathFinding/HexagonGrid.h"
 
@@ -590,7 +591,7 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                             {
 
                                 // if wall -> check light orientation
-                                /*if (auto wall = dynamic_cast<Game::WallObject*>(object))
+                                if (auto wall = dynamic_cast<Game::WallObject*>(object))
                                 {
 
                                     if (wall->lightOrientation() == Game::Orientation::EC || wall->lightOrientation() == Game::Orientation::WC)
@@ -619,10 +620,10 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                                         lightHex = false;
                                     }
                                 }
-                                else
-                                {*/
+                                //else
+                                {
                                     block = true;
-                                //}
+                                }
 
 
                                 break;

--- a/src/PathFinding/HexagonGrid.cpp
+++ b/src/PathFinding/HexagonGrid.cpp
@@ -575,6 +575,7 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                             break;
 
                     }
+
                     if (!block)
                     {
                         // find objs/walls
@@ -620,11 +621,15 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                                         lightHex = false;
                                     }
                                 }
-                                //else
+                                else
                                 {
-                                    block = true;
+                                    if (dir>=1 && dir <=3 )
+                                    {
+                                        lightHex=false;
+                                    }
                                 }
 
+                                block = true;
 
                                 break;
                             }

--- a/src/PathFinding/HexagonGrid.cpp
+++ b/src/PathFinding/HexagonGrid.cpp
@@ -22,7 +22,6 @@
 #include <queue>
 #include <array>
 #include <cstdlib>
-#include <iostream>
 
 // Falltergeist includes
 #include "../Base/StlFeatures.h"
@@ -287,13 +286,13 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
             std::array<bool, 36*6> blocked;
             blocked.fill(false);
 
-            auto prevTwo = [blocked](int idx, int radius, int dir) -> bool
+            auto prevTwo = [&blocked](int idx, int radius, int dir) -> bool
             {
                 idx = idx-(radius-1)*6-dir;
                 return blocked[idx-1] && blocked[idx];
             };
 
-            auto isBlocked = [blocked](int coneIdx, int radius, int dir) -> bool
+            auto isBlocked = [&blocked](int coneIdx, int radius, int dir) -> bool
             {
                 dir = dir % 6;
                 int base = 0;
@@ -582,20 +581,19 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                         bool lightHex = true;
                         for (auto it2 = ringhex->objects()->begin(); it2 != ringhex->objects()->end(); ++it2)
                         {
-                            auto curObject = *it;
+                            auto curObject = *it2;
                             // dead objects block nothing
                             //if (curObject->dead()) continue;
                             // flat objects block nothing
                             if (curObject->flat()) continue;
+                            if (curObject->type()==Game::Object::Type::DUDE) continue;
 
                             if (!curObject->canLightThru())
                             {
-
                                 // if wall -> check light orientation
-                                if (auto wall = dynamic_cast<Game::WallObject*>(object))
+                                if (auto wall = dynamic_cast<Game::WallObject*>(curObject))
                                 {
-
-                                    if (wall->lightOrientation() == Game::Orientation::EC || wall->lightOrientation() == Game::Orientation::WC)
+                                    if (wall->lightOrientation() == Game::Orientation::EW || wall->lightOrientation() == Game::Orientation::EC)
                                     {
                                         if ( (dir != 4) && (dir != 5) && (dir>0 || coneIdx > 0) && (dir != 3 || ((coneIdx>=0 && coneIdx<=1) || (radius==3 && coneIdx==2) )))
                                         {

--- a/src/PathFinding/HexagonGrid.cpp
+++ b/src/PathFinding/HexagonGrid.cpp
@@ -590,7 +590,7 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                             {
 
                                 // if wall -> check light orientation
-                                if (auto wall = dynamic_cast<Game::WallObject*>(object))
+                                /*if (auto wall = dynamic_cast<Game::WallObject*>(object))
                                 {
 
                                     if (wall->lightOrientation() == Game::Orientation::EC || wall->lightOrientation() == Game::Orientation::WC)
@@ -620,9 +620,9 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                                     }
                                 }
                                 else
-                                {
+                                {*/
                                     block = true;
-                                }
+                                //}
 
 
                                 break;
@@ -639,6 +639,7 @@ void HexagonGrid::initLight(Hexagon *hex, bool add)
                             }
                         }
                     }
+
                     blocked[blockerIndex] = block;
                     ringIndex++;
                     blockerIndex++;

--- a/src/PathFinding/HexagonGrid.cpp
+++ b/src/PathFinding/HexagonGrid.cpp
@@ -21,6 +21,8 @@
 #include <functional>
 #include <queue>
 #include <cstdlib>
+#include <iostream>
+#include <Game/WallObject.h>
 
 // Falltergeist includes
 #include "../Base/StlFeatures.h"
@@ -236,7 +238,7 @@ Hexagon* HexagonGrid::hexInDirection(Hexagon* from, unsigned short rotation, uns
     int index = 200*q + p;
     if (index < 0 || index >= 200*200)
     {
-        return from;
+        return nullptr;
     }
     return at(index);
 
@@ -270,4 +272,381 @@ std::vector<Hexagon*> HexagonGrid::ring(Hexagon* from, unsigned int radius)
     return result;
 }
 
+void HexagonGrid::initLight(Hexagon *hex, bool add)
+{
+
+
+    auto objectsAtHex = hex->objects();
+    for (auto it = objectsAtHex->begin(); it != objectsAtHex->end(); ++it)
+    {
+        auto object = *it;
+        if (object->lightIntensity()>0 && object->lightRadius()>0)
+        {
+            // 36 hexes per direction
+            std::array<bool, 36*6> blocked;
+            blocked.fill(false);
+
+            auto prevTwo = [blocked](int idx, int radius, int dir) -> bool
+            {
+                idx = idx-(radius-1)*6-dir;
+                return blocked[idx-1] && blocked[idx];
+            };
+
+            auto isBlocked = [blocked](int coneIdx, int radius, int dir) -> bool
+            {
+                dir = dir % 6;
+                int base = 0;
+                int r = radius;
+                while (r>0)
+                {
+                    base+=(r-1)*6;
+                    r--;
+                }
+
+
+                return blocked[base+coneIdx+radius*dir];
+            };
+
+            auto index = [](int coneIdx, int radius, int dir) -> int
+            {
+                dir = dir % 6;
+                int base = 0;
+                int r = radius;
+                while (r>0)
+                {
+                    base+=(r-1)*6;
+                    r--;
+                }
+
+
+                return base+coneIdx+radius*dir;
+            };
+
+            int light = object->lightIntensity();
+            if (add)
+            {
+                hex->addLight(light);
+            }
+            else
+            {
+                hex->subLight(light);
+            }
+            int perRadius = (light - 655) / (object->lightRadius()+1);
+
+            int blockerIndex = 0;
+
+            for (unsigned int radius = 1; radius<= object->lightRadius();radius++)
+            {
+                light-=perRadius;
+                int ringIndex=0;
+                for (auto ringhex : ring(hex,radius))
+                {
+                    if (!ringhex) //invalid hex
+                    {
+                        ringIndex++;
+                        blockerIndex++;
+                        continue;
+                    }
+                    int dir = ringIndex / radius;
+
+                    int coneIdx = ringIndex % radius;
+
+                    bool block = false;
+                    switch (radius)
+                    {
+                        case 1:
+                            block = false;
+                            break;
+                        case 2:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                            }
+                            break;
+                        case 3:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                                case 2:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                            }
+                            break;
+                        case 4:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                                case 2:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || isBlocked(1, 2, dir);
+                                    break;
+                                case 3:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || prevTwo(index(2,3,dir),radius-1,dir) ;
+                                    break;
+                            }
+                            break;
+                        case 5:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                                case 2:
+
+                                    block = (isBlocked(1, 3, dir) && (isBlocked(2,3,dir) || isBlocked(1, 4, dir)))
+                                            || (isBlocked(2,4,dir) && (isBlocked(1, 4, dir) || isBlocked(1, 3, dir)))
+                                            || ((isBlocked(1, 4, dir) || isBlocked(1, 3, dir)) & isBlocked(1,2,dir));
+                                    break;
+                                case 3:
+                                    block = ((isBlocked(3, 4, dir) || isBlocked(2, 3, dir)) && isBlocked(2, 4, dir))
+                                            || (isBlocked(2, 3, dir) && (isBlocked(3, 4, dir) || isBlocked(1, 3, dir)))
+                                            || ((isBlocked(3, 4, dir) || isBlocked(2, 3, dir) || isBlocked(0, 2, dir + 1)) && isBlocked(1, 2, dir));
+                                    break;
+                                case 4:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || prevTwo(index(3,4,dir),radius-1,dir)
+                                            || prevTwo(index(2,3,dir),radius-2,dir);
+                                    break;
+                            }
+                            break;
+                        case 6:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                                case 2:
+                                    block = ((isBlocked(1,5, dir) || isBlocked(1,4,dir) || isBlocked(1,3,dir) || isBlocked(0,1,dir)) && isBlocked(2,5,dir))
+                                            || isBlocked(1,3,dir)
+                                            || (isBlocked(2,4,dir) && isBlocked(1,4,dir));
+                                    break;
+                                case 3:
+                                    block =  prevTwo(blockerIndex, radius, dir)
+                                            || prevTwo(index(2,4,dir), radius-2, dir)
+                                            || isBlocked(1,2,dir)
+                                            || isBlocked(2,4,dir);
+                                    break;
+                                case 4:
+                                    block = (prevTwo(index(3,5,dir), radius-1, dir)
+                                            || isBlocked(1,2,dir))
+                                            || isBlocked(2,3,dir)
+                                            || prevTwo(index(2,3,dir), radius-3, dir)
+                                            || ((isBlocked(4,5,dir) || isBlocked(3,4,dir) || isBlocked(2,3,dir) || isBlocked(0,1, dir+1))
+                                                && isBlocked(3,5,dir));
+                                    break;
+                                case 5:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || prevTwo(index(4,5,dir),radius-1,dir)
+                                            || prevTwo(index(3,4,dir),radius-2,dir)
+                                            || prevTwo(index(2,3,dir),radius-3,dir);
+                                    break;
+                            }
+                            break;
+                        case 7:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                                case 2:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                                     || isBlocked(1,4,dir)
+                                                     || isBlocked(1,3,dir)
+                                                     || ((isBlocked(0, radius-1, dir) || isBlocked(2,5,dir)) && isBlocked(1,5,dir));
+
+                                    break;
+                                case 3:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || (isBlocked(2,5,dir) && (isBlocked(3,6,dir) || isBlocked(3,5,dir) || isBlocked(2,3,dir)))
+                                            || isBlocked(1,2,dir)
+                                            || (isBlocked(1,3,dir) && (isBlocked(3,6,dir) || isBlocked(2,4,dir) || isBlocked(2,3,dir)))
+                                            || ((isBlocked(2,6,dir) || isBlocked(2,5,dir) || isBlocked(1,4,dir) || isBlocked(1,3,dir) || isBlocked(0,1,dir)) && isBlocked(2,4,dir));
+
+                                    break;
+                                case 4:
+                                    block = prevTwo(blockerIndex, radius, dir)
+                                            || (isBlocked(3,5,dir) && (isBlocked(3,6,dir) || isBlocked(2,5,dir) || isBlocked(1,3,dir)))
+                                            || (isBlocked(2,4,dir) && (isBlocked(4,6,dir) || isBlocked(3,5,dir) || isBlocked(3,4,dir) || isBlocked(0,1,dir+1)))
+                                            || isBlocked(1,2,dir)
+                                            || (isBlocked(2,3,dir) && (isBlocked(3,6,dir) || isBlocked(2,4,dir) || isBlocked(1,3,dir)));
+
+                                    break;
+                                case 5:
+                                    block = prevTwo(blockerIndex,radius, dir)
+                                            || (isBlocked(4,5,dir) && (isBlocked(4,6,dir) || isBlocked(3,5,dir) || isBlocked(1,2,dir)))
+                                            || isBlocked(2,3,dir)
+                                            || (isBlocked(0,2,dir+1) && isBlocked(1,2,dir))
+                                            || isBlocked(3,4,dir);
+
+                                    break;
+                                case 6:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || prevTwo(index(5,6,dir),radius-1,dir)
+                                            || prevTwo(index(4,5,dir),radius-2,dir)
+                                            || prevTwo(index(3,4,dir),radius-3,dir)
+                                            || prevTwo(index(2,3,dir),radius-4,dir);
+                                    break;
+                            }
+                            break;
+                        case 8:
+                            switch (coneIdx)
+                            {
+                                case 0:
+                                    block = isBlocked(0, radius-1, dir);
+                                    break;
+                                case 1:
+                                    block = prevTwo(blockerIndex,radius,dir);
+                                    break;
+                                case 2:
+                                    block = ((isBlocked(2,7,dir) || isBlocked(2,6,dir) || isBlocked(2,5,dir) || isBlocked(2,4,dir)) && isBlocked(1,5,dir))
+                                            || ((isBlocked(1,6,dir) || isBlocked(1,5,dir) || isBlocked(0,3,dir)) && isBlocked(1,2,dir))
+                                            || (isBlocked(1,3,dir) && (isBlocked(1,6,dir) || isBlocked(1,5,dir) || isBlocked(0,3,dir)))
+                                            || isBlocked(1,4,dir);
+                                    break;
+                                case 3:
+                                    block = (isBlocked(3,7,dir) && (isBlocked(2,7,dir) || isBlocked(0,1,dir)))
+                                            || (isBlocked(2,6,dir) && (isBlocked(3,7,dir) || isBlocked(3,6,dir) || isBlocked(2,4,dir) || isBlocked(1,2,dir)))
+                                            || isBlocked(2,5,dir)
+                                            || (isBlocked(1,4,dir) && (isBlocked(3,7,dir) || isBlocked(2,4,dir) || isBlocked(1,2,dir) || isBlocked(2,5,dir)))
+                                            || (isBlocked(0,2,dir) && isBlocked(1,2,dir))
+                                            || ((isBlocked(3,7,dir) || isBlocked(3,6,dir) || isBlocked(2,4,dir) || isBlocked(2,3,dir) || isBlocked(1,2,dir)) && isBlocked(1,3,dir));
+
+                                    break;
+                                case 4:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || prevTwo(index(3,6,dir),radius-2,dir)
+                                            || prevTwo(index(2,4,dir),radius-4,dir)
+                                            || isBlocked(3,6,dir)
+                                            || isBlocked(2,4,dir)
+                                            || isBlocked(1,2,dir);
+                                    break;
+                                case 5:
+                                    block = (isBlocked(4,7,dir) && (isBlocked(5,7,dir) || isBlocked(0,1,dir)))
+                                            || (isBlocked(4,6,dir) && (isBlocked(4,7,dir) || isBlocked(3,6,dir) || isBlocked(2,4,dir) || isBlocked(1,2,dir)))
+                                            || isBlocked(3,5,dir)
+                                            || (isBlocked(0,2,dir+1) && isBlocked(1,2,dir))
+                                            || ((isBlocked(4,7,dir) || isBlocked(3,6,dir) || isBlocked(2,4,dir) || isBlocked(1,3,dir) || isBlocked(1,2,dir)) && isBlocked(2,3,dir))
+                                            || (isBlocked(3,4,dir) && (isBlocked(2,4,dir) || isBlocked(1,2,dir) || isBlocked(4,7,dir)));
+                                    break;
+                                case 6:
+                                    block = ((isBlocked(5,7,dir) || isBlocked(4,6,dir) || isBlocked(3,5,dir) || isBlocked(2,4,dir)) && isBlocked(4,5,dir))
+                                            || isBlocked(3,4,dir)
+                                            || (isBlocked(2,3,dir) && (isBlocked(5,6,dir) || isBlocked(4,5,dir) || isBlocked(0,3,dir+1)))
+                                            || ((isBlocked(5,6,dir) || isBlocked(4,5,dir) || isBlocked(0,3,dir+1)) && isBlocked(1,2,dir));
+
+                                    break;
+                                case 7:
+                                    block = prevTwo(blockerIndex,radius,dir)
+                                            || prevTwo(index(6,7,dir),radius-1,dir)
+                                            || prevTwo(index(5,6,dir),radius-2,dir)
+                                            || prevTwo(index(4,5,dir),radius-3,dir)
+                                            || prevTwo(index(3,4,dir),radius-4,dir)
+                                            || prevTwo(index(2,3,dir),radius-5,dir);
+                                    break;
+                            }
+                            break;
+                        default:
+                            break;
+
+                    }
+                    if (!block)
+                    {
+                        // find objs/walls
+                        bool lightHex = true;
+                        for (auto it2 = ringhex->objects()->begin(); it2 != ringhex->objects()->end(); ++it2)
+                        {
+                            auto curObject = *it;
+                            // dead objects block nothing
+                            //if (curObject->dead()) continue;
+                            // flat objects block nothing
+                            if (curObject->flat()) continue;
+
+                            if (!curObject->canLightThru())
+                            {
+
+                                // if wall -> check light orientation
+                                if (auto wall = dynamic_cast<Game::WallObject*>(object))
+                                {
+
+                                    if (wall->lightOrientation() == Game::Orientation::EC || wall->lightOrientation() == Game::Orientation::WC)
+                                    {
+                                        if ( (dir != 4) && (dir != 5) && (dir>0 || coneIdx > 0) && (dir != 3 || ((coneIdx>=0 && coneIdx<=1) || (radius==3 && coneIdx==2) )))
+                                        {
+                                            lightHex = false;
+                                        }
+                                    }
+                                    else if (wall->lightOrientation() == Game::Orientation::NC)
+                                    {
+                                        if( dir != 0 && dir != 5)
+                                        {
+                                            lightHex = false;
+                                        }
+                                    }
+                                    else if (wall->lightOrientation() == Game::Orientation::SC)
+                                    {
+                                        if( (dir>0) && dir != 1 && dir != 4 && dir != 5 && (dir != 3 || ((coneIdx>=0 && coneIdx<=1) || (radius==3 && coneIdx==2) )))
+                                        {
+                                            lightHex = false;
+                                        }
+                                    }
+                                    else if (dir != 0 && dir != 1 && ( dir != 5 || coneIdx==0 ))
+                                    {
+                                        lightHex = false;
+                                    }
+                                }
+                                else
+                                {
+                                    block = true;
+                                }
+
+
+                                break;
+                            }
+
+                        }
+                        if (lightHex)
+                        {
+                            if (add) {
+                                ringhex->addLight(light);
+                            }
+                            else {
+                                ringhex->subLight(light);
+                            }
+                        }
+                    }
+                    blocked[blockerIndex] = block;
+                    ringIndex++;
+                    blockerIndex++;
+                }
+
+            }
+        }
+    }
+
+}
 }

--- a/src/PathFinding/HexagonGrid.h
+++ b/src/PathFinding/HexagonGrid.h
@@ -48,6 +48,7 @@ public:
     std::vector<Hexagon*> findPath(Hexagon* from, Hexagon* to);
     Hexagon* hexInDirection(Hexagon* from, unsigned short rotation, unsigned int distance);
     std::vector<Hexagon*> ring(Hexagon* from, unsigned int radius);
+    void initLight(Hexagon* hex, bool add = true);
 
 protected:
     HexagonVector _hexagons;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -183,6 +183,7 @@ bool Settings::load()
     if (logger)
     {
         _loggerLevel = logger->propertyString("level", _loggerLevel);
+        Logger::setLevel(_loggerLevel);
         _loggerColors = logger->propertyBool("colors", _loggerColors);
     }
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -175,7 +175,61 @@ void Location::setLocation(const std::string& name)
     {
         _vertices.push_back(glm::vec2(hex->position().x(), hex->position().y()));
     }
-    _lightmap = new Graphics::Lightmap(_vertices);
+    std::vector<GLuint> indexes;
+    for (auto hexagon : _hexagonGrid->hexagons())
+    {
+        /*if (!Rect::inRect(hexagon->position()-camera()->topLeft(),Size(Game::getInstance()->renderer()->width(),Game::getInstance()->renderer()->height())))
+        {
+            continue;
+        }*/
+        bool doup=true;
+        bool dodown = true;
+        if (hexagon->number() % 200 == 0)
+        {
+            doup=false;
+        }
+        if ((hexagon->number()+1) % 200 == 0)
+        {
+            dodown=false;
+        }
+        if (hexagon->number()<200)
+        {
+            doup = false;
+        }
+        if (hexagon->number()>=39800)
+        {
+            dodown = false;
+        }
+        if (dodown)
+        {
+            indexes.push_back(hexagon->number());
+            if (hexagon->number() % 2) // odd
+            {
+                indexes.push_back(hexagon->number()+200);
+                indexes.push_back(hexagon->number()+1);
+            }
+            else
+            {
+                indexes.push_back(hexagon->number()+200);
+                indexes.push_back(hexagon->number()+201);
+            }
+        }
+        if (doup)
+        {
+            indexes.push_back(hexagon->number());
+            if (hexagon->number() % 2) // odd
+            {
+                indexes.push_back(hexagon->number()-200);
+                indexes.push_back(hexagon->number()-201);
+            }
+            else
+            {
+                indexes.push_back(hexagon->number()-200);
+                indexes.push_back(hexagon->number()-1);
+            }
+        }
+    }
+    _lightmap = new Graphics::Lightmap(_vertices,indexes);
 
     auto mapFile = ResourceManager::getInstance()->mapFileType(name);
 
@@ -486,57 +540,8 @@ void Location::render()
 {
     _floor->render();
 
-    std::vector<GLuint> indexes;
-    for (auto hexagon : _hexagonGrid->hexagons())
-    {
-        bool doup=true;
-        bool dodown = true;
-        if (hexagon->number() % 200 == 0)
-        {
-            doup=false;
-        }
-        if ((hexagon->number()+1) % 200 == 0)
-        {
-            dodown=false;
-        }
-        if (hexagon->number()<200)
-        {
-            doup = false;
-        }
-        if (hexagon->number()>=39800)
-        {
-            dodown = false;
-        }
-        if (dodown)
-        {
-            indexes.push_back(hexagon->number());
-            if (hexagon->number() % 2) // odd
-            {
-                indexes.push_back(hexagon->number()+200);
-                indexes.push_back(hexagon->number()+1);
-            }
-            else
-            {
-                indexes.push_back(hexagon->number()+200);
-                indexes.push_back(hexagon->number()+201);
-            }
-        }
-        if (doup)
-        {
-            indexes.push_back(hexagon->number());
-            if (hexagon->number() % 2) // odd
-            {
-                indexes.push_back(hexagon->number()-200);
-                indexes.push_back(hexagon->number()-201);
-            }
-            else
-            {
-                indexes.push_back(hexagon->number()-200);
-                indexes.push_back(hexagon->number()-1);
-            }
-        }
-    }
-    _lightmap->render(_camera->topLeft(),indexes);
+
+    _lightmap->render(_camera->topLeft());
 
     // render hex cursor
     if (Game::getInstance()->mouse()->state() == Input::Mouse::Cursor::HEXAGON_RED)
@@ -1105,23 +1110,10 @@ void Location::moveObjectToHexagon(Game::Object *object, Hexagon *hexagon, bool 
             for (auto hex: _hexagonGrid->hexagons())
             {
                 int lightLevel = 100;
-                //int light = std::max(hex->light(),_lightLevel);
                 unsigned int light = hex->light();
                 if (light<=_lightLevel) light=655;
                 lightLevel = light / ((65536-655)/100);
-                /*if ( light < 0xA000 )
-                {
-                    lightLevel = (light - 0x4000) * 100 / 0x6000;
 
-                }
-                else if ( light == 0xA000 )
-                {
-                    lightLevel = 50;
-                }
-                else
-                {
-                    lightLevel = (light - 0xA000) * 100 / 0x6000;
-                }*/
                 float l = lightLevel/100.0;
                 lights.push_back(l);
             }
@@ -1308,24 +1300,11 @@ void Location::initLight()
     for (auto hex: _hexagonGrid->hexagons())
     {
         int lightLevel = 100;
-        //int light = std::max(hex->light(),_lightLevel);
 
         unsigned int light = hex->light();
         if (light<=_lightLevel) light=655;
         lightLevel = light / ((65536-655)/100);
-        /*if ( light < 0xA000 )
-        {
-            lightLevel = (light - 0x4000) * 100 / 0x6000;
 
-        }
-        else if ( light == 0xA000 )
-        {
-            lightLevel = 50;
-        }
-        else
-        {
-            lightLevel = (light - 0xA000) * 100 / 0x6000;
-        }*/
         float l = lightLevel/100.0;
         lights.push_back(l);
     }

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -1182,13 +1182,16 @@ void Location::removeTimerEvent(Game::Object* obj, int fixedParam)
     _timerEvents.remove_if([=](Location::TimerEvent& item) { return item.object == obj && item.fixedParam == fixedParam; });
 }
 
-unsigned short Location::lightLevel()
+unsigned int Location::lightLevel()
 {
     return _lightLevel;
 }
 
-void Location::setLightLevel(unsigned short level)
+void Location::setLightLevel(unsigned int level)
 {
+    // TODO: check night vision perk and increase light by 20% (20% of what, maximum or current?)
+    if (level>0x10000) level=0x10000;
+    if (level<0x4000) level=0x4000;
     _lightLevel = level;
 }
 }

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -388,6 +388,7 @@ void Location::setLocation(const std::string& name)
             Logger::error("Location") << "No ambient sfx for map " << mapShortName << std::endl;
         }
     }
+    initLight();
 }
 
 std::vector<Input::Mouse::Icon> Location::getCursorIconsForObject(Game::Object* object)
@@ -874,7 +875,8 @@ void Location::onMouseMove(Event::Mouse* mouseEvent)
         text += "Hex coords: " + std::to_string(hexagon->position().x()) + "," + std::to_string(hexagon->position().y()) + "\n";
         auto dude = Game::getInstance()->player();
         auto hex = dude->hexagon();
-        text += "Hex delta:\n dx=" + std::to_string(hex->cubeX()-hexagon->cubeX()) + "\n dy="+ std::to_string(hex->cubeY()-hexagon->cubeY()) + "\n dz=" + std::to_string(hex->cubeZ()-hexagon->cubeZ());
+        text += "Hex delta:\n dx=" + std::to_string(hex->cubeX()-hexagon->cubeX()) + "\n dy="+ std::to_string(hex->cubeY()-hexagon->cubeY()) + "\n dz=" + std::to_string(hex->cubeZ()-hexagon->cubeZ()) + "\n";
+        text += "Hex light: " + std::to_string(hexagon->light()) + "\n";
         _hexagonInfo->setText(text);
     }
     else
@@ -986,6 +988,11 @@ void Location::moveObjectToHexagon(Game::Object *object, Hexagon *hexagon, bool 
     auto oldHexagon = object->hexagon();
     if (oldHexagon)
     {
+        if (update)
+        {
+            _hexagonGrid->initLight(oldHexagon, false);
+        }
+
         for (auto it = oldHexagon->objects()->begin(); it != oldHexagon->objects()->end(); ++it)
         {
             if (*it == object)
@@ -1032,6 +1039,10 @@ void Location::moveObjectToHexagon(Game::Object *object, Hexagon *hexagon, bool 
                     return obj1->hexagon()->number() < obj2->hexagon()->number();
                 }
         );
+        if(hexagon)
+        {
+            _hexagonGrid->initLight(hexagon, true);
+        }
     }
 
     if (auto dude = dynamic_cast<Game::DudeObject*>(object))
@@ -1193,6 +1204,14 @@ void Location::setLightLevel(unsigned int level)
     if (level>0x10000) level=0x10000;
     if (level<0x4000) level=0x4000;
     _lightLevel = level;
+}
+
+void Location::initLight()
+{
+    for (auto hex: _hexagonGrid->hexagons())
+    {
+        _hexagonGrid->initLight(hex);
+    }
 }
 }
 }

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -609,12 +609,13 @@ void Location::render()
 
 
     // just for testing
-    for (auto &object: _objects)
+    if (Game::getInstance()->settings()->targetHighlight())
     {
-        if (dynamic_cast<Game::CritterObject*>(object.get()))
-        {
-            if (!dynamic_cast<Game::DudeObject*>(object.get())) {
-                object->renderOutline(1);
+        for (auto &object: _objects) {
+            if (dynamic_cast<Game::CritterObject *>(object.get())) {
+                if (!dynamic_cast<Game::DudeObject *>(object.get())) {
+                    object->renderOutline(1);
+                }
             }
         }
     }
@@ -1054,7 +1055,7 @@ void Location::moveObjectToHexagon(Game::Object *object, Hexagon *hexagon, bool 
     {
         if (update)
         {
-            _hexagonGrid->initLight(oldHexagon, false);
+            //_hexagonGrid->initLight(oldHexagon, false);
         }
 
         for (auto it = oldHexagon->objects()->begin(); it != oldHexagon->objects()->end(); ++it)
@@ -1105,7 +1106,8 @@ void Location::moveObjectToHexagon(Game::Object *object, Hexagon *hexagon, bool 
         );
         if(hexagon)
         {
-            _hexagonGrid->initLight(hexagon, true);
+            initLight();
+            /*_hexagonGrid->initLight(hexagon, true);
             std::vector<float> lights;
             for (auto hex: _hexagonGrid->hexagons())
             {
@@ -1117,7 +1119,7 @@ void Location::moveObjectToHexagon(Game::Object *object, Hexagon *hexagon, bool 
                 float l = lightLevel/100.0;
                 lights.push_back(l);
             }
-            _lightmap->update(lights);
+            _lightmap->update(lights);*/
 
         }
     }

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -110,8 +110,8 @@ public:
     void onStateActivate(Event::State* event) override;
     void onStateDeactivate(Event::State* event) override;
 
-    unsigned short lightLevel();
-    void setLightLevel(unsigned short level);
+    unsigned int lightLevel();
+    void setLightLevel(unsigned int level);
 
     UI::PlayerPanel* playerPanel();
 
@@ -169,7 +169,7 @@ protected:
     
     std::vector<Input::Mouse::Icon> getCursorIconsForObject(Game::Object* object);
 
-    unsigned short _lightLevel = 100;
+    unsigned int _lightLevel = 0x4000;
 
 };
 

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -30,6 +30,8 @@
 #include "../UI/ImageButton.h"
 #include "../Game/Object.h"
 #include "../Game/Timer.h"
+#include <Graphics/Lightmap.h>
+
 
 // Third party includes
 
@@ -172,6 +174,7 @@ protected:
     std::vector<Input::Mouse::Icon> getCursorIconsForObject(Game::Object* object);
 
     unsigned int _lightLevel = 0x4000;
+    Falltergeist::Graphics::Lightmap* _lightmap;
 
 };
 

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -115,6 +115,8 @@ public:
 
     UI::PlayerPanel* playerPanel();
 
+    void initLight();
+
 protected:
     struct TimerEvent
     {

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -22,6 +22,7 @@
 
 // C++ standard includes
 #include <cmath>
+#include <iostream>
 
 // Falltergeist includes
 #include "../Base/StlFeatures.h"
@@ -147,7 +148,7 @@ void Animation::render(bool eggTransparency)
     Point offsetPosition = position() + shift() + frame->offset();
     _animation->trans(_trans);
     _animation->render(offsetPosition.x(), offsetPosition.y(), _direction, _currentFrame, eggTransparency, light(),
-                       _outline);
+                       _outline, _lightLevel);
 /* TODO: newrender
     auto& frame = _animationFrames.at(_currentFrame);
     Point framePos = frame->position();

--- a/src/UI/AnimationQueue.cpp
+++ b/src/UI/AnimationQueue.cpp
@@ -76,6 +76,8 @@ void AnimationQueue::setRepeat(bool value)
 
 void AnimationQueue::render(bool eggTransparency)
 {
+    currentAnimation()->setLightLevel(_lightLevel);
+    currentAnimation()->setLight(light());
     currentAnimation()->setPosition(this->position());
     currentAnimation()->render(eggTransparency);
 }

--- a/src/UI/Base.cpp
+++ b/src/UI/Base.cpp
@@ -438,5 +438,9 @@ void Base::setOutline(int outline)
 }
 
 
+void Base::setLightLevel(unsigned int level)
+{
+    _lightLevel = level;
+}
 }
 }

--- a/src/UI/Base.h
+++ b/src/UI/Base.h
@@ -112,6 +112,7 @@ public:
 
     virtual void setLight(bool light);
     virtual bool light();
+    virtual void setLightLevel(unsigned int level);
     // object translucency mode
     Falltergeist::TransFlags::Trans trans() const;
     // sets object translucency mode
@@ -137,6 +138,7 @@ protected:
                         _mouseClickHandler, _mouseDownHandler, _mouseUpHandler;
 
     int _outline = 0;
+    unsigned int _lightLevel;
 };
 
 }

--- a/src/UI/Image.cpp
+++ b/src/UI/Image.cpp
@@ -50,7 +50,7 @@ Image::~Image()
 void Image::render(bool eggTransparency)
 {
     _sprite.trans(_trans);
-    _sprite.render(position().x(),position().y(), eggTransparency, light(), _outline);
+    _sprite.render(position().x(),position().y(), eggTransparency, light(), _outline, _lightLevel);
 }
 
 Image::Image(Format::Frm::File *frm, unsigned int direction) : Falltergeist::UI::Base(), _sprite(frm)

--- a/src/VM/Handlers/Opcode80E9Handler.cpp
+++ b/src/VM/Handlers/Opcode80E9Handler.cpp
@@ -41,7 +41,22 @@ void Opcode80E9Handler::_run()
     auto level = _vm->dataStack()->popInteger();
     if (level<0) level=0;
     if (level>100) level=100;
-    Game::getInstance()->locationState()->setLightLevel(level);
+
+    unsigned int light;
+    if ( level < 50 )
+    {
+        light = 0x4000 + level * 0x6000 / 100;
+    }
+    else if ( level == 50 )
+    {
+        light = 0xA000;
+    }
+    else
+    {
+        light = 0xA000 + level * 0x6000 / 100;
+    }
+
+    Game::getInstance()->locationState()->setLightLevel(light);
 }
 
 }

--- a/src/VM/Handlers/Opcode8107Handler.cpp
+++ b/src/VM/Handlers/Opcode8107Handler.cpp
@@ -17,13 +17,10 @@
  * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// C++ standard includes
-
 // Falltergeist includes
-#include <Game/Game.h>
-#include <State/Location.h>
+#include <Game/Object.h>
 #include "../../Logger.h"
-#include "../../VM/Handlers/Opcode80E9Handler.h"
+#include "../../VM/Handlers/Opcode8107Handler.h"
 #include "../../VM/VM.h"
 
 // Third party includes
@@ -31,36 +28,30 @@
 namespace Falltergeist
 {
 
-Opcode80E9Handler::Opcode80E9Handler(VM* vm) : OpcodeHandler(vm)
+Opcode8107Handler::Opcode8107Handler(VM* vm) : OpcodeHandler(vm)
 {
 }
 
-void Opcode80E9Handler::_run()
+void Opcode8107Handler::_run()
 {
-    Logger::debug("SCRIPT") << "[80E9] [*] void set_light_level(int level)" << std::endl;
+    Logger::debug("SCRIPT") << "[8107] [*] void obj_set_light_level(Object* object, int level, int radius)" << std::endl;
+    auto object = _vm->dataStack()->popObject();
     auto level = _vm->dataStack()->popInteger();
-
+    auto radius = _vm->dataStack()->popInteger();
     if (level > 100 || level < 0)
     {
-        _warning("set_light_level: level should be 0-100");
+        _warning("obj_set_light_level: level should be 0-100");
+        return;
+    }
+    if (radius > 8 || radius < 0)
+    {
+        _warning("obj_set_light_level: radius should be 0-8");
         return;
     }
 
-    unsigned int light;
-    if ( level < 50 )
-    {
-        light = 0x4000 + level * 0x6000 / 100;
-    }
-    else if ( level == 50 )
-    {
-        light = 0xA000;
-    }
-    else
-    {
-        light = 0xA000 + level * 0x6000 / 100;
-    }
-
-    Game::getInstance()->locationState()->setLightLevel(light);
+    unsigned int light = 65536/100*level;
+    object->setLightIntensity(light);
+    object->setLightRadius(radius);
 }
 
 }

--- a/src/VM/Handlers/Opcode8107Handler.h
+++ b/src/VM/Handlers/Opcode8107Handler.h
@@ -17,50 +17,28 @@
  * along with Falltergeist.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef FALLTERGEIST_OPCODE8107HANDLER_H
+#define FALLTERGEIST_OPCODE8107HANDLER_H
+
 // C++ standard includes
 
 // Falltergeist includes
-#include <Game/Game.h>
-#include <State/Location.h>
-#include "../../Logger.h"
-#include "../../VM/Handlers/Opcode80E9Handler.h"
-#include "../../VM/VM.h"
+#include "../../VM/OpcodeHandler.h"
 
 // Third party includes
 
 namespace Falltergeist
 {
 
-Opcode80E9Handler::Opcode80E9Handler(VM* vm) : OpcodeHandler(vm)
+class Opcode8107Handler : public OpcodeHandler
 {
-}
-
-void Opcode80E9Handler::_run()
-{
-    Logger::debug("SCRIPT") << "[80E9] [*] void set_light_level(int level)" << std::endl;
-    auto level = _vm->dataStack()->popInteger();
-
-    if (level > 100 || level < 0)
-    {
-        _warning("set_light_level: level should be 0-100");
-        return;
-    }
-
-    unsigned int light;
-    if ( level < 50 )
-    {
-        light = 0x4000 + level * 0x6000 / 100;
-    }
-    else if ( level == 50 )
-    {
-        light = 0xA000;
-    }
-    else
-    {
-        light = 0xA000 + level * 0x6000 / 100;
-    }
-
-    Game::getInstance()->locationState()->setLightLevel(light);
-}
+public:
+    Opcode8107Handler(VM* vm);
+private:
+    void _run();
+};
 
 }
+
+
+#endif //FALLTERGEIST_OPCODE8107HANDLER_H

--- a/src/VM/OpcodeFactory.cpp
+++ b/src/VM/OpcodeFactory.cpp
@@ -145,6 +145,7 @@
 #include "../VM/Handlers/Opcode8102Handler.h"
 #include "../VM/Handlers/Opcode8105Handler.h"
 #include "../VM/Handlers/Opcode8106Handler.h"
+#include "../VM/Handlers/Opcode8107Handler.h"
 #include "../VM/Handlers/Opcode810AHandler.h"
 #include "../VM/Handlers/Opcode810BHandler.h"
 #include "../VM/Handlers/Opcode810CHandler.h"
@@ -335,6 +336,7 @@ std::unique_ptr<OpcodeHandler> OpcodeFactory::createOpcode(unsigned int number, 
         case 0x8102: return make_unique<Opcode8102Handler>(vm);
         case 0x8105: return make_unique<Opcode8105Handler>(vm);
         case 0x8106: return make_unique<Opcode8106Handler>(vm);
+        case 0x8107: return make_unique<Opcode8107Handler>(vm);
         case 0x810A: return make_unique<Opcode810AHandler>(vm);
         case 0x810B: return make_unique<Opcode810BHandler>(vm);
         case 0x810C: return make_unique<Opcode810CHandler>(vm);
@@ -343,7 +345,7 @@ std::unique_ptr<OpcodeHandler> OpcodeFactory::createOpcode(unsigned int number, 
         case 0x810F: return make_unique<Opcode810FHandler>(vm);
         case 0x8113: return make_unique<Opcode8113Handler>(vm);
         case 0x8115: return make_unique<Opcode8115Handler>(vm);
-        case 0x8116: return make_unique<Opcode8115Handler>(vm);
+        case 0x8116: return make_unique<Opcode8116Handler>(vm);
         case 0x8117: return make_unique<Opcode8117Handler>(vm);
         case 0x8118: return make_unique<Opcode8118Handler>(vm);
         case 0x8119: return make_unique<Opcode8119Handler>(vm);


### PR DESCRIPTION
Subj.
Original lighting (with original bugs) + op_set_light_level and op_obj_set_light_level opcodes.
Also fixed two bugs (typo in opcodes switch, and in settings for logger) and removed permanent outlining of critters (can be toggled by target_highlight ini setting for now)

Sadly, it's not color-perfect, due to gradients done by opengl, and not original conversion tables, but looks fairly close.
![screenshot009](https://cloud.githubusercontent.com/assets/273697/13715141/01f0c35a-e7e4-11e5-92e3-c04a95edd101.png)
