### PR TITLE
Fall back to "./" if platform not supported by SDL_GetBasePath()

### DIFF
--- a/src/CrossPlatform.cpp
+++ b/src/CrossPlatform.cpp
@@ -109,6 +109,11 @@ std::string CrossPlatform::getHomeDirectory()
 std::string CrossPlatform::getExecutableDirectory()
 {
     char* buffer=SDL_GetBasePath();
+    if (buffer == NULL)
+    {
+        Logger::warning() << "SDL_GetBasePath() not able to obtain a path on this platform" << std::endl;
+        return "./";
+    }
     std::string path(buffer);
     SDL_free(buffer);
     return path;
@@ -400,8 +405,8 @@ std::vector<std::string> CrossPlatform::getDataPaths()
     if(pxDir)
     {
         _dataPaths.push_back(sharedir.c_str());
+        closedir(pxDir);
     }
-    closedir(pxDir);
 #else
     _dataPaths.push_back(getConfigPath());
 #endif


### PR DESCRIPTION
This change prevents a segmentation fault on platforms where
SDL might return NULL (like OpenBSD on <=SDL2 v2.0.4).

While here make sure that closedir is only called if the directory
was actually open preventing a segmentation fault.