### PR TITLE
Call SDL_Quit on exit

### DIFF
--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -117,6 +117,8 @@ void Game::init(std::unique_ptr<Settings> settings)
     IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG);
 
     srand(time(0)); /// randomization
+
+    atexit(SDL_Quit);
 }
 
 Game::~Game()


### PR DESCRIPTION
So that in fullscreen mode the host screen resolution is restored upon exiting the game.