### PR TITLE
Precompiled header fix for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: cpp
 sudo: required
 osx_image: xcode7.3
-dist: precise
+dist: trusty
 
 script:
   - cmake .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,19 +77,24 @@ endif()
 
 file(GLOB_RECURSE SOURCES  src/*.cpp)
 
-set(CMAKE_CXX_STANDARD 14)
-if(NOT MSVC)
+if(MSVC)
+	set(_additional_includes "package/windows.rc" pchheader.cpp)
+endif()
+
+add_executable(falltergeist main.cpp ${SOURCES} ${_additional_includes})
+
+set_target_properties(falltergeist PROPERTIES
+	CXX_STANDARD 14
+	CXX_STANDARD_REQUIRED YES
+	CXX_EXTENSIONS NO
+)
+
+if(MSVC)
+	include(cmake/modules/PrecompiledHeader.cmake)
+	add_precompiled_header(falltergeist pchheader.h FORCEINCLUDE SOURCE_CXX pchheader.cpp)
+else()
 	add_definitions(-Wall)
 endif()
-
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-	add_executable(falltergeist main.cpp ${SOURCES} "package/windows.rc" pchheader.cpp)
-else()
-	add_executable(falltergeist main.cpp ${SOURCES} pchheader.cpp)
-endif()
-
-include(cmake/modules/PrecompiledHeader.cmake)
-add_precompiled_header(falltergeist pchheader.h FORCEINCLUDE SOURCE_CXX pchheader.cpp)
 
 if (CONAN_LIBS)
 	target_link_libraries(falltergeist ${CONAN_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 file(GLOB_RECURSE SOURCES  src/*.cpp)
 
 set(CMAKE_CXX_STANDARD 14)
-if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows" OR MINGW)
+if(NOT MSVC)
 	add_definitions(-Wall)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # It must be set before project
 set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build (by default Debug)")
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 project(falltergeist)
@@ -77,12 +77,9 @@ endif()
 
 file(GLOB_RECURSE SOURCES  src/*.cpp)
 
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-  if(MINGW)
-	add_definitions(-std=c++14 -Wall)
-  endif()
-else()
-    add_definitions (-std=c++14 -Wall)
+set(CMAKE_CXX_STANDARD 14)
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows" OR MINGW)
+	add_definitions(-Wall)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/cmake/modules/PrecompiledHeader.cmake
+++ b/cmake/modules/PrecompiledHeader.cmake
@@ -171,11 +171,6 @@ function(add_precompiled_header _target _input)
     set(_pch_flags_file "${_pch_binary_dir}/compile_flags.rsp")
     export_all_flags("${_pch_flags_file}")
     set(_compiler_FLAGS "@${_pch_flags_file}")
-    if(CMAKE_CXX_STANDARD EQUAL 11)
-        set(_cpp_standard_FLAG "-std=c++11")
-	elseif(CMAKE_CXX_STANDARD EQUAL 14)
-        set(_cpp_standard_FLAG "-std=c++14")
-    endif()
     add_custom_command(
       OUTPUT "${_pchfile}"
       COMMAND "${CMAKE_COMMAND}" -E copy "${_pch_header}" "${_pchfile}"
@@ -183,12 +178,12 @@ function(add_precompiled_header _target _input)
       COMMENT "Updating ${_name}")
     add_custom_command(
       OUTPUT "${_output_cxx}"
-      COMMAND "${CMAKE_CXX_COMPILER}" ${_compiler_FLAGS} ${_cpp_standard_FLAG} -x c++-header -o "${_output_cxx}" "${_pchfile}"
+      COMMAND "${CMAKE_CXX_COMPILER}" ${_compiler_FLAGS} -x c++-header -o "${_output_cxx}" "${_pchfile}"
       DEPENDS "${_pchfile}" "${_pch_flags_file}"
       COMMENT "Precompiling ${_name} for ${_target} (C++)")
     add_custom_command(
       OUTPUT "${_output_c}"
-      COMMAND "${CMAKE_C_COMPILER}" ${_compiler_FLAGS} ${_cpp_standard_FLAG} -x c-header -o "${_output_c}" "${_pchfile}"
+      COMMAND "${CMAKE_C_COMPILER}" ${_compiler_FLAGS} -x c-header -o "${_output_c}" "${_pchfile}"
       DEPENDS "${_pchfile}" "${_pch_flags_file}"
       COMMENT "Precompiling ${_name} for ${_target} (C)")
 

--- a/cmake/modules/PrecompiledHeader.cmake
+++ b/cmake/modules/PrecompiledHeader.cmake
@@ -171,6 +171,11 @@ function(add_precompiled_header _target _input)
     set(_pch_flags_file "${_pch_binary_dir}/compile_flags.rsp")
     export_all_flags("${_pch_flags_file}")
     set(_compiler_FLAGS "@${_pch_flags_file}")
+    if(CMAKE_CXX_STANDARD EQUAL 11)
+        set(_cpp_standard_FLAG "-std=c++11")
+	elseif(CMAKE_CXX_STANDARD EQUAL 14)
+        set(_cpp_standard_FLAG "-std=c++14")
+    endif()
     add_custom_command(
       OUTPUT "${_pchfile}"
       COMMAND "${CMAKE_COMMAND}" -E copy "${_pch_header}" "${_pchfile}"
@@ -178,12 +183,12 @@ function(add_precompiled_header _target _input)
       COMMENT "Updating ${_name}")
     add_custom_command(
       OUTPUT "${_output_cxx}"
-      COMMAND "${CMAKE_CXX_COMPILER}" ${_compiler_FLAGS} -x c++-header -o "${_output_cxx}" "${_pchfile}"
+      COMMAND "${CMAKE_CXX_COMPILER}" ${_compiler_FLAGS} ${_cpp_standard_FLAG} -x c++-header -o "${_output_cxx}" "${_pchfile}"
       DEPENDS "${_pchfile}" "${_pch_flags_file}"
       COMMENT "Precompiling ${_name} for ${_target} (C++)")
     add_custom_command(
       OUTPUT "${_output_c}"
-      COMMAND "${CMAKE_C_COMPILER}" ${_compiler_FLAGS} -x c-header -o "${_output_c}" "${_pchfile}"
+      COMMAND "${CMAKE_C_COMPILER}" ${_compiler_FLAGS} ${_cpp_standard_FLAG} -x c-header -o "${_output_c}" "${_pchfile}"
       DEPENDS "${_pchfile}" "${_pch_flags_file}"
       COMMENT "Precompiling ${_name} for ${_target} (C)")
 

--- a/pchheader.h
+++ b/pchheader.h
@@ -8,4 +8,4 @@
 #include <unordered_map>
 #include <vector>
 
-#include "src/Logger.h"
+#include "Logger.h"


### PR DESCRIPTION
Fixed precompiled header compilation on linux with gcc;
Updated travis build to newer machine;
Replaced -std=  flags with CMAKE_CXX_STANDARD variable;
Updated minimum CMake version to 3.1