### PR TITLE
Use two worker threads to build code on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: precise
 
 script:
   - cmake .
-  - make
+  - make -j2
 
 compiler:
   - clang


### PR DESCRIPTION
Travis-CI offers up to 2 cores on worker nodes[1], make use of both of them.

[1] https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments