### PR TITLE
Fix the Player Panel offset

### DIFF
--- a/src/UI/PlayerPanel.cpp
+++ b/src/UI/PlayerPanel.cpp
@@ -62,8 +62,8 @@ PlayerPanel::PlayerPanel() : UI::Base()
     _background = std::make_shared<Image>("art/intrface/iface.frm");
     _ui.push_back(_background);
 
-    setX((renderer->width() - 640) / 2);
-    setY(renderer->height() - _background->height());
+    setX((renderer->width() - 640) / 2-1);
+    setY(renderer->height() - _background->height()+1);
 
     _background->setPosition(this->position());
 


### PR DESCRIPTION
Fixes the player panel offset.

the same should be done for doors(not sure if this actually counts for all scenery objects or only door objects, this also explains the difficulty selecting the door to Slim to get to the mine)

for game objects would probably to override _generateUi as it seems input is also offset by the same amount(need to find out if its only doors or all scenery objects that are offset