### PR TITLE
Seems like the && is an error

### DIFF
--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -336,7 +336,7 @@ void Object::render()
 bool Object::_isIntersectsWithEgg()
 {
     //only walls and scenery are affected by egg
-    if (_type != Type::WALL && _type !=Type::SCENERY)
+    if (_type != Type::WALL || _type !=Type::SCENERY)
     {
         return false;
     }


### PR DESCRIPTION
objects can't be Wall and Scenery at the same time it should return false instantly, this makes check faster if it's wall, else it will check both. instead of checking both every time