### PR TITLE
Remove manual memory management in Format classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# top-most EditorConfig file
+root = true
+
+[*.{h,cpp}]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/pchheader.h
+++ b/pchheader.h
@@ -1,5 +1,7 @@
 #include <algorithm>
 #include <array>
+#include <cmath>
+#include <cstdint>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -10,4 +12,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Base/Buffer.h"
+#include "Base/Delegate.h"
+#include "Base/Iterators.h"
+#include "Base/Singleton.h"
 #include "Logger.h"

--- a/src/Base/Buffer.h
+++ b/src/Base/Buffer.h
@@ -20,6 +20,9 @@
 #ifndef FALLTERGEIST_BASE_BUFFER_H
 #define FALLTERGEIST_BASE_BUFFER_H
 
+// C++ standard includes
+#include <cstddef>
+
 namespace Falltergeist
 {
 namespace Base

--- a/src/Base/Buffer.h
+++ b/src/Base/Buffer.h
@@ -27,9 +27,10 @@ namespace Base
 
 // A thin wrapper over plain C-array.
 // Handles allocation and deallocation of the underlying buffer.
-// Does not perform any kind of initialization allocated of data.
+// Does not perform any kind of initialization of allocated memory.
 template <typename T>
-class Buffer {
+class Buffer
+{
 public:
     // Creates new empty buffer
     Buffer<T>() : _size(0), _buf(nullptr)
@@ -52,9 +53,7 @@ public:
     // Move-assigns buffer pointer from another Buffer object
     Buffer<T>& operator= (Buffer<T>&& other)
     {
-        if (_buf != nullptr) {
-            delete[] _buf;
-        }
+        _cleanUpBuffer();
         _size = other._size;
         _buf = other._buf;
         other._size = 0;
@@ -67,22 +66,42 @@ public:
 
     ~Buffer<T>()
     {
-        if (_buf != nullptr) {
-            delete[] _buf;
-        }
+        _cleanUpBuffer();
+    }
+
+    // Access element at a given index. No bounds checking is performed.
+    T& operator[] (size_t index)
+    {
+        return _buf[index];
+    }
+
+    // Access element at a given index. No bounds checking is performed.
+    const T& operator[] (size_t index) const
+    {
+        return _buf[index];
+    }
+
+    T* begin()
+    {
+        return &_buf[0];
+    }
+
+    T* end() {
+        return &_buf[_size];
     }
 
     // Reallocate the underlying buffer to the specified size
     // All data in buffer will be discarded
     void resize(size_t newSize)
     {
-        if (_buf != nullptr) {
-            delete[] _buf;
-        }
+        _cleanUpBuffer();
         _size = newSize;
-        if (newSize > 0) {
+        if (newSize > 0)
+        {
             _buf = new T[newSize];
-        } else {
+        }
+        else
+        {
             _buf = nullptr;
         }
     }
@@ -114,6 +133,14 @@ public:
 private:
     size_t _size;
     T* _buf;
+
+    void _cleanUpBuffer()
+    {
+        if (_buf != nullptr)
+        {
+            delete[] _buf;
+        }
+    }
 };
 
 }

--- a/src/Format/Aaf/File.cpp
+++ b/src/Format/Aaf/File.cpp
@@ -61,25 +61,18 @@ File::File(Dat::Stream&& stream)
             _maximumWidth = width;
         }
 
-        _glyphs.push_back(new Glyph(width, height));
-        _glyphs.back()->setDataOffset(offset);
+        _glyphs.push_back(Glyph(width, height));
+        _glyphs.back().setDataOffset(offset);
     }
 
     _loadRgba(stream);
-}
-
-File::~File() {
-    for (auto glyph : _glyphs) {
-        delete glyph;
-    }
-    delete[] _rgba;
 }
 
 void File::_loadRgba(Dat::Stream& stream)
 {
     //_rgba = new uint32_t[_maximumWidth * _maximumHeight * 256]();
     // leave 1 px around glyph
-    _rgba = new uint32_t[((_maximumWidth+2)*16) * ((_maximumHeight+2) * 16)]();
+    _rgba.resize((_maximumWidth + 2) * 16 * (_maximumHeight + 2) * 16);
 
     for (unsigned i = 0; i != 256; ++i)
     {
@@ -87,13 +80,13 @@ void File::_loadRgba(Dat::Stream& stream)
         uint32_t glyphX = (i%16) * _maximumWidth+(i%16)*2+1;
 
         // Move glyph to bottom
-        glyphY += _maximumHeight - _glyphs.at(i)->height();
+        glyphY += _maximumHeight - _glyphs.at(i).height();
 
-        stream.setPosition(0x080C + _glyphs.at(i)->dataOffset());
+        stream.setPosition(0x080C + _glyphs.at(i).dataOffset());
 
-        for (uint16_t y = 0; y != _glyphs.at(i)->height(); ++y)
+        for (uint16_t y = 0; y != _glyphs.at(i).height(); ++y)
         {
-            for (uint16_t x = 0; x != _glyphs.at(i)->width(); ++x)
+            for (uint16_t x = 0; x != _glyphs.at(i).width(); ++x)
             {
                 uint8_t byte = stream.uint8();
                 if (byte != 0)
@@ -132,13 +125,14 @@ void File::_loadRgba(Dat::Stream& stream)
     }
 }
 
-uint32_t* File::rgba() {
-    return _rgba;
+uint32_t* File::rgba()
+{
+    return _rgba.data();
 }
 
-std::vector<Glyph*>* File::glyphs()
+const std::vector<Glyph>& File::glyphs() const
 {
-    return &_glyphs;
+    return _glyphs;
 }
 
 uint16_t File::horizontalGap() const

--- a/src/Format/Aaf/File.h
+++ b/src/Format/Aaf/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -32,7 +32,6 @@
 #include <vector>
 
 // Falltergeist includes
-#include "../../Base/Buffer.h"
 #include "../../Format/Dat/Item.h"
 
 // Third party includes
@@ -74,7 +73,7 @@ protected:
     uint16_t _horizontalGap = 0;
     uint16_t _spaceWidth = 0;
     uint16_t _verticalGap = 0;
-    Base::Buffer<uint32_t> _rgba;
+    std::vector<uint32_t> _rgba;
 
     void _loadRgba(Dat::Stream& stream);
 };

--- a/src/Format/Aaf/File.h
+++ b/src/Format/Aaf/File.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 // Falltergeist includes
+#include "../../Base/Buffer.h"
 #include "../../Format/Dat/Item.h"
 
 // Third party includes
@@ -54,11 +55,10 @@ class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    ~File();
 
     uint32_t* rgba();
 
-    std::vector<Glyph*>* glyphs();
+    const std::vector<Glyph>& glyphs() const;
 
     uint16_t maximumHeight() const;
     uint16_t maximumWidth() const;
@@ -67,14 +67,14 @@ public:
     uint16_t spaceWidth() const;
 
 protected:
-    std::vector<Glyph*> _glyphs;
+    std::vector<Glyph> _glyphs;
     uint32_t _signature;
     uint16_t _maximumHeight = 0;
     uint16_t _maximumWidth = 0;
     uint16_t _horizontalGap = 0;
     uint16_t _spaceWidth = 0;
     uint16_t _verticalGap = 0;
-    uint32_t* _rgba = 0;
+    Base::Buffer<uint32_t> _rgba;
 
     void _loadRgba(Dat::Stream& stream);
 };

--- a/src/Format/Aaf/File.h
+++ b/src/Format/Aaf/File.h
@@ -32,6 +32,7 @@
 #include <vector>
 
 // Falltergeist includes
+#include "../../Format/Aaf/Glyph.h"
 #include "../../Format/Dat/Item.h"
 
 // Third party includes
@@ -47,8 +48,6 @@ class Stream;
 
 namespace Aaf
 {
-
-class Glyph;
 
 class File : public Dat::Item
 {

--- a/src/Format/Acm/File.cpp
+++ b/src/Format/Acm/File.cpp
@@ -115,7 +115,7 @@ int32_t File::_makeNewSamples()
     return 1;
 }
 
-size_t File::readSamples(short* buffer, size_t count)
+size_t File::readSamples(uint16_t* buffer, size_t count)
 {
     size_t res = 0;
     while (res < count) {

--- a/src/Format/Acm/File.cpp
+++ b/src/Format/Acm/File.cpp
@@ -88,6 +88,10 @@ File::File(Dat::Stream&& stream) : _stream(std::move(stream))
     }
 }
 
+File::~File()
+{
+}
+
 void File::rewind()
 {
     _stream.setPosition(HEADER_SIZE);

--- a/src/Format/Acm/File.cpp
+++ b/src/Format/Acm/File.cpp
@@ -74,7 +74,7 @@ File::File(Dat::Stream&& stream) : _stream(std::move(stream))
     _bitrate = hdr.rate;
     _blockSize = ( 1 << _levels) * _subblocks;
 
-    _block = (int32_t *) malloc(sizeof(int32_t)* _blockSize);
+    _block.resize(_blockSize);
 
     _unpacker = std::make_unique<ValueUnpacker>(_levels, _subblocks, &_stream);
     if (!_unpacker || !_unpacker->init())
@@ -88,13 +88,6 @@ File::File(Dat::Stream&& stream) : _stream(std::move(stream))
     }
 }
 
-File::~File() {
-    if (_block != nullptr) {
-        free(_block);
-        _block = nullptr;
-    }
-}
-
 void File::rewind()
 {
     _stream.setPosition(HEADER_SIZE);
@@ -103,13 +96,15 @@ void File::rewind()
 
 int32_t File::_makeNewSamples()
 {
-    if (!_unpacker->getOneBlock(_block))
+    // TODO: maybe use fixed-size ints in Unpacker?
+    if (!_unpacker->getOneBlock(reinterpret_cast<int*>(_block.data())))
     {
         // FIXME: is it an error or the end of the stream?
         return 0;
     }
-    _decoder->decodeData(_block, _subblocks);
-    _values = _block;
+    // TODO: maybe use fixed-size ints in Decoder?
+    _decoder->decodeData(reinterpret_cast<int*>(_block.data()), _subblocks);
+    _values = _block.data();
     _samplesReady = ( _blockSize > _samplesLeft) ? _samplesLeft : _blockSize;
     _samplesLeft -= _samplesReady;
     return 1;
@@ -125,7 +120,7 @@ size_t File::readSamples(uint16_t* buffer, size_t count)
             if (!_makeNewSamples())
                 break;
         }
-        *buffer = ( short ) ( ( *_values) >> _levels);
+        *buffer = ( short ) ( (*_values) >> _levels);
         _values++;
         buffer++;
         res += 1;

--- a/src/Format/Acm/File.h
+++ b/src/Format/Acm/File.h
@@ -40,13 +40,14 @@ namespace Format
 namespace Acm
 {
 
-class ValueUnpacker;
 class Decoder;
+class ValueUnpacker;
 
 class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
+    ~File();
 
     void init();
     void rewind();

--- a/src/Format/Acm/File.h
+++ b/src/Format/Acm/File.h
@@ -26,6 +26,7 @@
 #define FALLTERGEIST_FORMAT_ACM_FILE_H
 
 // C++ standard includes
+#include <cstdint>
 
 // Falltergeist includes
 #include "../Dat/Item.h"
@@ -53,7 +54,7 @@ public:
     int channels() const;
     int bitrate() const;
 
-    size_t readSamples(short* buffer, size_t count);
+    size_t readSamples(uint16_t* buffer, size_t count);
 
     int samplesLeft() const;
 

--- a/src/Format/Acm/File.h
+++ b/src/Format/Acm/File.h
@@ -29,6 +29,7 @@
 #include <cstdint>
 
 // Falltergeist includes
+#include "../../Base/Buffer.h"
 #include "../Dat/Item.h"
 #include "../Dat/Stream.h"
 
@@ -46,7 +47,7 @@ class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    ~File();
+
     void init();
     void rewind();
 
@@ -58,19 +59,20 @@ public:
 
     int samplesLeft() const;
 
-protected:
+private:
     Dat::Stream _stream;
     int _samplesLeft; // count of unread samples
     int _levels, _subblocks;
     int _blockSize;
-    int* _block = nullptr;
-    int* _values = nullptr;
+    Base::Buffer<uint32_t> _block;
+    uint32_t* _values;
     int _samplesReady;
     std::unique_ptr<ValueUnpacker> _unpacker; // ACM-stream unpacker
     std::unique_ptr<Decoder> _decoder; // IP's subband decoder
     int _samples; // total count of sound samples
     int _channels;
     int _bitrate;
+
     int _makeNewSamples();
 };
 

--- a/src/Format/Acm/Unpacker.cpp
+++ b/src/Format/Acm/Unpacker.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -107,7 +107,7 @@ inline void ValueUnpacker::_prepareBits(int bits)
         unsigned char one_byte;
         if (_bufferBitOffset == UNPACKER_BUFFER_SIZE)
         {
-            unsigned long remains = stream->bytesRemains();
+            auto remains = stream->bytesRemains();
             if (remains > UNPACKER_BUFFER_SIZE)
                 remains = UNPACKER_BUFFER_SIZE;
             _bufferBitOffset = UNPACKER_BUFFER_SIZE - remains;

--- a/src/Format/Acm/Unpacker.h
+++ b/src/Format/Acm/Unpacker.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -85,7 +85,7 @@ protected:
     unsigned int _nextBits; // new bits
     int _availBits; // count of new bits
     unsigned char _bitsBuffer[UNPACKER_BUFFER_SIZE];
-    unsigned int _bufferBitOffset;
+    size_t _bufferBitOffset;
 
     int _sbSize;
     short *_ampBuffer, *_buffMiddle;

--- a/src/Format/Dat/Stream.h
+++ b/src/Format/Dat/Stream.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -59,13 +59,13 @@ public:
 
     virtual std::streambuf::int_type underflow();
 
-    Stream& readBytes(uint8_t* destination, uint32_t size);
-    Stream& skipBytes(unsigned int numberOfBytes);
-    Stream& setPosition(unsigned int position);
-    uint32_t position();
-    uint32_t size();
+    Stream& readBytes(uint8_t* destination, size_t size);
+    Stream& skipBytes(size_t numberOfBytes);
+    Stream& setPosition(size_t position);
+    size_t position() const;
+    size_t size() const;
 
-    unsigned int bytesRemains();
+    size_t bytesRemains();
 
     ENDIANNESS endianness();
     void setEndianness(ENDIANNESS value);
@@ -85,11 +85,8 @@ public:
     Stream& operator>>(int8_t &value);
 
 private:
-    Base::Buffer<uint8_t> _buffer;
-    int32_t _size;
+    Base::Buffer<char> _buffer;
     ENDIANNESS _endianness = ENDIANNESS::BIG;
-
-    char* _rawBuffer();
 };
 
 }

--- a/src/Format/Fon/File.cpp
+++ b/src/Format/Fon/File.cpp
@@ -40,7 +40,8 @@ namespace Format
 namespace Fon
 {
 
-File::File(Dat::Stream&& stream) {
+File::File(Dat::Stream&& stream)
+{
     stream.setPosition(0);
 
     _numchars = stream.uint32();
@@ -58,25 +59,18 @@ File::File(Dat::Stream&& stream) {
         {
             _maximumWidth = width;
         }
-        _glyphs.push_back(new Glyph(width, _maximumHeight));
-        _glyphs.back()->setDataOffset(offset);
+        _glyphs.push_back(Glyph(width, _maximumHeight));
+        _glyphs.back().setDataOffset(offset);
     }
 
-    _spaceWidth = _glyphs.at(0x20)->width();
+    _spaceWidth = _glyphs.at(0x20).width();
 
     _loadRgba(stream);
 }
 
-File::~File() {
-    for (auto glyph : _glyphs) {
-        delete glyph;
-    }
-    delete[] _rgba;
-}
-
 void File::_loadRgba(Dat::Stream& stream)
 {
-    _rgba = new uint32_t[(_maximumWidth+2)*16 * (_maximumHeight+2) * 16]();
+    _rgba.resize((_maximumWidth + 2) * 16 * (_maximumHeight + 2) * 16);
 
     for (unsigned int i=0; i < _numchars; i++)
     {
@@ -84,15 +78,15 @@ void File::_loadRgba(Dat::Stream& stream)
         uint32_t glyphX = (i%16) * _maximumWidth+(i%16)*2+1;
 
         // Move glyph to bottom
-        glyphY += _maximumHeight - _glyphs.at(i)->height();
+        glyphY += _maximumHeight - _glyphs.at(i).height();
 
-        if (_maximumHeight * _glyphs.at(i)->width() != 0)
+        if (_maximumHeight * _glyphs.at(i).width() != 0)
         {
-            uint32_t offset = _glyphs.at(i)->dataOffset();
-            uint32_t bytesPerLine = (_glyphs.at(i)->width() + 7) / 8;
+            uint32_t offset = _glyphs.at(i).dataOffset();
+            uint32_t bytesPerLine = (_glyphs.at(i).width() + 7) / 8;
             for (unsigned int y = 0; y < _maximumHeight; y++)
             {
-                for (unsigned int x = 0; x < _glyphs.at(i)->width(); x++)
+                for (unsigned int x = 0; x < _glyphs.at(i).width(); x++)
                 {
                     // [offset + y * bytesPerLine + (x / 8)]
                     stream.setPosition(0x0414+offset + y * bytesPerLine + (x / 8));
@@ -113,13 +107,14 @@ void File::_loadRgba(Dat::Stream& stream)
     }
 }
 
-uint32_t* File::rgba() {
-    return _rgba;
+uint32_t* File::rgba()
+{
+    return _rgba.data();
 }
 
-std::vector<Glyph *>* File::glyphs()
+const std::vector<Glyph>& File::glyphs() const
 {
-    return &_glyphs;
+    return _glyphs;
 }
 
 uint32_t File::maximumHeight() const

--- a/src/Format/Fon/File.h
+++ b/src/Format/Fon/File.h
@@ -30,6 +30,7 @@
 
 // Falltergeist includes
 #include "../Dat/Item.h"
+#include "../Fon/Glyph.h"
 
 // Third party includes
 
@@ -44,8 +45,6 @@ class Stream;
 
 namespace Fon
 {
-
-class Glyph;
 
 class File : public Dat::Item
 {

--- a/src/Format/Fon/File.h
+++ b/src/Format/Fon/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2016 Falltergeist developers
@@ -29,7 +29,6 @@
 #include <vector>
 
 // Falltergeist includes
-#include "../../Base/Buffer.h"
 #include "../Dat/Item.h"
 
 // Third party includes
@@ -70,7 +69,7 @@ protected:
     uint32_t _horizontalGap = 0;
     uint32_t _spaceWidth = 0;
     uint32_t _verticalGap = 0;
-    Base::Buffer<uint32_t> _rgba;
+    std::vector<uint32_t> _rgba;
     uint32_t _numchars;
 
     void _loadRgba(Dat::Stream& stream);

--- a/src/Format/Fon/File.h
+++ b/src/Format/Fon/File.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 // Falltergeist includes
+#include "../../Base/Buffer.h"
 #include "../Dat/Item.h"
 
 // Third party includes
@@ -52,11 +53,9 @@ class File : public Dat::Item
 
 public:
     File(Dat::Stream&& stream);
-    ~File() override;
     uint32_t* rgba();
 
-    // TODO: return by reference
-    std::vector<Glyph*>* glyphs();
+    const std::vector<Glyph>& glyphs() const;
 
     uint32_t maximumHeight() const;
     uint32_t maximumWidth() const;
@@ -64,17 +63,16 @@ public:
     uint32_t verticalGap() const;
     uint32_t spaceWidth() const;
 
-
 protected:
-    // TODO: replace with vector of objects
-    std::vector<Glyph*> _glyphs;
+    std::vector<Glyph> _glyphs;
     uint32_t _maximumHeight = 0;
     uint32_t _maximumWidth = 0;
     uint32_t _horizontalGap = 0;
     uint32_t _spaceWidth = 0;
     uint32_t _verticalGap = 0;
-    uint32_t* _rgba = 0;
+    Base::Buffer<uint32_t> _rgba;
     uint32_t _numchars;
+
     void _loadRgba(Dat::Stream& stream);
 };
 

--- a/src/Format/Fon/Glyph.cpp
+++ b/src/Format/Fon/Glyph.cpp
@@ -36,13 +36,7 @@ namespace Format
 namespace Fon
 {
 
-
-Glyph::Glyph(uint32_t width, uint32_t height)
-{
-
-}
-
-Glyph::~Glyph()
+Glyph::Glyph(uint32_t width, uint32_t height) : _width(width), _height(height)
 {
 }
 

--- a/src/Format/Fon/Glyph.h
+++ b/src/Format/Fon/Glyph.h
@@ -28,10 +28,10 @@
 // C++ standard includes
 #include <vector>
 #include <cstdint>
+
 // Falltergeist includes
 
 // Third party includes
-
 
 
 namespace Falltergeist
@@ -45,7 +45,6 @@ class Glyph
 {
 public:
     Glyph(uint32_t width, uint32_t height);
-    ~Glyph();
 
     uint32_t width() const;
     void setWidth(uint32_t width);

--- a/src/Format/Frm/Direction.cpp
+++ b/src/Format/Frm/Direction.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -38,18 +38,6 @@ namespace Format
 namespace Frm
 {
 
-Direction::Direction()
-{
-}
-
-Direction::~Direction()
-{
-    for (auto frame : _frames)
-    {
-        delete frame;
-    }
-}
-
 int16_t Direction::shiftX() const
 {
     return _shiftX;
@@ -77,22 +65,20 @@ uint32_t Direction::dataOffset() const
 
 uint16_t Direction::width() const
 {
-    std::vector<uint16_t> widths;
-    for (auto frame : _frames)
-    {
-        widths.push_back(frame->width()+2);
-    }
-    return static_cast<uint16_t>((*std::max_element(widths.begin(), widths.end())) * _frames.size());
+    auto widest = std::max_element(_frames.begin(), _frames.end(), [](const Frame& a, const Frame& b) {
+        return a.width() < b.width();
+    });
+
+    return static_cast<uint16_t>((widest->width() + 2) * _frames.size());
 }
 
 uint16_t Direction::height() const
 {
-    std::vector<uint16_t> heights;
-    for (auto frame : _frames)
+    auto tallest = std::max_element(_frames.begin(), _frames.end(), [](const Frame& a, const Frame& b)
     {
-        heights.push_back(frame->height()+2);
-    }
-    return *std::max_element(heights.begin(), heights.end());
+        return a.height() < b.height();
+    });
+    return tallest->height() + 2;
 }
 
 void Direction::setDataOffset(uint32_t value)
@@ -100,9 +86,14 @@ void Direction::setDataOffset(uint32_t value)
     _dataOffset = value;
 }
 
-std::vector<Frame*>* Direction::frames()
+std::vector<Frame>& Direction::frames()
 {
-    return &_frames;
+    return _frames;
+}
+
+const std::vector<Frame>& Direction::frames() const
+{
+    return _frames;
 }
 
 }

--- a/src/Format/Frm/Direction.h
+++ b/src/Format/Frm/Direction.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -41,13 +41,10 @@ namespace Frm
 {
 class Frame;
 
-class Direction      
+class Direction
 {
 
 public:
-    Direction();
-    ~Direction();
-
     int16_t shiftX() const;
     void setShiftX(int16_t value);
 
@@ -60,13 +57,14 @@ public:
     uint16_t width() const;
     uint16_t height() const;
 
-    std::vector<Frame*>* frames();
+    std::vector<Frame>& frames();
+    const std::vector<Frame>& frames() const;
 
 protected:
     int16_t _shiftX = 0;
     int16_t _shiftY = 0;
     uint32_t _dataOffset = 0;
-    std::vector<Frame*> _frames;
+    std::vector<Frame> _frames;
 
 };
 

--- a/src/Format/Frm/Direction.h
+++ b/src/Format/Frm/Direction.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 // Falltergeist includes
+#include "../Frm/Frame.h"
 
 // Third party includes
 
@@ -39,7 +40,6 @@ namespace Format
 {
 namespace Frm
 {
-class Frame;
 
 class Direction
 {
@@ -49,6 +49,7 @@ public:
     Direction(const Direction&) = delete;
     Direction& operator= (const Direction&) = delete;
     Direction& operator= (Direction&&) = default;
+    ~Direction() = default;
 
     int16_t shiftX() const;
     void setShiftX(int16_t value);

--- a/src/Format/Frm/Direction.h
+++ b/src/Format/Frm/Direction.h
@@ -43,8 +43,13 @@ class Frame;
 
 class Direction
 {
-
 public:
+    Direction() = default;
+    Direction(Direction&&) = default;
+    Direction(const Direction&) = delete;
+    Direction& operator= (const Direction&) = delete;
+    Direction& operator= (Direction&&) = default;
+
     int16_t shiftX() const;
     void setShiftX(int16_t value);
 

--- a/src/Format/Frm/File.cpp
+++ b/src/Format/Frm/File.cpp
@@ -72,7 +72,7 @@ File::File(Dat::Stream&& stream)
     }
 
     // for each direction
-    for (auto direction : _directions)
+    for (auto& direction : _directions)
     {
         // jump to frames data at frames area
         stream.setPosition(direction.dataOffset() + 62);

--- a/src/Format/Frm/File.h
+++ b/src/Format/Frm/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -30,7 +30,9 @@
 #include <vector>
 
 // Falltergeist includes
+#include "../../Base/Buffer.h"
 #include "../Dat/Item.h"
+#include "../Frm/Direction.h"
 #include "../Enums.h"
 
 // Third party includes
@@ -55,7 +57,6 @@ class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    ~File();
 
     uint32_t version() const;
     uint16_t framesPerSecond() const;
@@ -70,20 +71,19 @@ public:
     int16_t offsetY(unsigned int direction = 0, unsigned int frame = 0) const;
 
     uint32_t* rgba(Pal::File* palFile);
-    std::vector<bool>* mask(Pal::File* palFile);
+    std::vector<bool>& mask(Pal::File* palFile);
 
-    std::vector<Direction*>* directions();
+    const std::vector<Direction>& directions() const;
 
 protected:
-    // TODO: use vector
-    uint32_t* _rgba = 0;
+    Base::Buffer<uint32_t> _rgba;
     uint32_t _version = 0;
     uint16_t _framesPerSecond = 0;
     uint16_t _framesPerDirection = 0;
     uint16_t _actionFrame = 0;
     bool _animatedPalette = false;
-    // TODO: replace with vector of objects
-    std::vector<Direction*> _directions;
+
+    std::vector<Direction> _directions;
     std::vector<bool> _mask;
 };
 

--- a/src/Format/Frm/File.h
+++ b/src/Format/Frm/File.h
@@ -30,7 +30,6 @@
 #include <vector>
 
 // Falltergeist includes
-#include "../../Base/Buffer.h"
 #include "../Dat/Item.h"
 #include "../Frm/Direction.h"
 #include "../Enums.h"
@@ -76,7 +75,7 @@ public:
     const std::vector<Direction>& directions() const;
 
 protected:
-    Base::Buffer<uint32_t> _rgba;
+    std::vector<uint32_t> _rgba;
     uint32_t _version = 0;
     uint16_t _framesPerSecond = 0;
     uint16_t _framesPerDirection = 0;

--- a/src/Format/Frm/Frame.cpp
+++ b/src/Format/Frm/Frame.cpp
@@ -36,28 +36,10 @@ namespace Format
 namespace Frm
 {
 
-Frame::Frame(uint16_t width, uint16_t height)
+Frame::Frame(uint16_t width, uint16_t height) : _indexes(width * height, 0)
 {
     _width = width;
     _height = height;
-
-    for (unsigned i = 0; i != (unsigned)_width*_height; ++i)
-    {
-        _indexes.push_back(0);
-    }
-}
-
-Frame::Frame(const Frame& other)
-{
-    _width = other._width;
-    _height = other._height;
-    _offsetX = other._offsetX;
-    _offsetY = other._offsetY;
-    _indexes = other._indexes;
-}
-
-Frame::~Frame()
-{
 }
 
 uint16_t Frame::width() const
@@ -90,11 +72,6 @@ void Frame::setOffsetY(int16_t value)
     _offsetY = value;
 }
 
-const std::vector<uint8_t>* Frame::indexes() const
-{
-    return &_indexes;
-}
-
 uint8_t Frame::index(uint16_t x, uint16_t y) const
 {
     if (x >= _width || y >= _height) return 0;
@@ -102,11 +79,9 @@ uint8_t Frame::index(uint16_t x, uint16_t y) const
     return _indexes.at(_width*y + x);
 }
 
-void Frame::setIndex(uint16_t x, uint16_t y, uint8_t index)
+uint8_t* Frame::data()
 {
-    if (x >= _width || y >= _height) return;
-
-    _indexes.at(_width*y + x) = index;
+    return _indexes.data();
 }
 
 }

--- a/src/Format/Frm/Frame.cpp
+++ b/src/Format/Frm/Frame.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers

--- a/src/Format/Frm/Frame.h
+++ b/src/Format/Frm/Frame.h
@@ -45,8 +45,7 @@ class Frame
 
 public:
     Frame(uint16_t width, uint16_t height);
-    Frame(const Frame& other);
-    ~Frame();
+    Frame(const Frame& other) = default;
 
     uint16_t width() const;
     uint16_t height() const;
@@ -57,10 +56,9 @@ public:
     int16_t offsetY() const;
     void setOffsetY(int16_t value);
 
-    const std::vector<uint8_t>* indexes() const;
-
     uint8_t index(uint16_t x, uint16_t y) const;
-    void setIndex(uint16_t x, uint16_t y, uint8_t index);
+
+    uint8_t* data();
 
 protected:
     uint16_t _width = 0;

--- a/src/Format/Frm/Frame.h
+++ b/src/Format/Frm/Frame.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -42,10 +42,10 @@ namespace Frm
 
 class Frame
 {
-
 public:
     Frame(uint16_t width, uint16_t height);
     Frame(const Frame& other) = default;
+    Frame& operator= (const Frame&) = delete;
 
     uint16_t width() const;
     uint16_t height() const;

--- a/src/Format/Frm/Frame.h
+++ b/src/Format/Frm/Frame.h
@@ -43,9 +43,13 @@ namespace Frm
 class Frame
 {
 public:
+    Frame() = default;
     Frame(uint16_t width, uint16_t height);
-    Frame(const Frame& other) = default;
+    Frame(const Frame& other) = delete;
+    Frame(Frame&& other) = default;
     Frame& operator= (const Frame&) = delete;
+    Frame& operator= (Frame&&) = default;
+    ~Frame() = default;
 
     uint16_t width() const;
     uint16_t height() const;

--- a/src/Format/Int/File.cpp
+++ b/src/Format/Int/File.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -39,7 +39,8 @@ namespace Format
 namespace Int
 {
 
-File::File(Dat::Stream&& stream) : _stream(std::move(stream)) {
+File::File(Dat::Stream&& stream) : _stream(std::move(stream))
+{
     _stream.setPosition(0);
 
     // Initialization code goes here
@@ -52,19 +53,18 @@ File::File(Dat::Stream&& stream) : _stream(std::move(stream)) {
 
     for (unsigned i = 0; i != proceduresCount; ++i)
     {
-        auto procedure = new Procedure();
+        _procedures.emplace_back();
+        auto& procedure = _procedures.back();
 
         procedureNameOffsets.push_back(_stream.uint32());
-        procedure->setFlags(_stream.uint32());
-        procedure->setDelay(_stream.uint32());
-        procedure->setConditionOffset(_stream.uint32());
-        procedure->setBodyOffset(_stream.uint32());
-        procedure->setArgumentsCounter(_stream.uint32());
-
-        _procedures.push_back(procedure);
+        procedure.setFlags(_stream.uint32());
+        procedure.setDelay(_stream.uint32());
+        procedure.setConditionOffset(_stream.uint32());
+        procedure.setBodyOffset(_stream.uint32());
+        procedure.setArgumentsCounter(_stream.uint32());
     }
 
-    // Identificators table
+    // Identifiers table
     uint32_t tableSize = _stream.uint32();
     unsigned j = 0;
     while (j < tableSize)
@@ -87,7 +87,7 @@ File::File(Dat::Stream&& stream) : _stream(std::move(stream)) {
 
     for (unsigned i = 0; i != procedureNameOffsets.size(); ++i)
     {
-        _procedures.at(i)->setName(_identifiers.at(procedureNameOffsets.at(i)));
+        _procedures.at(i).setName(_identifiers.at(procedureNameOffsets.at(i)));
     }
 
     // STRINGS TABLE
@@ -112,33 +112,27 @@ File::File(Dat::Stream&& stream) : _stream(std::move(stream)) {
     }
 }
 
-File::~File() {
-    for (auto procedure : _procedures) {
-        delete procedure;
-    }
-}
-
-std::map<unsigned int, std::string>* File::identifiers()
+const std::map<unsigned int, std::string>& File::identifiers() const
 {
-    return &_identifiers;
+    return _identifiers;
 }
 
-std::map<unsigned int, std::string>* File::strings()
+const std::map<unsigned int, std::string>& File::strings() const
 {
-    return &_strings;
+    return _strings;
 }
 
-unsigned int File::position()
+size_t File::position() const
 {
     return _stream.position();
 }
 
-void File::setPosition(unsigned int pos)
+void File::setPosition(size_t pos)
 {
     _stream.setPosition(pos);
 }
 
-uint32_t File::size()
+size_t File::size() const
 {
     return _stream.size();
 }
@@ -153,21 +147,21 @@ uint32_t File::readValue()
     return _stream.uint32();
 }
 
-std::vector<Procedure*>* File::procedures()
+const std::vector<Procedure>& File::procedures() const
 {
-    return &_procedures;
+    return _procedures;
 }
 
-Procedure* File::procedure(std::string name)
+const Procedure* File::procedure(const std::string& name) const
 {
-    for (auto procedure : _procedures)
+    for (auto& procedure : _procedures)
     {
-        if (procedure->name() == name)
+        if (procedure.name() == name)
         {
-            return procedure;
+            return &procedure;
         }
     }
-    return 0;
+    return nullptr;
 }
 
 }

--- a/src/Format/Int/File.h
+++ b/src/Format/Int/File.h
@@ -33,6 +33,7 @@
 // Falltergeist includes
 #include "../../Format/Dat/Item.h"
 #include "../../Format/Dat/Stream.h"
+#include "../../Format/Int/Procedure.h"
 
 // Third party includes
 
@@ -42,7 +43,6 @@ namespace Format
 {
 namespace Int
 {
-class Procedure;
 
 class File : public Dat::Item
 {

--- a/src/Format/Int/File.h
+++ b/src/Format/Int/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -48,31 +48,34 @@ class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    virtual ~File();
 
-    // TODO: return by reference
-    std::vector<Procedure*>* procedures();
-    Procedure* procedure(std::string name);
+    const std::vector<Procedure>& procedures() const;
 
-    std::map<unsigned int, std::string>* identifiers();
-    std::map<unsigned int, std::string>* strings();
+    // returns procedure with a given name or nullptr if none found
+    const Procedure* procedure(const std::string& name) const;
+
+    const std::map<unsigned int, std::string>& identifiers() const;
+    const std::map<unsigned int, std::string>& strings() const;
 
     // current position in script file
-    unsigned int position();
+    size_t position() const;
+
     // set current position in script file
-    void setPosition(unsigned int);
+    void setPosition(size_t);
+
     // the size of script file
-    uint32_t size();
+    size_t size() const;
+
     // read the next opcode
     uint16_t readOpcode();
+
     // read the next value
     uint32_t readValue();
 
 protected:
     Dat::Stream _stream;
 
-    // TODO: replace with vector of objects
-    std::vector<Procedure*> _procedures;
+    std::vector<Procedure> _procedures;
 
     std::map<unsigned int, std::string> _functions;
     std::vector<unsigned int> _functionsOffsets;

--- a/src/Format/Int/Procedure.h
+++ b/src/Format/Int/Procedure.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -45,7 +45,7 @@ class Procedure
 {
 
 public:
-    Procedure();       
+    Procedure();
 
     uint32_t flags() const;
     void setFlags(uint32_t flags);

--- a/src/Format/Map/Elevation.cpp
+++ b/src/Format/Map/Elevation.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -41,27 +41,34 @@ Elevation::Elevation()
 {
 }
 
-Elevation::~Elevation()
+std::vector<std::unique_ptr<Object>>& Elevation::objects()
 {
-    for(auto object : _objects)
-    {
-        delete object;
-    }
+    return _objects;
 }
 
-std::vector<Object*>* Elevation::objects()
+const std::vector<std::unique_ptr<Object>>& Elevation::objects() const
 {
-    return &_objects;
+    return _objects;
 }
 
-std::vector<uint16_t>* Elevation::floorTiles()
+std::vector<uint16_t>& Elevation::floorTiles()
 {
-    return &_floorTiles;
+    return _floorTiles;
 }
 
-std::vector<uint16_t>* Elevation::roofTiles()
+const std::vector<uint16_t>& Elevation::floorTiles() const
 {
-    return &_roofTiles;
+    return _floorTiles;
+}
+
+std::vector<uint16_t>& Elevation::roofTiles()
+{
+    return _roofTiles;
+}
+
+const std::vector<uint16_t>& Elevation::roofTiles() const
+{
+    return _roofTiles;
 }
 
 }

--- a/src/Format/Map/Elevation.h
+++ b/src/Format/Map/Elevation.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -30,6 +30,7 @@
 #include <memory>
 
 // Falltergeist includes
+#include "../Map/Object.h"
 
 // Third party includes
 
@@ -39,22 +40,23 @@ namespace Format
 {
 namespace Map
 {
-class Object;
 
 class Elevation
 {
 
 public:
     Elevation();
-    ~Elevation();
-    std::vector<Object*>* objects();
-    std::vector<uint16_t>* floorTiles();
-    std::vector<uint16_t>* roofTiles();
+    std::vector<std::unique_ptr<Object>>& objects();
+    const std::vector<std::unique_ptr<Object>>& objects() const;
+    std::vector<uint16_t>& floorTiles();
+    const std::vector<uint16_t>& floorTiles() const;
+    std::vector<uint16_t>& roofTiles();
+    const std::vector<uint16_t>& roofTiles() const;
 
 protected:
     std::vector<uint16_t> _floorTiles;
     std::vector<uint16_t> _roofTiles;
-    std::vector<Object*> _objects;
+    std::vector<std::unique_ptr<Object>> _objects;
 
 };
 

--- a/src/Format/Map/File.cpp
+++ b/src/Format/Map/File.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -78,11 +78,13 @@ void File::init(ProFileTypeLoaderCallback callback)
     stream.skipBytes(4*44); // unkonwn
 
     // MVAR AND SVAR SECTION
+    _MVARS.reserve(_MVARsize);
     for (unsigned int i = 0; i != _MVARsize; ++i)
     {
         _MVARS.push_back(stream.int32());
     }
 
+    _LVARS.reserve(_LVARsize);
     for (unsigned int i = 0; i != _LVARsize; ++i)
     {
         _LVARS.push_back(stream.int32());
@@ -91,12 +93,12 @@ void File::init(ProFileTypeLoaderCallback callback)
     // TILES SECTION
     for (unsigned int i = 0; i < elevations; i++)
     {
-        _elevations.push_back(new Elevation);
+        _elevations.emplace_back();
 
         for (unsigned i = 0; i < 10000; i++)
         {
-            _elevations.back()->roofTiles()->push_back(stream.uint16());
-            _elevations.back()->floorTiles()->push_back(stream.uint16());
+            _elevations.back().roofTiles().push_back(stream.uint16());
+            _elevations.back().floorTiles().push_back(stream.uint16());
         }
     }
 
@@ -115,36 +117,36 @@ void File::init(ProFileTypeLoaderCallback callback)
             uint32_t check = 0;
             for (unsigned j = 0; j < loop; j++)
             {
-                auto script = new Script();
-                script->setPID(stream.int32());
+                Script script;
+                script.setPID(stream.int32());
 
                 stream.uint32(); // next script. unused
 
-                switch ((script->PID() & 0xFF000000) >> 24)
+                switch ((script.PID() & 0xFF000000) >> 24)
                 {
                     case 0:
-                        script->setType(Script::Type::SYSTEM);
+                        script.setType(Script::Type::SYSTEM);
                         break;
                     case 1:
-                        script->setType(Script::Type::SPATIAL);
-                        script->setSpatialTile(stream.uint32());
-                        script->setSpatialRadius(stream.uint32());
+                        script.setType(Script::Type::SPATIAL);
+                        script.setSpatialTile(stream.uint32());
+                        script.setSpatialRadius(stream.uint32());
                         break;
                     case 2:
-                        script->setType(Script::Type::TIMER);
-                        script->setTimerTime(stream.uint32());
+                        script.setType(Script::Type::TIMER);
+                        script.setTimerTime(stream.uint32());
                         break;
                     case 3:
-                        script->setType(Script::Type::ITEM);
+                        script.setType(Script::Type::ITEM);
                         break;
                     case 4:
-                        script->setType(Script::Type::CRITTER);
+                        script.setType(Script::Type::CRITTER);
                         break;
                     default:
                         break;
                 }
                 stream.uint32(); //flags
-                script->setScriptId(stream.int32());
+                script.setScriptId(stream.int32());
                 stream.uint32(); //unknown 5
                 stream.uint32(); //oid == object->OID
                 stream.uint32(); //local var offset
@@ -162,11 +164,6 @@ void File::init(ProFileTypeLoaderCallback callback)
                 {
                     _scripts.push_back(script);
                 }
-                else
-                {
-                    // TODO: use RAII
-                    delete script;
-                }
 
                 if ((j % 16) == 15)
                 {
@@ -183,42 +180,30 @@ void File::init(ProFileTypeLoaderCallback callback)
 
     //OBJECTS SECTION
     stream.uint32(); // objects total
-    for (unsigned i = 0; i != elevations; ++i)
+    for (auto& elev : _elevations)
     {
-        unsigned objectsOnElevation = stream.uint32();
-        for (unsigned j = 0; j != objectsOnElevation; ++j)
+        auto objectsOnElevation = stream.uint32();
+        for (size_t j = 0; j != objectsOnElevation; ++j)
         {
             auto object = _readObject(stream, callback);
-            _elevations.at(i)->objects()->push_back(object);
-
             if (object->inventorySize() > 0)
             {
-                for (unsigned int i = 0; i != object->inventorySize(); ++i)
+                for (size_t i = 0; i < object->inventorySize(); ++i)
                 {
-                    uint32_t ammount = stream.uint32();
+                    uint32_t amount = stream.uint32();
                     auto subobject = _readObject(stream, callback);
-                    subobject->setAmmount(ammount);
-                    object->children()->push_back(subobject);
+                    subobject->setAmmount(amount);
+                    object->children().emplace_back(std::move(subobject));
                 }
             }
+            elev.objects().emplace_back(std::move(object));
         }
     }
 }
 
-File::~File() {
-    for (auto elevation : _elevations) {
-        delete elevation;
-    }
-
-    for (auto script : _scripts) {
-        delete script;
-    }
-}
-
-Object* File::_readObject(Dat::Stream& stream, ProFileTypeLoaderCallback callback)
+std::unique_ptr<Object> File::_readObject(Dat::Stream& stream, ProFileTypeLoaderCallback callback)
 {
-    auto object = new Object();
-
+    auto object = std::make_unique<Object>();
     object->setOID(stream.uint32());
     object->setHexPosition(stream.int32());
     object->setX(stream.uint32());
@@ -243,11 +228,12 @@ Object* File::_readObject(Dat::Stream& stream, ProFileTypeLoaderCallback callbac
     int32_t SID = stream.int32();
     if (SID != -1)
     {
-        for (auto it = _scripts.begin(); it != _scripts.end(); ++it)
+        for (auto& script : _scripts)
         {
-            if ((*it)->PID() == SID)
+            // TODO: comparing PID to SID? If this is not bug, need better name for PID
+            if (script.PID() == SID)
             {
-                object->setMapScriptId((*it)->scriptId());
+                object->setMapScriptId(script.scriptId());
             }
         }
     }
@@ -373,12 +359,12 @@ Object* File::_readObject(Dat::Stream& stream, ProFileTypeLoaderCallback callbac
         default:
             throw Exception("File::_readObject() - unknown type");
     }
-    return object;
+    return std::move(object);
 }
 
-std::vector<Elevation*>* File::elevations()
+const std::vector<Elevation>& File::elevations() const
 {
-    return &_elevations;
+    return _elevations;
 }
 
 unsigned int File::version() const
@@ -431,19 +417,19 @@ unsigned int File::timeSinceEpoch() const
     return _timeSinceEpoch;
 }
 
-std::vector<int>* File::LVARS()
+const std::vector<int>& File::LVARS() const
 {
-    return &_LVARS;
+    return _LVARS;
 }
 
-std::vector<int>* File::MVARS()
+const std::vector<int>& File::MVARS() const
 {
-    return &_MVARS;
+    return _MVARS;
 }
 
-std::vector<Script*>* File::scripts()
+const std::vector<Script>& File::scripts() const
 {
-    return &_scripts;
+    return _scripts;
 }
 
 }

--- a/src/Format/Map/File.cpp
+++ b/src/Format/Map/File.cpp
@@ -359,7 +359,7 @@ std::unique_ptr<Object> File::_readObject(Dat::Stream& stream, ProFileTypeLoader
         default:
             throw Exception("File::_readObject() - unknown type");
     }
-    return std::move(object);
+    return object;
 }
 
 const std::vector<Elevation>& File::elevations() const

--- a/src/Format/Map/File.h
+++ b/src/Format/Map/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -32,6 +32,8 @@
 // Falltergeist includes
 #include "../Dat/Item.h"
 #include "../Dat/Stream.h"
+#include "../Map/Elevation.h"
+#include "../Map/Script.h"
 
 // Third party includes
 
@@ -51,9 +53,7 @@ namespace Pro
 
 namespace Map
 {
-class Elevation;
 class Object;
-class Script;
 
 typedef Pro::File* (*ProFileTypeLoaderCallback)(uint32_t);
 
@@ -61,15 +61,14 @@ class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    ~File();
 
     // TODO: get rid of two-step initialization
     void init(ProFileTypeLoaderCallback callback);
 
-    std::vector<Elevation*>* elevations();
-    std::vector<Script*>* scripts();
-    std::vector<int32_t>* LVARS();
-    std::vector<int32_t>* MVARS();
+    const std::vector<Elevation>& elevations() const;
+    const std::vector<Script>& scripts() const;
+    const std::vector<int32_t>& LVARS() const;
+    const std::vector<int32_t>& MVARS() const;
 
     uint32_t defaultPosition() const;
     uint32_t defaultElevation() const;
@@ -84,11 +83,11 @@ public:
 
     std::string name() const;
 
-protected:
+private:
     Dat::Stream _stream;
 
-    std::vector<Elevation*> _elevations;
-    std::vector<Script*> _scripts;
+    std::vector<Elevation> _elevations;
+    std::vector<Script> _scripts;
     std::vector<int32_t> _MVARS;
     std::vector<int32_t> _LVARS;
 
@@ -107,7 +106,7 @@ protected:
 
     std::string _name;
 
-    Object* _readObject(Dat::Stream& stream, ProFileTypeLoaderCallback callback);
+    std::unique_ptr<Object> _readObject(Dat::Stream& stream, ProFileTypeLoaderCallback callback);
 };
 
 }

--- a/src/Format/Map/Object.cpp
+++ b/src/Format/Map/Object.cpp
@@ -40,10 +40,6 @@ Object::Object()
 {
 }
 
-Object::~Object()
-{
-}
-
 std::vector<std::unique_ptr<Object>>& Object::children()
 {
     return _children;

--- a/src/Format/Map/Object.cpp
+++ b/src/Format/Map/Object.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -42,15 +42,11 @@ Object::Object()
 
 Object::~Object()
 {
-    for (auto child : _children)
-    {
-        delete child;
-    }
 }
 
-std::vector<Object*>* Object::children()
+std::vector<std::unique_ptr<Object>>& Object::children()
 {
-    return &_children;
+    return _children;
 }
 
 unsigned int Object::OID()

--- a/src/Format/Map/Object.h
+++ b/src/Format/Map/Object.h
@@ -45,7 +45,8 @@ class Object
 
 public:
     Object();
-    ~Object();
+    Object(const Object&) = delete;
+    Object& operator= (const Object&) = delete;
 
     unsigned int ammount();
     void setAmmount(unsigned int value);

--- a/src/Format/Map/Object.h
+++ b/src/Format/Map/Object.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -164,9 +164,9 @@ public:
     int ammoPID();
     void setAmmoPID(int PID);
 
-    std::vector<Object*>* children();
+    std::vector<std::unique_ptr<Object>>& children();
 
-protected:
+private:
     unsigned int _ammount = 0;
     unsigned int _unknown1;
     unsigned int _unknown2;
@@ -208,7 +208,7 @@ protected:
     int _mapScriptId = -1;
     int _scriptId = -1;
     int _hexPosition = -1;
-    std::vector<Object*> _children;
+    std::vector<std::unique_ptr<Object>> _children;
 
 };
 

--- a/src/Format/Map/Script.cpp
+++ b/src/Format/Map/Script.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -36,14 +36,6 @@ namespace Format
 namespace Map
 {
 
-Script::Script()
-{
-}
-
-Script::~Script()
-{
-}
-
 int32_t Script::PID() const
 {
     return _PID;
@@ -64,7 +56,7 @@ void Script::setScriptId(int32_t value)
     _scriptId = value;
 }
 
-Script::Type Script::type()
+Script::Type Script::type() const
 {
     return _type;
 }
@@ -79,7 +71,7 @@ void Script::setSpatialTile(uint32_t tile)
     _spatialTile = tile;
 }
 
-uint32_t Script::spatialTile()
+uint32_t Script::spatialTile() const
 {
     return _spatialTile;
 }
@@ -89,7 +81,7 @@ void Script::setSpatialRadius(uint32_t radius)
     _spatialRadius = radius;
 }
 
-uint32_t Script::spatialRadius()
+uint32_t Script::spatialRadius() const
 {
     return _spatialRadius;
 }
@@ -99,7 +91,7 @@ void Script::setTimerTime(uint32_t time)
     _timerTime = time;
 }
 
-uint32_t Script::timerTime()
+uint32_t Script::timerTime() const
 {
     return _timerTime;
 }

--- a/src/Format/Map/Script.h
+++ b/src/Format/Map/Script.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -39,9 +39,9 @@ namespace Format
 namespace Map
 {
 
+// TODO: replace with struct
 class Script
 {
-
 public:
     enum class Type
     {
@@ -52,8 +52,6 @@ public:
         CRITTER
 
     };
-    Script();
-    ~Script();
 
     int32_t PID() const;
     void setPID(int32_t PID);
@@ -61,18 +59,19 @@ public:
     int32_t scriptId() const;
     void setScriptId(int32_t value);
 
-    Type type();
+    Type type() const;
     void setType(Type type);
 
     void setSpatialTile(uint32_t tile);
-    uint32_t spatialTile();
+    uint32_t spatialTile() const;
 
     void setSpatialRadius(uint32_t radius);
-    uint32_t spatialRadius();
+    uint32_t spatialRadius() const;
 
     void setTimerTime(uint32_t time);
-    uint32_t timerTime();
-protected:
+    uint32_t timerTime() const;
+
+private:
     int32_t _PID = 0;
     int32_t _scriptId = -1;
     int32_t _unknown1 = 0;

--- a/src/Format/Map/Script.h
+++ b/src/Format/Map/Script.h
@@ -74,23 +74,9 @@ public:
 private:
     int32_t _PID = 0;
     int32_t _scriptId = -1;
-    int32_t _unknown1 = 0;
     uint32_t _spatialTile = 0;
     uint32_t _spatialRadius = 0;
     uint32_t _timerTime = 0;
-    int32_t _unknown4 = 0;
-    int32_t _unknown5 = 0;
-    int32_t _unknown6 = 0;
-    int32_t _unknown7 = 0;
-    int32_t _unknown8 = 0;
-    int32_t _unknown9 = 0;
-    int32_t _unknown10 = 0;
-    int32_t _unknown11 = 0;
-    int32_t _unknown12 = 0;
-    int32_t _unknown13 = 0;
-    int32_t _unknown14 = 0;
-    int32_t _unknown15 = 0;
-    int32_t _unknown16 = 0;
 
     Type _type;
 };

--- a/src/Format/Msg/File.cpp
+++ b/src/Format/Msg/File.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -103,33 +103,22 @@ File::File(Dat::Stream&& stream)
                 text.replace(text.find("\r"), 1, "");
             }
 
-            auto message = new Message();
-            message->setNumber(std::stoi(number));
-            message->setSound(sound);
-            message->setText(text);
+            Message message;
+            message.setNumber(std::stoi(number));
+            message.setSound(sound);
+            message.setText(text);
             _messages.push_back(message);
         }
     }
 }
 
-File::~File() {
-    for (auto message : _messages) {
-        delete message;
-    }
-}
-
-std::vector<Message*>* File::messages()
-{
-    return &_messages;
-}
-
 Message* File::message(unsigned int number)
 {
-    for (auto message : _messages)
+    for (auto& message : _messages)
     {
-        if (message->number() == number)
+        if (message.number() == number)
         {
-            return message;
+            return &message;
         }
     }
     throw Exception("File::message() - number is out of range: " + std::to_string(number));

--- a/src/Format/Msg/File.h
+++ b/src/Format/Msg/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -30,6 +30,7 @@
 
 // Falltergeist includes
 #include "../../Format/Dat/Item.h"
+#include "../../Format/Msg/Message.h"
 
 // Third party includes
 
@@ -45,21 +46,15 @@ class Stream;
 namespace Msg
 {
 
-class Message;
-
 class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    ~File();
 
-    // TODO: return by reference
-    std::vector<Message*>* messages();
     Message* message(unsigned int number);
 
-protected:
-    // TODO: use vector of objects
-    std::vector<Message*> _messages;
+private:
+    std::vector<Message> _messages;
 
 };
 

--- a/src/Format/Mve/Chunk.cpp
+++ b/src/Format/Mve/Chunk.cpp
@@ -36,18 +36,6 @@ namespace Format
 namespace Mve
 {
 
-Chunk::Chunk()
-{
-}
-
-Chunk::~Chunk()
-{
-    for (auto opcode : _opcodes)
-    {
-        delete opcode;
-    }
-}
-
 uint16_t Chunk::length() const
 {
     return _length;
@@ -68,9 +56,14 @@ void Chunk::setType(uint16_t value)
     _type = value;
 }
 
-std::vector<Opcode*>* Chunk::opcodes()
+std::vector<Opcode>& Chunk::opcodes()
 {
-    return &_opcodes;
+    return _opcodes;
+}
+
+const std::vector<Opcode>& Chunk::opcodes() const
+{
+    return _opcodes;
 }
 
 }

--- a/src/Format/Mve/Chunk.h
+++ b/src/Format/Mve/Chunk.h
@@ -45,21 +45,19 @@ class Chunk
 {
 
 public:
-    Chunk();
-    ~Chunk();
-
     uint16_t length() const;
     void setLength(uint16_t value);
 
     uint16_t type() const;
     void setType(uint16_t value);
 
-    std::vector<Opcode*>* opcodes();
+    std::vector<Opcode>& opcodes();
+    const std::vector<Opcode>& opcodes() const;
 
 protected:
     uint16_t _length;
     uint16_t _type;
-    std::vector<Opcode*> _opcodes;
+    std::vector<Opcode> _opcodes;
 
 };
 

--- a/src/Format/Mve/File.cpp
+++ b/src/Format/Mve/File.cpp
@@ -72,21 +72,22 @@ std::unique_ptr<Chunk> File::getNextChunk()
         auto chunk = std::make_unique<Chunk>();
         chunk->setLength(_stream.uint16());
         chunk->setType(_stream.uint16());
-        for (unsigned i = 0; i < chunk->length();)
+        for (size_t i = 0; i < chunk->length();)
         {
-            auto opcode = new Opcode(_stream.uint16());
-            opcode->setType(_stream.uint8());
-            opcode->setVersion(_stream.uint8());
-            _stream.readBytes((uint8_t*)opcode->data(), opcode->length());
-            chunk->opcodes()->push_back(opcode);
-            i += opcode->length() + 4;
+            chunk->opcodes().emplace_back(_stream.uint16());
+            auto& opcode = chunk->opcodes().back();
+            opcode.setType(_stream.uint8());
+            opcode.setVersion(_stream.uint8());
+            _stream.readBytes(opcode.data(), opcode.length());
+            i += opcode.length() + 4;
         }
         return chunk;
     }
     return nullptr;
 }
 
-void File::setPosition(unsigned int position) {
+void File::setPosition(unsigned int position)
+{
     _stream.setPosition(position);
 }
 

--- a/src/Format/Mve/Opcode.cpp
+++ b/src/Format/Mve/Opcode.cpp
@@ -36,20 +36,13 @@ namespace Format
 namespace Mve
 {
 
-Opcode::Opcode(uint16_t length)
+Opcode::Opcode(uint16_t length) : _data(length)
 {
-    _length = length;
-    _data = new uint8_t[_length];
-}
-
-Opcode::~Opcode()
-{
-    delete [] _data;
 }
 
 uint16_t Opcode::length() const
 {
-    return _length;
+    return static_cast<uint16_t>(_data.size());
 }
 
 uint8_t Opcode::type() const
@@ -72,9 +65,9 @@ void Opcode::setVersion(uint8_t value)
     _version = value;
 }
 
-uint8_t* Opcode::data() const
+uint8_t* Opcode::data()
 {
-    return _data;
+    return _data.data();
 }
 
 }

--- a/src/Format/Mve/Opcode.h
+++ b/src/Format/Mve/Opcode.h
@@ -28,7 +28,8 @@
 // C++ standard includes
 #include <cstdint>
 
-// libfallteregeist includes
+// Falltergeist includes
+#include "../../Base/Buffer.h"
 
 // Third party includes
 
@@ -44,7 +45,6 @@ class Opcode
 
 public:
     Opcode(uint16_t length);
-    ~Opcode();
 
     uint16_t length() const;
 
@@ -54,13 +54,13 @@ public:
     uint8_t version() const;
     void setVersion(uint8_t value);
 
-    uint8_t* data() const;
+    uint8_t* data();
 
 protected:
     uint16_t _length = 0;
     uint8_t _type = 0;
     uint8_t _version = 0;
-    uint8_t* _data = nullptr;
+    Base::Buffer<uint8_t> _data;
 
 };
 

--- a/src/Format/Pal/File.cpp
+++ b/src/Format/Pal/File.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -42,14 +42,14 @@ File::File(Dat::Stream&& stream)
 {
     stream.setPosition(3);
 
-    _colors.push_back(new Color(0, 0, 0, 0)); // zero color (transparent)
+    _colors.emplace_back(0, 0, 0, 0); // zero color (transparent)
 
     for (unsigned i = 1; i != 256; ++i)
     {
         uint8_t r = stream.uint8();
         uint8_t g = stream.uint8();
         uint8_t b = stream.uint8();
-        _colors.push_back(new Color(r,g,b));
+        _colors.emplace_back(r, g, b);
     }
 
     // I guess this section requires a little explanation
@@ -71,65 +71,54 @@ File::File(Dat::Stream&& stream)
     for (unsigned i = 229; i<=254; ++i)
     {
         // magic, sorry
-        _colors.at(i)->setAlpha(51);
-        _colors.at(i)->setRed(153);
-        _colors.at(i)->nomod();
+        _colors.at(i).setAlpha(51);
+        _colors.at(i).setRed(153);
+        _colors.at(i).nomod();
     }
 
     // SLIME
     for (unsigned int i=229; i<=232; i++)
     {
-        _colors.at(i)->setGreen(0); //
-        _colors.at(i)->setBlue((i-229)*51);
+        _colors.at(i).setGreen(0); //
+        _colors.at(i).setBlue((i-229)*51);
     }
 
     // MONITORS
     for (unsigned int i=233; i<=237; i++)
     {
-        _colors.at(i)->setGreen(51); //
-        _colors.at(i)->setBlue((i-233)*51);
+        _colors.at(i).setGreen(51); //
+        _colors.at(i).setBlue((i-233)*51);
     }
 
     // SLOW FIRE
     for (unsigned int i=238; i<=242; i++)
     {
-        _colors.at(i)->setGreen(102); //
-        _colors.at(i)->setBlue((i-238)*51);
+        _colors.at(i).setGreen(102); //
+        _colors.at(i).setBlue((i-238)*51);
     }
 
     // FAST FIRE
     for (unsigned int i=243; i<=247; i++)
     {
-        _colors.at(i)->setGreen(153); //
-        _colors.at(i)->setBlue((i-243)*51);
+        _colors.at(i).setGreen(153); //
+        _colors.at(i).setBlue((i-243)*51);
     }
 
     // SHORE
     for (unsigned int i=248; i<=253; i++)
     {
-        _colors.at(i)->setGreen(204); //
-        _colors.at(i)->setBlue((i-248)*51);
+        _colors.at(i).setGreen(204); //
+        _colors.at(i).setBlue((i-248)*51);
     }
 
     // ALARM
-    _colors.at(254)->setGreen(255); //
-    _colors.at(254)->setBlue(0);
+    _colors.at(254).setGreen(255); //
+    _colors.at(254).setBlue(0);
 }
 
-File::~File() {
-    for (auto color : _colors) {
-        delete color;
-    }
-}
-
-std::vector<Color*>* File::colors()
+const Color* File::color(unsigned index) const
 {
-    return &_colors;
-}
-
-Color* File::color(unsigned index) const
-{
-    return _colors.at(index);
+    return &_colors.at(index);
 }
 
 }

--- a/src/Format/Pal/File.h
+++ b/src/Format/Pal/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -30,6 +30,7 @@
 
 // Falltergeist includes
 #include "../Dat/Item.h"
+#include "../Pal/Color.h"
 
 // Third party includes
 
@@ -45,23 +46,16 @@ class Stream;
 namespace Pal
 {
 
-class Color;
-
 class File : public Dat::Item
 {
 
 public:
     File(Dat::Stream&& stream);
-    ~File();
 
-    // TODO: return by reference
-    std::vector<Color*>* colors();
-
-    Color* color(unsigned index) const;
+    const Color* color(unsigned index) const;
 
 protected:
-    // TODO: vector of objects
-    std::vector<Color*> _colors;
+    std::vector<Color> _colors;
 
 };
 

--- a/src/Format/Rix/File.cpp
+++ b/src/Format/Rix/File.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -63,17 +63,13 @@ File::File(Dat::Stream&& stream)
         palette[i] = (r << 26 | g << 18 | b << 10 | 0x000000FF);  // RGBA
     }
 
-    _rgba = new uint32_t[_width * _height];
+    _rgba.resize(_width * _height);
 
     // Data
     for (unsigned i = 0; i != (unsigned)_width * _height; ++i)
     {
         _rgba[i] = palette[stream.uint8()];
     }
-}
-
-File::~File() {
-    delete[] _rgba;
 }
 
 uint16_t File::width() const
@@ -86,9 +82,9 @@ uint16_t File::height() const
     return _height;
 }
 
-uint32_t* File::rgba() const
+uint32_t* File::rgba()
 {
-    return _rgba;
+    return _rgba.data();
 }
 
 }

--- a/src/Format/Rix/File.h
+++ b/src/Format/Rix/File.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2012-2015 Falltergeist developers
@@ -28,6 +28,7 @@
 // C++ standard includes
 
 // Falltergeist includes
+#include "../../Base/Buffer.h"
 #include "../Dat/Item.h"
 #include "../Enums.h"
 
@@ -49,17 +50,16 @@ class File : public Dat::Item
 {
 public:
     File(Dat::Stream&& stream);
-    ~File() override;
 
     uint16_t width() const;
     uint16_t height() const;
 
-    uint32_t* rgba() const;
+    uint32_t* rgba();
 
 protected:
     uint16_t _width = 0;
     uint16_t _height = 0;
-    uint32_t* _rgba = nullptr;
+    Base::Buffer<uint32_t> _rgba;
 
 };
 

--- a/src/Game/Location.cpp
+++ b/src/Game/Location.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -50,7 +50,7 @@ namespace Falltergeist
             setDefaultOrientation(mapFile->defaultOrientation());
             
             // Initialize MAP vars
-            if (mapFile->MVARS()->size() > 0)
+            if (mapFile->MVARS().size() > 0)
             {
                 auto gam = ResourceManager::getInstance()->gamFileType("maps/" + name() + ".gam");
                 if (gam)

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -202,7 +202,7 @@ void Object::_generateUi()
     auto frm = ResourceManager::getInstance()->frmFileType(FID());
     if (frm)
     {
-        if (frm->framesPerDirection() > 1 || frm->directions()->size() > 1)
+        if (frm->framesPerDirection() > 1 || frm->directions().size() > 1)
         {
             auto queue = std::make_unique<UI::AnimationQueue>();
             queue->animations().push_back(std::make_unique<UI::Animation>(ResourceManager::getInstance()->FIDtoFrmName(FID()), orientation()));

--- a/src/Graphics/Animation.cpp
+++ b/src/Graphics/Animation.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -64,31 +64,42 @@ Animation::Animation(const std::string &filename)
 
     _stride = frm->framesPerDirection();
 
+    int offsetX = 1;
+    int offsetY = 1;
 
-    int offsetX=1;
-    int offsetY=1;
-
-    for (auto direction : *frm->directions())
+    for (auto& direction : frm->directions())
     {
         offsetX = 1;
         for (unsigned int f = 0; f != frm->framesPerDirection(); ++f)
         {
-            auto srcFrame = direction->frames()->at(f);
+            auto& srcFrame = direction.frames().at(f);
 
-            _vertices.push_back(glm::vec2(0.0,0.0));
-            _vertices.push_back(glm::vec2(0.0,(float)srcFrame->height()+2.0));
-            _vertices.push_back(glm::vec2((float)srcFrame->width()+2.0,0.0));
-            _vertices.push_back(glm::vec2((float)srcFrame->width()+2.0,(float)srcFrame->height()+2.0));
+            _vertices.push_back(glm::vec2(0.0, 0.0));
+            _vertices.push_back(glm::vec2(0.0, (float)srcFrame.height() + 2.0));
+            _vertices.push_back(glm::vec2((float)srcFrame.width() + 2.0, 0.0));
+            _vertices.push_back(glm::vec2((float)srcFrame.width() + 2.0, (float)srcFrame.height() + 2.0));
 
-            _texCoords.push_back(glm::vec2( (float)(offsetX-1.0)/(float)_texture->textureWidth(), (float)(offsetY-1.0)/(float)_texture->textureHeight() ));
-            _texCoords.push_back(glm::vec2( (float)(offsetX-1.0)/(float)_texture->textureWidth(), (float)(offsetY+srcFrame->height()+1.0)/(float)_texture->textureHeight() ));
-            _texCoords.push_back(glm::vec2( (float)(offsetX+srcFrame->width()+1.0)/(float)_texture->textureWidth(), (float)(offsetY-1.0)/(float)_texture->textureHeight() ));
-            _texCoords.push_back(glm::vec2( (float)(offsetX+srcFrame->width()+1.0)/(float)_texture->textureWidth(), (float)(offsetY+srcFrame->height()+1.0)/(float)_texture->textureHeight() ));
+            _texCoords.push_back(glm::vec2(
+                (float)(offsetX - 1.0) / (float)_texture->textureWidth(),
+                (float)(offsetY - 1.0) / (float)_texture->textureHeight()
+            ));
+            _texCoords.push_back(glm::vec2(
+                (float)(offsetX - 1.0) / (float)_texture->textureWidth(),
+                (float)(offsetY + srcFrame.height() + 1.0) / (float)_texture->textureHeight()
+            ));
+            _texCoords.push_back(glm::vec2(
+                (float)(offsetX + srcFrame.width() + 1.0) / (float)_texture->textureWidth(),
+                (float)(offsetY - 1.0) / (float)_texture->textureHeight()
+            ));
+            _texCoords.push_back(glm::vec2(
+                (float)(offsetX + srcFrame.width() + 1.0) / (float)_texture->textureWidth(),
+                (float)(offsetY + srcFrame.height() + 1.0) / (float)_texture->textureHeight()
+            ));
 
-            offsetX+=srcFrame->width()+2;
+            offsetX += srcFrame.width()+2;
 
         }
-        offsetY+=direction->height();
+        offsetY += direction.height();
 
     }
 

--- a/src/Graphics/Font/AAF.cpp
+++ b/src/Graphics/Font/AAF.cpp
@@ -81,7 +81,7 @@ unsigned short AAF::height()
 
 unsigned short AAF::glyphWidth(uint8_t ch)
 {
-    return _aaf->glyphs()->at(ch)->width();
+    return _aaf->glyphs().at(ch).width();
 }
 
 }

--- a/src/Graphics/Font/FON.cpp
+++ b/src/Graphics/Font/FON.cpp
@@ -79,7 +79,7 @@ unsigned short FON::height()
 
 unsigned short FON::glyphWidth(uint8_t ch)
 {
-    return _fon->glyphs()->at(ch)->width();
+    return _fon->glyphs().at(ch).width();
 }
 
 }

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -26,6 +26,7 @@
 #include <memory>
 
 // Falltergeist includes
+#include "../Base/Buffer.h"
 #include "../CrossPlatform.h"
 #include "../Event/State.h"
 #include "../Exception.h"
@@ -382,17 +383,17 @@ void Renderer::screenshot()
 
     output = SDL_CreateRGBSurface(0, width(), height(), 32, rmask, gmask, bmask, amask);
     uint8_t *destPixels = (uint8_t*)output->pixels;
-    uint8_t *srcPixels = new uint8_t[width() * height() * 4];
+    Base::Buffer<uint8_t> srcPixels(width() * height() * 4);
 
     glReadBuffer(GL_BACK);
-    glReadPixels(0, 0, width(), height(), GL_RGBA, GL_UNSIGNED_BYTE, srcPixels);
+    glReadPixels(0, 0, width(), height(), GL_RGBA, GL_UNSIGNED_BYTE, srcPixels.data());
 
-    for(int y=0; y<height(); ++y)
+    for (int y = 0; y < height(); ++y)
     {
-        for(int x=0; x<width(); ++x)
+        for (int x = 0; x < width(); ++x)
         {
             uint8_t* pDestPix = &destPixels[((width() * y) + x) * 4];
-            uint8_t* pSrcPix = &srcPixels[((width() * ((height()-1) - y)) + x) * 4];
+            uint8_t* pSrcPix = &srcPixels[((width() * ((height() - 1) - y)) + x) * 4];
             pDestPix[0] = pSrcPix[0];
             pDestPix[1] = pSrcPix[1];
             pDestPix[2] = pSrcPix[2];
@@ -401,7 +402,6 @@ void Renderer::screenshot()
     }
 
     IMG_SavePNG(output,filename.c_str());
-    delete[] srcPixels;
     SDL_FreeSurface(output);
     Logger::info("GAME") << "Screenshot saved to " + filename << std::endl;
 

--- a/src/Graphics/Texture.cpp
+++ b/src/Graphics/Texture.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -227,7 +227,7 @@ bool Texture::opaque(unsigned int x, unsigned int y)
 
 void Texture::setMask(std::vector<bool> mask)
 {
-    _mask=mask;
+    _mask = mask;
 }
 
 }

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -341,7 +341,7 @@ Graphics::Texture* ResourceManager::texture(const string& filename)
         if (!frm) return nullptr;
         texture = new Graphics::Texture(frm->width(), frm->height());
         texture->loadFromRGBA(frm->rgba(palFileType("color.pal")));
-        texture->setMask(*frm->mask(palFileType("color.pal")));
+        texture->setMask(frm->mask(palFileType("color.pal")));
     }
     else
     {

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -242,7 +242,7 @@ namespace Falltergeist
 
             // @todo optimize
             auto script = dialog->script();
-            int newOffset = script->script()->procedures()->at(_functions.at(i))->bodyOffset();
+            int newOffset = script->script()->procedures().at(_functions.at(i)).bodyOffset();
             int oldOffset = script->programCounter() - 2;
             int reaction = 50;
             if (i < _reactions.size())

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -258,11 +258,11 @@ namespace Falltergeist
                 _MVARS.push_back(mvar);
             }
 
-            auto mapObjects = mapFile->elevations()->at(_currentElevation)->objects();
+            auto& mapObjects = mapFile->elevations().at(_currentElevation).objects();
 
             auto ticks = SDL_GetTicks();
             // @todo remove old objects from hexagonal grid
-            for (auto mapObject : *mapObjects)
+            for (auto& mapObject : mapObjects)
             {
                 auto object = Game::ObjectFactory::getInstance()->createObject(mapObject->PID());
                 if (!object)
@@ -295,7 +295,7 @@ namespace Falltergeist
 
                 if (auto container = dynamic_cast<Game::ContainerItemObject*>(object))
                 {
-                    for (auto child : *mapObject->children())
+                    for (auto& child : mapObject->children())
                     {
                         auto item = dynamic_cast<Game::ItemObject*>(Game::ObjectFactory::getInstance()->createObject(child->PID()));
                         if (!item)
@@ -311,7 +311,7 @@ namespace Falltergeist
                 // TODO: use common interface...
                 if (auto critter = dynamic_cast<Game::CritterObject*>(object))
                 {
-                    for (auto child : *mapObject->children())
+                    for (auto& child : mapObject->children())
                     {
                         auto item = dynamic_cast<Game::ItemObject*>(Game::ObjectFactory::getInstance()->createObject(child->PID()));
                         if (!item)
@@ -402,23 +402,23 @@ namespace Falltergeist
                 _locationScript = std::make_unique<VM::Script>(ResourceManager::getInstance()->intFileType(mapFile->scriptId()-1), nullptr);
             }
 
-            // Spatials
-            for (auto script: *mapFile->scripts())
+            // Spatial Scripts
+            for (auto& script: mapFile->scripts())
             {
-                if (script->type() == Format::Map::Script::Type::SPATIAL)
+                if (script.type() == Format::Map::Script::Type::SPATIAL)
                 {
-                    auto tile = script->spatialTile();
+                    auto tile = script.spatialTile();
                     auto hex = tile & 0xFFFF;
                     auto elev = ((tile >> 28) & 0xf) >> 1;
                     if (elev == _currentElevation)
                     {
-                        auto spatial = new Game::SpatialObject(script->spatialRadius());
+                        auto spatial = std::make_unique<Game::SpatialObject>(script.spatialRadius());
                         spatial->setElevation(elev);
                         spatial->setHexagon(_hexagonGrid->at(hex));
-                        auto intFile = ResourceManager::getInstance()->intFileType(script->scriptId());
-                        if (intFile) spatial->setScript(new VM::Script(intFile, spatial));
+                        auto intFile = ResourceManager::getInstance()->intFileType(script.scriptId());
+                        if (intFile) spatial->setScript(new VM::Script(intFile, spatial.get()));
 
-                        _spatials.emplace_back(spatial);
+                        _spatials.emplace_back(std::move(spatial));
                     }
 
                 }
@@ -433,13 +433,13 @@ namespace Falltergeist
                     unsigned int x = (100 - tileY - 1)*48 + 32*(tileX - 1);
                     unsigned int y = tileX*24 +(tileY - 1)*12 + 1;
 
-                    unsigned int tileNum = mapFile->elevations()->at(_currentElevation)->floorTiles()->at(i);
+                    unsigned int tileNum = mapFile->elevations().at(_currentElevation).floorTiles().at(i);
                     if (tileNum > 1)
                     {
                         _floor->tiles()[i] = std::make_unique<UI::Tile>(tileNum, Point(x, y));
                     }
 
-                    tileNum = mapFile->elevations()->at(_currentElevation)->roofTiles()->at(i);
+                    tileNum = mapFile->elevations().at(_currentElevation).roofTiles().at(i);
                     if (tileNum > 1)
                     {
                         _roof->tiles()[i] = std::make_unique<UI::Tile>(tileNum, Point(x, y - 96));

--- a/src/UI/Animation.cpp
+++ b/src/UI/Animation.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -60,16 +60,16 @@ Animation::Animation(const std::string& frmName, unsigned int direction) : Fallt
     _animation = std::make_unique<Graphics::Animation>(frmName);
 
     _actionFrame = frm->actionFrame();
-    auto dir = frm->directions()->at(direction);
-    _shift = Point(dir->shiftX(), dir->shiftY());
+    auto& dir = frm->directions().at(direction);
+    _shift = Point(dir.shiftX(), dir.shiftY());
 
     // Frame offset in texture's animation
-    unsigned int x = 0;
-    unsigned int y = 0;
+    int x = 0;
+    int y = 0;
 
     for (unsigned int d = 0; d != direction; ++d)
     {
-        y += frm->directions()->at(d)->height(); //? может i - 1
+        y += frm->directions().at(d).height(); //? может i - 1
     }
 
     int xOffset = 1;
@@ -80,10 +80,10 @@ Animation::Animation(const std::string& frmName, unsigned int direction) : Fallt
         yOffset += frm->offsetY(direction, f);
 
         auto frame = std::make_unique<AnimationFrame>();
-        auto srcFrame = frm->directions()->at(direction)->frames()->at(f);
-        frame->setSize(Size(srcFrame->width(), srcFrame->height()));
-        frame->setOffset({xOffset, yOffset});
-        frame->setPosition(Point(x, y));
+        auto& srcFrame = frm->directions().at(direction).frames().at(f);
+        frame->setSize({ srcFrame.width(), srcFrame.height() });
+        frame->setOffset({ xOffset, yOffset });
+        frame->setPosition({ x, y });
 
         auto fps = frm->framesPerSecond();
         if (fps == 0)

--- a/src/UI/Image.cpp
+++ b/src/UI/Image.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -54,14 +54,14 @@ void Image::render(bool eggTransparency)
 
 Image::Image(Format::Frm::File *frm, unsigned int direction) : Falltergeist::UI::Base(), _sprite(frm)
 {
-    if (direction >= frm->directions()->size())
+    if (direction >= frm->directions().size())
     {
         //throw Exception("Image::Image(frm, direction) - direction not found: " + std::to_string(direction));
         direction = 0;
     }
-    auto dir = frm->directions()->at(direction);
-    setOffset(frm->offsetX(direction) + dir->shiftX(),
-      frm->offsetY(direction) + dir->shiftY());
+    auto& dir = frm->directions().at(direction);
+    setOffset(frm->offsetX(direction) + dir.shiftX(),
+      frm->offsetY(direction) + dir.shiftY());
 }
 
 Size Image::size() const

--- a/src/UI/MvePlayer.cpp
+++ b/src/UI/MvePlayer.cpp
@@ -824,6 +824,8 @@ void MvePlayer::_processChunk()
     {
         switch (static_cast<Opcode>(opcode.type()))
         {
+            case Opcode::END_CHUNK:
+                break;
             case Opcode::CREATE_TIMER:
                 _delay = get_int(opcode.data()) * get_short(opcode.data() + 4);
                 _timerStarted = true;

--- a/src/UI/MvePlayer.cpp
+++ b/src/UI/MvePlayer.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -824,14 +824,11 @@ void MvePlayer::_processChunk()
     {
         switch (static_cast<Opcode>(opcode.type()))
         {
-            case Opcode::END_CHUNK:
-              _chunk = _mve->getNextChunk();
-              break;
             case Opcode::CREATE_TIMER:
-              _delay = get_int(opcode.data()) * get_short(opcode.data() + 4);
-              _timerStarted = true;
-              _lastts=CrossPlatform::microtime();
-              break;
+                _delay = get_int(opcode.data()) * get_short(opcode.data() + 4);
+                _timerStarted = true;
+                _lastts = CrossPlatform::microtime();
+                break;
             case Opcode::END_STREAM:
                 _finished = true;
                 return;
@@ -848,7 +845,7 @@ void MvePlayer::_processChunk()
                 break;
             case Opcode::SEND_BUFFER:
                 _sendVideoBuffer(opcode.data());
-                //copy buffer to texture (with pallete)
+                //copy buffer to texture (with palette)
                 break;
             case Opcode::AUDIO_DATA:
                 _decodeAudio(opcode.data(), opcode.length());
@@ -884,6 +881,7 @@ void MvePlayer::_processChunk()
                 break;
         }
     }
+    _chunk = _mve->getNextChunk();
 }
 
 void MvePlayer::think()

--- a/src/UI/MvePlayer.cpp
+++ b/src/UI/MvePlayer.cpp
@@ -819,16 +819,16 @@ void MvePlayer::_processChunk()
         return;
     }
 
-    const auto opcodes = *_chunk->opcodes();
-    for (const auto opcode : opcodes)
+    auto& opcodes = _chunk->opcodes();
+    for (auto& opcode : opcodes)
     {
-        switch (static_cast<Opcode>(opcode->type()))
+        switch (static_cast<Opcode>(opcode.type()))
         {
             case Opcode::END_CHUNK:
               _chunk = _mve->getNextChunk();
               break;
             case Opcode::CREATE_TIMER:
-              _delay = get_int(opcode->data()) * get_short(opcode->data() + 4);
+              _delay = get_int(opcode.data()) * get_short(opcode.data() + 4);
               _timerStarted = true;
               _lastts=CrossPlatform::microtime();
               break;
@@ -837,21 +837,21 @@ void MvePlayer::_processChunk()
                 return;
                 break;
             case Opcode::INIT_AUDIO_BUF:
-                _initAudioBuffer(opcode->version(), opcode->data());
+                _initAudioBuffer(opcode.version(), opcode.data());
                 break;
             case Opcode::START_AUDIO:
                 _playAudio();
                 break;
             case Opcode::INIT_VIDIO_BUF:
                 //can be called multiple times (intro and tanker)
-                _initVideoBuffer(opcode->data());
+                _initVideoBuffer(opcode.data());
                 break;
             case Opcode::SEND_BUFFER:
-                _sendVideoBuffer(opcode->data());
+                _sendVideoBuffer(opcode.data());
                 //copy buffer to texture (with pallete)
                 break;
             case Opcode::AUDIO_DATA:
-                _decodeAudio(opcode->data(), opcode->length());
+                _decodeAudio(opcode.data(), opcode.length());
                 break;
             case Opcode::AUDIO_SILENCE:
                 break;
@@ -862,15 +862,15 @@ void MvePlayer::_processChunk()
                 break;
             case Opcode::SET_PALETTE:
                 //can be called several times (intro and tanker)
-                _setPalette(opcode->data());
+                _setPalette(opcode.data());
                 break;
             case Opcode::SET_PALETTE_COMPRESSED:
                 break;
             case Opcode::SET_DECODING_MAP:
-                _setDecodingMap(opcode->data());
+                _setDecodingMap(opcode.data());
                 break;
             case Opcode::VIDEO_DATA:
-                _decodeVideo(opcode->data(), opcode->length());
+                _decodeVideo(opcode.data(), opcode.length());
                 //set (buffer) texture
                 break;
             case Opcode::UNKNOWN_0x06:

--- a/src/UI/MvePlayer.cpp
+++ b/src/UI/MvePlayer.cpp
@@ -615,7 +615,7 @@ void MvePlayer::_decodeFrame(uint8_t* data, uint32_t len)
     }
 }
 
-void MvePlayer::_decodeVideo(uint8_t* data, uint32_t len)
+void MvePlayer::_decodeVideo( uint8_t* data, uint32_t len )
 {
 /*
     int16_t nFrameHot, nFrameCold;
@@ -761,7 +761,7 @@ uint32_t MvePlayer::getAudio(uint8_t* data, uint32_t len)
     }
     uint32_t res = 0;
     int16_t *buf = (int16_t*)data;
-    while (res < len/2)
+    while (res < len / 2)
     {
         if (_samplesReady <= 0) break;
         *buf = _audioBuf[_audioBufHead];

--- a/src/UI/MvePlayer.h
+++ b/src/UI/MvePlayer.h
@@ -43,6 +43,7 @@ namespace Mve
 namespace UI
 {
 
+// MVE Movie Player
 class MvePlayer : public Falltergeist::UI::Base
 {
 public:
@@ -54,6 +55,7 @@ public:
     bool finished();
     uint32_t getAudio(uint8_t* data, uint32_t len);
     uint32_t samplesLeft();
+    // Current frame number
     uint32_t frame();
 
 private:

--- a/src/UI/TileMap.cpp
+++ b/src/UI/TileMap.cpp
@@ -50,6 +50,10 @@ TileMap::TileMap()
 {
 }
 
+TileMap::~TileMap()
+{
+}
+
 void TileMap::init()
 {
     auto ticks = SDL_GetTicks();
@@ -67,8 +71,6 @@ void TileMap::init()
     for (auto& it : _tiles)
     {
         auto& tile = it.second;
-
-
 
         auto position = std::find(numbers.begin(), numbers.end(), tile->number());
         if (position == numbers.end())
@@ -156,10 +158,6 @@ void TileMap::init()
     }
 
     Logger::info("GAME") << "Tilemap generated in " << (SDL_GetTicks() - ticks) << std::endl;
-}
-
-TileMap::~TileMap()
-{
 }
 
 void TileMap::render()

--- a/src/UI/TileMap.cpp
+++ b/src/UI/TileMap.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -71,7 +71,7 @@ void TileMap::init()
 
 
         auto position = std::find(numbers.begin(), numbers.end(), tile->number());
-        if ( position == numbers.end())
+        if (position == numbers.end())
         {
             tile->setIndex(static_cast<unsigned>(numbers.size()));
             numbers.push_back(tile->number());
@@ -100,7 +100,7 @@ void TileMap::init()
         float vh = static_cast<float>(vy + 36.0);
 
         vertices.push_back(glm::vec2(vx, vy));
-        vertices.push_back( glm::vec2(vw, vy) );
+        vertices.push_back(glm::vec2(vw, vy));
         vertices.push_back(glm::vec2(vx, vh));
         vertices.push_back(glm::vec2(vw, vh));
 
@@ -116,10 +116,10 @@ void TileMap::init()
         float w = static_cast<float>(x + 80.0) / Game::getInstance()->renderer()->maxTextureSize();
         float h = static_cast<float>(y + 36.0) / Game::getInstance()->renderer()->maxTextureSize();
 
-        UV.push_back(glm::vec2(fx,fy));
-        UV.push_back(glm::vec2(w,fy));
-        UV.push_back(glm::vec2(fx,h));
-        UV.push_back(glm::vec2(w,h));
+        UV.push_back(glm::vec2(fx, fy));
+        UV.push_back(glm::vec2(w, fy));
+        UV.push_back(glm::vec2(fx, h));
+        UV.push_back(glm::vec2(w, h));
 
     }
 
@@ -127,26 +127,26 @@ void TileMap::init()
 
     Logger::info("GAME") << "Tilemap uniq tiles " << numbers.size() << std::endl;
 
-    _atlases = (uint32_t)std::ceil((float)numbers.size()/(float)_tilesPerAtlas);
+    _atlases = (uint32_t)std::ceil((float)numbers.size() / (float)_tilesPerAtlas);
     Logger::info("GAME") << "Tilemap atlases " << _atlases << std::endl;
 
     auto tilesLst = ResourceManager::getInstance()->lstFileType("art/tiles/tiles.lst");
 
-    for (uint8_t i=0;i<_atlases;i++)
+    for (uint8_t i = 0; i < _atlases; i++)
     {
-        SDL_Surface* tmp = SDL_CreateRGBSurface(0,Game::getInstance()->renderer()->maxTextureSize(), Game::getInstance()->renderer()->maxTextureSize(), 32, 0xff000000,0x00ff0000,0x0000ff00,0x000000ff);
+        SDL_Surface* tmp = SDL_CreateRGBSurface(0, Game::getInstance()->renderer()->maxTextureSize(), Game::getInstance()->renderer()->maxTextureSize(), 32, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
         SDL_SetSurfaceBlendMode(tmp, SDL_BLENDMODE_NONE);
-        for (unsigned int j = _tilesPerAtlas*i; j < std::min((uint32_t)numbers.size(), (uint32_t)_tilesPerAtlas*(i+1)); ++j)
+        for (unsigned int j = _tilesPerAtlas*i; j < std::min((uint32_t)numbers.size(), (uint32_t)_tilesPerAtlas*(i + 1)); ++j)
         {
             auto frm = ResourceManager::getInstance()->frmFileType("art/tiles/" + tilesLst->strings()->at(numbers.at(j)));
 
-            SDL_Surface* tileSurf = SDL_CreateRGBSurfaceFrom(frm->rgba(ResourceManager::getInstance()->palFileType("color.pal")), 82, 38, 32, 82*4, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
+            SDL_Surface* tileSurf = SDL_CreateRGBSurfaceFrom(frm->rgba(ResourceManager::getInstance()->palFileType("color.pal")), 82, 38, 32, 82 * 4, 0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff);
             SDL_SetSurfaceBlendMode(tileSurf, SDL_BLENDMODE_NONE);
             int x = (j % maxW) * 80;
             int y = (j / maxW) * 36;
-            SDL_Rect srcrect = {1,1,80,36};
-            SDL_Rect rect = {x,y,80,36};
-            SDL_BlitSurface(tileSurf,&srcrect,tmp,&rect);
+            SDL_Rect srcrect = { 1,1,80,36 };
+            SDL_Rect rect = { x,y,80,36 };
+            SDL_BlitSurface(tileSurf, &srcrect, tmp, &rect);
             SDL_FreeSurface(tileSurf);
         }
         //push new atlas
@@ -166,11 +166,11 @@ void TileMap::render()
 {
     auto camera = Game::getInstance()->locationState()->camera();
     std::vector<std::vector<GLuint>> indexes;
-    for (uint8_t i =0; i<_atlases;i++)
+    for (uint8_t i = 0; i < _atlases; i++)
     {
         indexes.push_back(std::vector<GLuint>());
     }
-    int cnt=0;
+    int cnt = 0;
 
     auto topLeft = camera->topLeft();
     auto size = camera->size();
@@ -181,17 +181,17 @@ void TileMap::render()
         if (tile->enabled() && Rect::intersects(tile->position(), tileSize, topLeft, size))
         {
             uint32_t aIndex = tile->index() / _tilesPerAtlas;
-            indexes.at(aIndex).push_back(cnt*4);
-            indexes.at(aIndex).push_back(cnt*4+1);
-            indexes.at(aIndex).push_back(cnt*4+2);
-            indexes.at(aIndex).push_back(cnt*4+3);
-            indexes.at(aIndex).push_back(cnt*4+2);
-            indexes.at(aIndex).push_back(cnt*4+1);
+            indexes.at(aIndex).push_back(cnt * 4);
+            indexes.at(aIndex).push_back(cnt * 4 + 1);
+            indexes.at(aIndex).push_back(cnt * 4 + 2);
+            indexes.at(aIndex).push_back(cnt * 4 + 3);
+            indexes.at(aIndex).push_back(cnt * 4 + 2);
+            indexes.at(aIndex).push_back(cnt * 4 + 1);
         }
         cnt++;
     }
 
-    for (uint32_t i = 0; i< _atlases; i++)
+    for (uint32_t i = 0; i < _atlases; i++)
     {
         //render atlas with indexes->at(atlasIndex)
         _tilemap.get()->render(topLeft, indexes.at(i), i);
@@ -212,14 +212,15 @@ bool TileMap::inside()
 
 void TileMap::enableAll()
 {
-    for (auto& tile: _tiles)
+    for (auto& tile : _tiles)
     {
         tile.second->enable();
     }
 
 }
 
-std::map<unsigned int, std::unique_ptr<Tile>> &TileMap::tiles() {
+std::map<unsigned int, std::unique_ptr<Tile>> &TileMap::tiles()
+{
     return _tiles;
 }
 
@@ -227,21 +228,21 @@ void TileMap::disable(unsigned int num)
 {
     int x = num % 100;
     int y = num / 100;
-    _floodDisable(x,y);
+    _floodDisable(x, y);
 }
 
 void TileMap::_floodDisable(int x, int y)
 {
     // TODO: this is basic 4-way floodfill
     // maybe better replace it with scanlines or QuickFill
-    int num = y*100+x;
+    int num = y * 100 + x;
     if (_tiles.count(num) && _tiles.at(num)->enabled())
     {
         _tiles.at(num)->disable();
-        _floodDisable(x+1,y);
-        _floodDisable(x-1,y);
-        _floodDisable(x,y+1);
-        _floodDisable(x,y-1);
+        _floodDisable(x + 1, y);
+        _floodDisable(x - 1, y);
+        _floodDisable(x, y + 1);
+        _floodDisable(x, y - 1);
     }
 }
 
@@ -249,20 +250,23 @@ bool TileMap::opaque(const Point &pos)
 {
     auto camera = Game::getInstance()->locationState()->camera();
 
-
     auto tilesLst = ResourceManager::getInstance()->lstFileType("art/tiles/tiles.lst");
     for (auto& it : _tiles)
     {
         auto& tile = it.second;
         const Size tileSize = Size(80, 36);
-        if (tile->enabled() && Rect::inRect(pos+camera->topLeft(), tile->position(),tileSize))
+        if (tile->enabled() && Rect::inRect(pos + camera->topLeft(), tile->position(), tileSize))
         {
             auto frm = ResourceManager::getInstance()->frmFileType("art/tiles/" + tilesLst->strings()->at(tile->number()));
-            auto mask = frm->mask(ResourceManager::getInstance()->palFileType("color.pal"));
-            auto position = pos-tile->position()+camera->topLeft()+Point(1,1);
+            auto& mask = frm->mask(ResourceManager::getInstance()->palFileType("color.pal"));
+            auto position = pos - tile->position() + camera->topLeft() + Point(1, 1);
 
-            if ((position.y()*82+position.x()) > 0 &&  ((unsigned)(position.y()*82+position.x()) < mask->size())) {
-                if (mask->at(position.y()*82+position.x())) return true;
+            if ((position.y() * 82 + position.x()) > 0 && ((unsigned)(position.y() * 82 + position.x()) < mask.size()))
+            {
+                if (mask.at(position.y() * 82 + position.x()))
+                {
+                    return true;
+                }
             }
         }
     }

--- a/src/UI/TileMap.h
+++ b/src/UI/TileMap.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -52,13 +52,15 @@ public:
     TileMap();
     ~TileMap();
 
-    std::map<unsigned int, std::unique_ptr<Tile>>&tiles();
+    std::map<unsigned int, std::unique_ptr<Tile>>& tiles();
     void render();
     void init();
     void setInside(bool inside);
     bool inside();
     void enableAll();
     void disable(unsigned int num);
+
+    // Tests if there is a non-transparent pixel at the given point.
     bool opaque(const Point& pos);
 
 protected:

--- a/src/VM/Handler/Opcode8005.cpp
+++ b/src/VM/Handler/Opcode8005.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -32,27 +32,29 @@
 
 namespace Falltergeist
 {
-    namespace VM
-    {
-        namespace Handler
-        {
-            Opcode8005::Opcode8005(VM::Script* script) : OpcodeHandler(script)
-            {
-            }
+namespace VM
+{
+namespace Handler
+{
 
-            void Opcode8005::_run()
-            {
-                auto functionIndex = _script->dataStack()->popInteger();
-                // @TODO: pass arguments and call external procedures
-                /*auto argumentCount = _script->dataStack()->popInteger();
-                std::vector<int> args;
-                for (int i = 0; i < argumentCount; i++)
-                {
-                    args.push_back(_script->dataStack()->popInteger());
-                }*/
-                _script->setProgramCounter(_script->script()->procedures()->at(functionIndex)->bodyOffset());
-                Logger::debug("SCRIPT") << "[8005] [*] op_call(0x" << std::hex << functionIndex << ") = 0x" << _script->programCounter() << std::endl;
-            }
-        }
-    }
+Opcode8005::Opcode8005(VM::Script* script) : OpcodeHandler(script)
+{
+}
+
+void Opcode8005::_run()
+{
+    auto functionIndex = _script->dataStack()->popInteger();
+    // @TODO: pass arguments and call external procedures
+    /*auto argumentCount = _script->dataStack()->popInteger();
+    std::vector<int> args;
+    for (int i = 0; i < argumentCount; i++)
+    {
+        args.push_back(_script->dataStack()->popInteger());
+    }*/
+    _script->setProgramCounter(_script->script()->procedures().at(functionIndex).bodyOffset());
+    Logger::debug("SCRIPT") << "[8005] [*] op_call(0x" << std::hex << functionIndex << ") = 0x" << _script->programCounter() << std::endl;
+}
+
+}
+}
 }

--- a/src/VM/Handler/Opcode8005.h
+++ b/src/VM/Handler/Opcode8005.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -29,19 +29,21 @@
 
 namespace Falltergeist
 {
-    namespace VM
-    {
-        namespace Handler
-        {
-            class Opcode8005 : public OpcodeHandler
-            {
-                public:
-                    Opcode8005(VM::Script* script);
+namespace VM
+{
+namespace Handler
+{
 
-                private:
-                    void _run() override;
-            };
-        }
-    }
+class Opcode8005 : public OpcodeHandler
+{
+public:
+    Opcode8005(VM::Script* script);
+
+private:
+    void _run() override;
+};
+
+}
+}
 }
 #endif // FALLTERGEIST_VM_HANDLER_OPCODE8005_H

--- a/src/VM/Handler/Opcode8014Handler.cpp
+++ b/src/VM/Handler/Opcode8014Handler.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -34,44 +34,46 @@
 
 namespace Falltergeist
 {
-    namespace VM
-    {
-        namespace Handler
-        {
-            Opcode8014::Opcode8014(VM::Script *script) : OpcodeHandler(script)
-            {
-            }
+namespace VM
+{
+namespace Handler
+{
 
-            void Opcode8014::_run()
-            {
-                auto& debug = Logger::debug("SCRIPT");
-                debug << "[8014] [+] value = op_fetch_external(name)" << std::endl;
-                auto game = Game::getInstance();
-                auto EVARS = game->locationState()->EVARS();
-                std::string name;
-                auto nameValue = _script->dataStack()->pop();
-                switch (nameValue.type())
-                {
-                    case StackValue::Type::INTEGER:
-                        name = _script->script()->identifiers()->at((unsigned int)nameValue.integerValue());
-                        break;
-                    case StackValue::Type::STRING:
-                    {
-                        name = nameValue.stringValue();
-                        break;
-                    }
-                    default:
-                        _error(std::string("op_fetch_external - invalid argument type: ") + nameValue.typeName());
-                }
-                debug << " name = " << name;
-                if (EVARS->find(name) == EVARS->end())
-                {
-                    _error(std::string() + "op_fetch_external: exported variable \"" + name + "\" not found.");
-                }
-                auto value = EVARS->at(name);
-                debug << ", type = " << value.typeName() << ", value = " << value.toString() << std::endl;
-                _script->dataStack()->push(value);
-            }
+Opcode8014::Opcode8014(VM::Script *script) : OpcodeHandler(script)
+{
+}
+
+void Opcode8014::_run()
+{
+    auto& debug = Logger::debug("SCRIPT");
+    debug << "[8014] [+] value = op_fetch_external(name)" << std::endl;
+    auto game = Game::getInstance();
+    auto EVARS = game->locationState()->EVARS();
+    std::string name;
+    auto nameValue = _script->dataStack()->pop();
+    switch (nameValue.type())
+    {
+        case StackValue::Type::INTEGER:
+            name = _script->script()->identifiers().at((unsigned int)nameValue.integerValue());
+            break;
+        case StackValue::Type::STRING:
+        {
+            name = nameValue.stringValue();
+            break;
         }
+        default:
+            _error(std::string("op_fetch_external - invalid argument type: ") + nameValue.typeName());
     }
+    debug << " name = " << name;
+    if (EVARS->find(name) == EVARS->end())
+    {
+        _error(std::string() + "op_fetch_external: exported variable \"" + name + "\" not found.");
+    }
+    auto value = EVARS->at(name);
+    debug << ", type = " << value.typeName() << ", value = " << value.toString() << std::endl;
+    _script->dataStack()->push(value);
+}
+
+}
+}
 }

--- a/src/VM/Handler/Opcode8014Handler.h
+++ b/src/VM/Handler/Opcode8014Handler.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2016 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -29,19 +29,21 @@
 
 namespace Falltergeist
 {
-    namespace VM
-    {
-        namespace Handler
-        {
-            class Opcode8014 : public OpcodeHandler
-            {
-                public:
-                    Opcode8014(VM::Script* script);
+namespace VM
+{
+namespace Handler
+{
 
-                private:
-                    void _run() override;
-            };
-        }
-    }
+class Opcode8014 : public OpcodeHandler
+{
+public:
+    Opcode8014(VM::Script* script);
+
+private:
+    void _run() override;
+};
+
+}
+}
 }
 #endif // FALLTERGEIST_VM_HANDLER_OPCODE8014_H

--- a/src/VM/Handler/Opcode9001Handler.cpp
+++ b/src/VM/Handler/Opcode9001Handler.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2014 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -32,44 +32,46 @@
 
 namespace Falltergeist
 {
-    namespace VM
+namespace VM
+{
+namespace Handler
+{
+
+Opcode9001::Opcode9001(VM::Script* script) : OpcodeHandler(script)
+{
+}
+
+void Opcode9001::_run()
+{
+    unsigned int data = _script->script()->readValue();
+    unsigned short nextOpcode = _script->script()->readOpcode();
+
+    // Skip 4 readed bytes
+    _script->setProgramCounter(_script->programCounter() + 4);
+
+    switch (nextOpcode)
     {
-        namespace Handler
+        case 0x8014: // get exported var value
+        case 0x8015: // set exported var value
+        case 0x8016: // export var
         {
-            Opcode9001::Opcode9001(VM::Script* script) : OpcodeHandler(script)
-            {
-            }
-
-            void Opcode9001::_run()
-            {
-                unsigned int data = _script->script()->readValue();
-                unsigned short nextOpcode = _script->script()->readOpcode();
-
-                // Skip 4 readed bytes
-                _script->setProgramCounter(_script->programCounter() + 4);
-
-                switch(nextOpcode)
-                {
-                    case 0x8014: // get exported var value
-                    case 0x8015: // set exported var value
-                    case 0x8016: // export var
-                    {
-                        _script->dataStack()->push(_script->script()->identifiers()->at(data));
-                        break;
-                    }
-                    default:
-                    {
-                        _script->dataStack()->push(_script->script()->strings()->at(data));
-                        break;
-                    }
-                }
-
-                auto value = _script->dataStack()->top();
-                auto& debug = Logger::debug("SCRIPT");
-                debug   << "[9001] [*] push_d string" << std::endl
-                        << "     type: " << value.typeName() << std::endl
-                        << "    value: " << value.toString() << std::endl;
-            }
+            _script->dataStack()->push(_script->script()->identifiers().at(data));
+            break;
+        }
+        default:
+        {
+            _script->dataStack()->push(_script->script()->strings().at(data));
+            break;
         }
     }
+
+    auto value = _script->dataStack()->top();
+    auto& debug = Logger::debug("SCRIPT");
+    debug << "[9001] [*] push_d string" << std::endl
+        << "     type: " << value.typeName() << std::endl
+        << "    value: " << value.toString() << std::endl;
+}
+}
+
+}
 }

--- a/src/VM/Handler/Opcode9001Handler.h
+++ b/src/VM/Handler/Opcode9001Handler.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2012-2014 Falltergeist Developers.
  *
  * This file is part of Falltergeist.
@@ -29,19 +29,21 @@
 
 namespace Falltergeist
 {
-    namespace VM
-    {
-        namespace Handler
-        {
-            class Opcode9001 : public OpcodeHandler
-            {
-                public:
-                    Opcode9001(VM::Script* script);
+namespace VM
+{
+namespace Handler
+{
 
-                private:
-                    void _run() override;
-            };
-        }
-    }
+class Opcode9001 : public OpcodeHandler
+{
+public:
+    Opcode9001(VM::Script* script);
+
+private:
+    void _run() override;
+};
+}
+
+}
 }
 #endif // FALLTERGEIST_VM_HANDLER_OPCODE9001_H


### PR DESCRIPTION
- Get rid of all (or almost) of manual memory management in Format classes.
- Return embedded collections as reference to vector of object rather than a pointer to a vector of pointers. This should make semantics of these classes more clear.
- Expanded Base::Buffer class a little bit to have some basic functionality of a vector.
- Minor refactoring of a few functions.
- Minor code style changes.
- Also adds `.editorconfig` file as "bonus"

Next step is to replace all getters and setters for Format classes with public properties, but this is probably not important now and can wait for much later..