### PR TITLE
Fixed rendering of floating text

### DIFF
--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -538,6 +538,7 @@ namespace Falltergeist {
             renderCursor();
             renderObjects();
             _roof->render();
+            renderObjectsText();
             renderCursorOutline();
             renderTestingOutline();
             if (active()) {
@@ -575,6 +576,9 @@ namespace Falltergeist {
                 object->render();
                 object->hexagon()->setInRender(object->inRender());
             }
+        }
+
+        void Location::renderObjectsText() const {
             for (auto &object: _objects) {
                 object->renderText();
             }

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -221,6 +221,7 @@ namespace Falltergeist
             void renderCursor() const;
 
             void renderObjects() const;
+            void renderObjectsText() const;
 
             void renderCursorOutline() const;
 


### PR DESCRIPTION
Roof sprites were overlapping object's floating text. If this is not a good solution, please close this pull request and I will submit an issue report instead.

![overlapping-text](https://user-images.githubusercontent.com/1261493/30965890-422d2252-a457-11e7-9cdf-8fa762ceb3b6.jpeg)
