### PR TITLE
Add support for Snap package format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ https://falltergeist.org/
 ```
 cmake . && make
 ```
+To build the Snap version:
+
+* checkout the `snap` branch in git
+* `sudo apt install snapcraft` (this command may vary according to your distro)
+* Execute the `snapcraft` command
 
 ## Running under linux
 
@@ -26,6 +31,8 @@ Put master.dat and critter.dat files into the falltergeist data directory, that 
 * `~/.local/share/falltergeist/`  or `/usr/local/share/falltergeist` (for global installs) on Linux,
 *  `~/Library/Application Support/falltergeist` on OS X,
 * `%APPDATA%/falltergeist` on Windows,
+* For Snap packages, the data must be stored locally in `~/snap/falltergeist/current/.local/share/falltergeist/` at the moment
+* To install a freshly built snap version, type `snap install --devmode --dangerous ./falltergeist_0.3.1_amd64.snap`, press enter and type your password when prompted
 
 or mount CD-ROM with original game, then run
 

--- a/snap/.snapcraft/state
+++ b/snap/.snapcraft/state
@@ -1,0 +1,4 @@
+!GlobalState
+assets:
+  build-packages: []
+  build-snaps: []

--- a/snap/.snapcraft/state
+++ b/snap/.snapcraft/state
@@ -1,4 +1,0 @@
-!GlobalState
-assets:
-  build-packages: []
-  build-snaps: []

--- a/snap/falltergeist.launcher
+++ b/snap/falltergeist.launcher
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#export SDL_DEBUG=1
+#export LIBGL_DEBUG=verbose
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+export LIBGL_DRIVERS_PATH="$SNAP/usr/lib/$ARCH/dri"
+
+export XLOCALEDIR="$SNAP/usr/share/X11/locale"
+
+export LOCPATH="$SNAP/usr/lib/locale"
+
+exec "$SNAP/bin/falltergeist" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,7 +43,6 @@ parts:
     - libsdl2-mixer-2.0-0 
     - libsdl2-image-2.0-0
     - libglew1.13 
-    - libglm-dev 
     - zlib1g
     
     prime:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,31 @@
+name: falltergeist # you probably want to 'snapcraft register <name>'
+version: 0.3.1 # just for humans, typically '1.2+git' or '1.3.2'
+summary: Open Source Fallout 2 game engine # 79 char long summary
+description: |
+  Opensource crossplatform Fallout 2™ engine writen in C++ and SDL. 
+  
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+ falltergeist:
+  command: falltergeist
+  plugs:
+  - a1sa
+  - pulsadio
+  - x11
+  - opengl
+  
+parts:
+  falltergiest:
+    # See 'snapcraft plugins'
+    plugin: cmake
+    source: https://github.com/falltergeist/falltergeist/archive/0.3.1.tar.gz
+    source-type: tar
+    build-packages:
+    - libsdl2-dev 
+    - libsdl2-mixer-dev 
+    - libsdl2-image-dev 
+    - libglew-dev 
+    - libglm-dev 
+    - zlib1g-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,15 +9,24 @@ confinement: devmode # use 'strict' once you have the right plugs and slots
 
 apps:
  falltergeist:
-  command: falltergeist
+  command: falltergeist.launcher
+  desktop: share/applications/falltergeist.desktop
   plugs:
   - a1sa
-  - pulsadio
+  - pulseaudio
   - x11
   - opengl
   
 parts:
-  falltergiest:
+  falltergeist.launcher:
+   source: snap
+   plugin: dump
+   install: |
+       chmod +x falltergeist.launcher
+   organize:
+    falltergeist.launcher: bin/falltergeist.launcher
+  
+  falltergeist:
     # See 'snapcraft plugins'
     plugin: cmake
     source: https://github.com/falltergeist/falltergeist/archive/0.3.1.tar.gz
@@ -29,3 +38,18 @@ parts:
     - libglew-dev 
     - libglm-dev 
     - zlib1g-dev
+    stage-packages:
+    - libsdl2-2.0-0
+    - libsdl2-mixer-2.0-0 
+    - libsdl2-image-2.0-0
+    - libglew1.13 
+    - libglm-dev 
+    - zlib1g
+    
+    prime:
+      - bin/falltergeist
+      - usr/lib
+      - share/applications
+      - share/falltergeist
+      
+      


### PR DESCRIPTION
# Changes:

* Add support for Ubuntu's Snap package format, which will allow a single binary to be run across multiple Lnux distributions 
* Update Readme.md with build and installation instructions for Snaps

### Notes:
* Currently, data files must be installed on a per-user basis, See Readme.md for details
* In theory, it is possible to build directly from github. This would greatly simplify package maintenance in the future
* adding the Falltergeist Snap to the Ubuntu store should be done by maintainers at some point in the future. This would allow users to test Falltergeist without bypassing snapd's security restrictions
* Future commits will test to make sure strict application confinement works. 
  
