### PR TITLE
Add -k option to make for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ dist: trusty
 
 script:
   - cmake .
-  - make -j2
+  - make -kj2
 
 compiler:
   - clang


### PR DESCRIPTION
In cases where compilation fails on a foreign platform, it's useful to
find all the errors at once rather than having to submit a fix for each
discovered error and wait for next one. Make's `-k` option makes it
continue in face of errors until it cannot proceed further, allowing to
surface more errors in one go.