### PR TITLE
do not add object to map if location is zero. Fixes #538, fixes #531

### DIFF
--- a/src/VM/Handler/Opcode80B7Handler.cpp
+++ b/src/VM/Handler/Opcode80B7Handler.cpp
@@ -50,7 +50,13 @@ namespace Falltergeist {
                 auto elevation = dataStack->popInteger();
                 auto position = dataStack->popInteger();
                 auto PID = dataStack->popInteger();
-                auto object = Game::getInstance()->locationState()->addObject(PID, position, elevation);
+                Game::Object *object;
+
+                if (position > 0) {
+                    object = Game::getInstance()->locationState()->addObject(PID, position, elevation);
+                } else {
+                    object = Game::ObjectFactory::getInstance()->createObject(PID);
+                }
                 if (SID > 0) {
                     auto intFile = ResourceManager::getInstance()->intFileType(SID);
                     if (intFile) {


### PR DESCRIPTION
I couldn't find much documentation for the `create_object_sid` script function, but this looks like a cleaner fix than the one I proposed in #531 