### PR TITLE
Do not repeatedly add test items to inventory

### DIFF
--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -367,6 +367,12 @@ namespace Falltergeist
 
         void Location::initializePlayerTestAppareance(std::shared_ptr<Game::DudeObject> player) const
         {
+            static bool equipped;
+            if (equipped) {
+                return;
+            }
+
+            equipped = true;
             player->setArmorSlot(nullptr);
             auto powerArmor = (Game::ItemObject*) Game::ObjectFactory::getInstance()->createObject(PID_POWERED_ARMOR);
             auto leatherJacket = (Game::ItemObject*) Game::ObjectFactory::getInstance()->createObject(PID_LEATHER_JACKET);


### PR DESCRIPTION
Test items are repeatedly added to player's inventory when moving between locations.