### PR TITLE
Fix crash when erasing timer on newr1 map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Under development
 =======================
 - [bugfix] Opcode810D (obj_carrying_pid_obj) checks containers as well (JanSimek)
 - [bugfix] Fix linking release builds on Windows and prevent closing console after a crash (JanSimek)
+- [bugfix] Fix crash when erasing timer on newr1 map
 - [feature] Search data files in parent dir too (alexeevdv)
 - [feature] Basic barter system (Zervox, JanSimek)
 - [feature] Fix and update Travis build (JanSimek)

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -1195,16 +1195,20 @@ namespace Falltergeist
 
         void Location::removeTimerEvent(Game::Object *obj)
         {
-            _timerEvents.remove_if([=](Location::TimerEvent &item) { return item.object == obj; });
+            _timerEvents.erase(std::remove_if(_timerEvents.begin(), _timerEvents.end(),
+                [=](Location::TimerEvent &item) {
+                    return item.object == obj;
+                }
+            ), _timerEvents.end());
         }
 
         void Location::removeTimerEvent(Game::Object *obj, int fixedParam)
         {
-            _timerEvents.remove_if(
+            _timerEvents.erase(std::remove_if(_timerEvents.begin(), _timerEvents.end(),
                 [=](Location::TimerEvent &item) {
                     return item.object == obj && item.fixedParam == fixedParam;
                 }
-            );
+            ), _timerEvents.end());
         }
 
         unsigned int Location::lightLevel()

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -138,7 +138,7 @@ namespace Falltergeist
                 Game::Timer _actionCursorTimer;
                 Game::Timer _ambientSfxTimer;
                 // for VM opcode add_timer_event
-                std::list<TimerEvent> _timerEvents;
+                std::vector<TimerEvent> _timerEvents;
                 // TODO: move to Game::Location class?
                 std::map<std::string, unsigned char> _ambientSfx;
 


### PR DESCRIPTION
If you load newr1.map and wait for a minute the game will crash when erasing timer from std::list. 

I have _no idea why_ but replacing `std::list` with `std::vector` fixes the issue and the game does not crash anymore. It seems to be faster too (3ms vs 11ms loop processing on average).

**src/State/Location.cpp**
```c++
// timers processing
void Location::processTimers()
{
    _actionCursorTimer.think();
    _ambientSfxTimer.think();

    for (auto it = _timerEvents.begin(); it != _timerEvents.end();) {
        it->timer.think();
        if (!it->timer.enabled()) {
            it = _timerEvents.erase(it); // <- CRASH
        } else ++it;
    }
}
```