### PR TITLE
Added 'x', 'y', and 'always_on_top' video options

### DIFF
--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -23,6 +23,26 @@
 #include "../UI/FpsCounter.h"
 #include "../UI/TextArea.h"
 
+namespace
+{
+    Falltergeist::Graphics::RendererConfig cfg_from_settings(const Falltergeist::Settings& settings)
+    {
+        Falltergeist::Graphics::RendererConfig cfg{
+                .width = settings.screenWidth(),
+                .height = settings.screenHeight(),
+                .fullscreen = settings.fullscreen(),
+                .alwaysOnTop = settings.alwaysOnTop(),
+        };
+        if (settings.screenX() >= 0) {
+            cfg.x = settings.screenX();
+        }
+        if (settings.screenY() >= 0) {
+            cfg.y = settings.screenY();
+        }
+        return cfg;
+    }
+}
+
 namespace Falltergeist
 {
     namespace Game
@@ -54,7 +74,7 @@ namespace Falltergeist
 
             _eventDispatcher = std::make_unique<Event::Dispatcher>();
 
-            _renderer = std::make_shared<Graphics::Renderer>(_settings->screenWidth(), _settings->screenHeight());
+            _renderer = std::make_shared<Graphics::Renderer>(cfg_from_settings(*_settings));
 
             Logger::info("GAME") << CrossPlatform::getVersion() << std::endl;
             Logger::info("GAME") << "Opensource Fallout 2 game engine" << std::endl;

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -25,21 +25,21 @@
 
 namespace
 {
-    Falltergeist::Graphics::RendererConfig cfg_from_settings(const Falltergeist::Settings& settings)
+    Falltergeist::Graphics::RendererConfig configFromSettings(const Falltergeist::Settings& settings)
     {
-        Falltergeist::Graphics::RendererConfig cfg{
+        Falltergeist::Graphics::RendererConfig config{
                 .width = settings.screenWidth(),
                 .height = settings.screenHeight(),
                 .fullscreen = settings.fullscreen(),
                 .alwaysOnTop = settings.alwaysOnTop(),
         };
         if (settings.screenX() >= 0) {
-            cfg.x = settings.screenX();
+            config.x = settings.screenX();
         }
         if (settings.screenY() >= 0) {
-            cfg.y = settings.screenY();
+            config.y = settings.screenY();
         }
-        return cfg;
+        return config;
     }
 }
 
@@ -74,7 +74,7 @@ namespace Falltergeist
 
             _eventDispatcher = std::make_unique<Event::Dispatcher>();
 
-            _renderer = std::make_shared<Graphics::Renderer>(cfg_from_settings(*_settings));
+            _renderer = std::make_shared<Graphics::Renderer>(configFromSettings(*_settings));
 
             Logger::info("GAME") << CrossPlatform::getVersion() << std::endl;
             Logger::info("GAME") << "Opensource Fallout 2 game engine" << std::endl;

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -22,11 +22,8 @@ namespace Falltergeist
 {
     namespace Graphics
     {
-        Renderer::Renderer(unsigned int width, unsigned int height)
+        Renderer::Renderer(RendererConfig cfg) : _config{cfg}
         {
-            _size.setWidth(width);
-            _size.setHeight(height);
-
             std::string message = "Renderer initialization - ";
             if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
             {
@@ -36,7 +33,11 @@ namespace Falltergeist
             Logger::info("VIDEO") << message + "[OK]" << std::endl;
         }
 
-        Renderer::Renderer(const Size& size) : Renderer((unsigned)size.width(), (unsigned)size.height())
+        Renderer::Renderer(int width, int height) : Renderer{ RendererConfig{ .width = width, .height = height }}
+        {
+        }
+
+        Renderer::Renderer(Size size) : Renderer{ RendererConfig{ .width = size.width(), .height = size.height() }}
         {
         }
 
@@ -60,15 +61,23 @@ namespace Falltergeist
             // Game::getInstance()->engineSettings()->setFullscreen(true);
             // Game::getInstance()->engineSettings()->setScale(1); //or 2, if fullhd device
 
-            std::string message =  "SDL_CreateWindow " + std::to_string(_size.width()) + "x" + std::to_string(_size.height()) + "x" +std::to_string(32)+ " - ";
+            std::string message =  "SDL_CreateWindow " + std::to_string(_config.width) + "x" + std::to_string(_config.height) + "x" +std::to_string(32)+ " - ";
 
             uint32_t flags = SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL;
-            if (Game::getInstance()->settings()->fullscreen())
-            {
+            if (_config.fullscreen) {
                 flags |= SDL_WINDOW_FULLSCREEN;
             }
+            if (_config.alwaysOnTop) {
+                flags |= SDL_WINDOW_ALWAYS_ON_TOP;
+            }
 
-            _sdlWindow = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, _size.width(), _size.height(), flags);
+            _sdlWindow = SDL_CreateWindow(
+                    "",
+                    _config.x,
+                    _config.y,
+                    _config.width,
+                    _config.height,
+                    flags);
             if (!_sdlWindow)
             {
                 throw Exception(message + "[FAIL]");
@@ -222,7 +231,7 @@ namespace Falltergeist
             GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER, 6*sizeof(GLushort), indexes, GL_STATIC_DRAW));
 
             // generate projection matrix
-            _MVP = glm::ortho(0.0, (double)_size.width(), (double)_size.height(), 0.0, -1.0, 1.0);
+            _MVP = glm::ortho(0.0, static_cast<double>(_config.width), static_cast<double>(_config.height), 0.0, -1.0, 1.0);
 
             // load egg
             _egg = ResourceManager::getInstance()->texture("data/egg.png");
@@ -302,17 +311,17 @@ namespace Falltergeist
 
         int Renderer::width()
         {
-            return _size.width();
+            return _config.width;
         }
 
         int Renderer::height()
         {
-            return _size.height();
+            return _config.height;
         }
 
-        const Size& Renderer::size() const
+        const Size Renderer::size() const
         {
-            return _size;
+            return { _config.width, _config.height };
         }
 
         void Renderer::screenshot()

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -321,19 +321,22 @@ namespace Falltergeist
             SDL_GL_SwapWindow(_sdlWindow);
         }
 
-        int Renderer::width()
+        unsigned int Renderer::width() const
         {
             return _config.width;
         }
 
-        int Renderer::height()
+        unsigned int Renderer::height() const
         {
             return _config.height;
         }
 
-        const Size Renderer::size() const
+        Size Renderer::size() const
         {
-            return { _config.width, _config.height };
+            return {
+                static_cast<int>(_config.width),
+                static_cast<int>(_config.height)
+            };
         }
 
         void Renderer::screenshot()
@@ -381,9 +384,9 @@ namespace Falltergeist
             glReadBuffer(GL_BACK);
             glReadPixels(0, 0, width(), height(), GL_RGBA, GL_UNSIGNED_BYTE, srcPixels.data());
 
-            for (int y = 0; y < height(); ++y)
+            for (int y = 0; y < static_cast<int>(height()); ++y)
             {
-                for (int x = 0; x < width(); ++x)
+                for (int x = 0; x < static_cast<int>(width()); ++x)
                 {
                     uint8_t* pDestPix = &destPixels[((width() * y) + x) * 4];
                     uint8_t* pSrcPix = &srcPixels[((width() * ((height() - 1) - y)) + x) * 4];

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -22,7 +22,7 @@ namespace Falltergeist
 {
     namespace Graphics
     {
-        Renderer::Renderer(RendererConfig cfg) : _config{cfg}
+        Renderer::Renderer(const RendererConfig& cfg) : _config{cfg}
         {
             std::string message = "Renderer initialization - ";
             if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
@@ -33,11 +33,23 @@ namespace Falltergeist
             Logger::info("VIDEO") << message + "[OK]" << std::endl;
         }
 
-        Renderer::Renderer(int width, int height) : Renderer{ RendererConfig{ .width = width, .height = height }}
+        Renderer::Renderer(unsigned int width, unsigned int height) :
+            Renderer {
+                RendererConfig {
+                    .width = width,
+                    .height = height
+                }
+            }
         {
         }
 
-        Renderer::Renderer(Size size) : Renderer{ RendererConfig{ .width = size.width(), .height = size.height() }}
+        Renderer::Renderer(Size size) :
+            Renderer {
+                RendererConfig {
+                    .width = static_cast<unsigned int>(size.width()),
+                    .height = static_cast<unsigned int>(size.height())
+                }
+            }
         {
         }
 

--- a/src/Graphics/Renderer.h
+++ b/src/Graphics/Renderer.h
@@ -24,6 +24,15 @@ namespace Falltergeist
             } \
         } while (0)
 
+        struct RendererConfig {
+            int width;
+            int height;
+            int x = SDL_WINDOWPOS_CENTERED;
+            int y = SDL_WINDOWPOS_CENTERED;
+            bool fullscreen = false;
+            bool alwaysOnTop = false;
+        };
+
         class Renderer
         {
             public:
@@ -35,8 +44,9 @@ namespace Falltergeist
                     GLES2
                 };
 
-                Renderer(unsigned int width, unsigned int height);
-                Renderer(const Size& size);
+                Renderer(RendererConfig cfg);
+                Renderer(int width, int height);
+                Renderer(Size size);
                 ~Renderer();
 
                 void init();
@@ -47,7 +57,7 @@ namespace Falltergeist
 
                 int width();
                 int height();
-                const Size& size() const;
+                const Size size() const;
 
                 float scaleX();
                 float scaleY();
@@ -80,7 +90,7 @@ namespace Falltergeist
                 RenderPath renderPath();
 
             protected:
-                Size _size;
+                RendererConfig _config;
                 RenderPath _renderpath = RenderPath::OGL21;
 
                 short _fadeStep = 0;

--- a/src/Graphics/Renderer.h
+++ b/src/Graphics/Renderer.h
@@ -55,9 +55,9 @@ namespace Falltergeist
                 void endFrame();
                 void think(const float &deltaTime);
 
-                int width();
-                int height();
-                const Size size() const;
+                unsigned int width() const;
+                unsigned int height() const;
+                Size size() const;
 
                 float scaleX();
                 float scaleY();

--- a/src/Graphics/Renderer.h
+++ b/src/Graphics/Renderer.h
@@ -44,8 +44,8 @@ namespace Falltergeist
                     GLES2
                 };
 
-                Renderer(RendererConfig cfg);
-                Renderer(int width, int height);
+                Renderer(const RendererConfig& cfg);
+                Renderer(unsigned int width, unsigned int height);
                 Renderer(Size size);
                 ~Renderer();
 

--- a/src/Graphics/Renderer.h
+++ b/src/Graphics/Renderer.h
@@ -25,8 +25,8 @@ namespace Falltergeist
         } while (0)
 
         struct RendererConfig {
-            int width;
-            int height;
+            unsigned int width;
+            unsigned int height;
             int x = SDL_WINDOWPOS_CENTERED;
             int y = SDL_WINDOWPOS_CENTERED;
             bool fullscreen = false;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -37,8 +37,11 @@ namespace Falltergeist
         auto video = file.section("video");
         video->setPropertyInt("width", _screenWidth);
         video->setPropertyInt("height", _screenHeight);
+        video->setPropertyInt("x", _screenX);
+        video->setPropertyInt("y", _screenY);
         video->setPropertyInt("scale", _scale);
         video->setPropertyBool("fullscreen", _fullscreen);
+        video->setPropertyBool("always_on_top", _alwaysOnTop);
 
         auto audio = file.section("audio");
         audio->setPropertyBool("enabled", _audioEnabled);
@@ -84,14 +87,24 @@ namespace Falltergeist
         return true;
     }
 
-    unsigned int Settings::screenWidth() const
+    int Settings::screenWidth() const
     {
         return _screenWidth;
     }
 
-    unsigned int Settings::screenHeight() const
+    int Settings::screenHeight() const
     {
         return _screenHeight;
+    }
+
+    int Settings::screenX() const
+    {
+        return _screenX;
+    }
+
+    int Settings::screenY() const
+    {
+        return _screenY;
     }
 
     bool Settings::audioEnabled() const
@@ -130,8 +143,11 @@ namespace Falltergeist
         {
             _screenWidth = video->propertyInt("width", _screenWidth);
             _screenHeight = video->propertyInt("height", _screenHeight);
+            _screenX = video->propertyInt("x", _screenX);
+            _screenY = video->propertyInt("y", _screenY);
             _scale = video->propertyInt("scale", _scale);
             _fullscreen = video->propertyBool("fullscreen", _fullscreen);
+            _alwaysOnTop = video->propertyBool("always_on_top", _alwaysOnTop);
         }
 
         auto audio = file->section("audio");
@@ -426,6 +442,11 @@ namespace Falltergeist
     bool Settings::fullscreen() const
     {
         return _fullscreen;
+    }
+
+    bool Settings::alwaysOnTop() const
+    {
+        return _alwaysOnTop;
     }
 
     void Settings::setAudioBufferSize(int _audioBufferSize)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -87,12 +87,12 @@ namespace Falltergeist
         return true;
     }
 
-    int Settings::screenWidth() const
+    unsigned int Settings::screenWidth() const
     {
         return _screenWidth;
     }
 
-    int Settings::screenHeight() const
+    unsigned int Settings::screenHeight() const
     {
         return _screenHeight;
     }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -23,9 +23,13 @@ namespace Falltergeist
             bool save();
             bool load();
 
-            unsigned int screenWidth() const;
+            int screenWidth() const;
 
-            unsigned int screenHeight() const;
+            int screenHeight() const;
+
+            int screenX() const;
+
+            int screenY() const;
 
             const std::string& initialLocation() const;
 
@@ -83,12 +87,16 @@ namespace Falltergeist
             unsigned int scale() const;
             void setFullscreen(bool _fullscreen);
             bool fullscreen() const;
+            bool alwaysOnTop() const;
             void setAudioBufferSize(int _audioBufferSize);
             int audioBufferSize() const;
 
         private:
-            unsigned int _screenWidth = 640;
-            unsigned int _screenHeight = 480;
+            int _screenWidth = 640;
+            int _screenHeight = 480;
+            int _screenX = -1;
+            int _screenY = -1;
+            bool _alwaysOnTop = false;
             std::string _initLocation = "klamall";
             bool _forceLocation = false;
             bool _displayFps = true;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -23,9 +23,9 @@ namespace Falltergeist
             bool save();
             bool load();
 
-            int screenWidth() const;
+            unsigned int screenWidth() const;
 
-            int screenHeight() const;
+            unsigned int screenHeight() const;
 
             int screenX() const;
 
@@ -92,8 +92,8 @@ namespace Falltergeist
             int audioBufferSize() const;
 
         private:
-            int _screenWidth = 640;
-            int _screenHeight = 480;
+            unsigned int _screenWidth = 640;
+            unsigned int _screenHeight = 480;
             int _screenX = -1;
             int _screenY = -1;
             bool _alwaysOnTop = false;


### PR DESCRIPTION
This PR adds `x`, `y`, and `always_on_top` to Falltergeist's video configuration options. 

It's a small quality-of-life patch that makes the change --> compile --> view feedback a little bit shorter because, ahead-of-time, I can configure `always_on_top = true`, `x = 1200` (on my monitor), and `y = 1200` (same) so that, whenever I run Falltergeist, the window just pops up in the bottom-right, so I can edit things in my IDE as I click around in the UI.

Again, this is nothing major and just a nice-to-have. I'm currently looking to make minor bugfixes, rather than big architectural changes, so I'm mostly speed-limited by trying something out /w a debugger, stepping through (which, because of `always_on_top`, I can visually see while still having a debugger full-screened), etc.