### PR TITLE
WIP: refactoring State to use smart pointers

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,41 +1,22 @@
-#include <memory>
-#include "src/Exception.h"
 #include "src/Game/Game.h"
 #include "src/Logger.h"
 #include "src/Settings.h"
 #include "src/State/Start.h"
 #include "src/UI/ResourceManager.h"
 
+#include <memory>
+
 using namespace Falltergeist;
 
 int main(int argc, char* argv[])
 {
-    try
-    {
-        auto uiResourceManager = std::make_shared<UI::ResourceManager>();
+    auto uiResourceManager = std::make_shared<UI::ResourceManager>();
 
-        auto game = Game::Game::getInstance();
-        game->setUIResourceManager(uiResourceManager);
-        game->init(std::unique_ptr<Settings>(new Settings()));
-        game->setState(new State::Start(uiResourceManager));
-        game->run();
-        game->shutdown();
-        return 0;
-    }
-    catch(const Exception &e)
-    {
-        Logger::critical() << e.what() << std::endl;
-
-#if defined(_WIN32) || defined(WIN32)
-        system("PAUSE");
-#endif
-    }
-    /*
-    catch (const std::exception &e)
-    {
-        Logger::critical() << e.what() << std::endl;
-    }
-    */
-    return 1;
+    auto game = Game::Game::getInstance();
+    game->setUIResourceManager(uiResourceManager);
+    game->init(std::make_unique<Settings>());
+    game->setState(std::make_unique<State::Start>(uiResourceManager));
+    game->run();
+    game->shutdown();
+    return 0;
 }
-

--- a/src/Event/EventTarget.h
+++ b/src/Event/EventTarget.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <memory>
 #include "../Event/Handler.h"
+#include <memory>
 
 namespace Falltergeist
 {

--- a/src/Format/Msg/File.cpp
+++ b/src/Format/Msg/File.cpp
@@ -89,7 +89,18 @@ namespace Falltergeist
                         return &message;
                     }
                 }
-                throw Exception("File::message() - number is out of range: " + std::to_string(number));
+                throw std::runtime_error("File::message() - number is out of range: " + std::to_string(number));
+            }
+
+            bool File::hasMessage(unsigned int number) {
+                for (auto& message : _messages)
+                {
+                    if (message.number() == number)
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
         }
     }

--- a/src/Format/Msg/File.h
+++ b/src/Format/Msg/File.h
@@ -20,6 +20,7 @@ namespace Falltergeist
                 public:
                     File(Dat::Stream&& stream);
 
+                    bool hasMessage(unsigned int number);
                     Message* message(unsigned int number);
 
                 private:

--- a/src/Game/ContainerItemObject.cpp
+++ b/src/Game/ContainerItemObject.cpp
@@ -20,9 +20,9 @@ namespace Falltergeist
 
         void ContainerItemObject::use_p_proc(CritterObject* usedBy)
         {
-            auto state = new State::Container(std::make_shared<UI::ResourceManager>());
+            auto state = std::make_unique<State::Container>(std::make_shared<UI::ResourceManager>());
             state->setObject(this);
-            Game::getInstance()->pushState(state);
+            Game::getInstance()->pushState(std::move(state));
         }
 
         void ContainerItemObject::setLocked(bool locked)

--- a/src/Game/CritterObject.cpp
+++ b/src/Game/CritterObject.cpp
@@ -498,7 +498,7 @@ namespace Falltergeist
                     animation->frameHandler().add(std::bind(&CritterObject::onMovementAnimationFrame, this, std::placeholders::_1));
                     animation->animationEndedHandler().add(std::bind(&CritterObject::onMovementAnimationEnded, this, std::placeholders::_1));
                     animation->play();
-                    _ui = move(animation);
+                    _ui = std::move(animation);
                 }
             } else {
                 auto anim = (UI::Animation*)ui();
@@ -567,9 +567,9 @@ namespace Falltergeist
                         newAnimation->frameHandler().add(std::bind(&CritterObject::onMovementAnimationFrame, this, std::placeholders::_1));
                         newAnimation->animationEndedHandler().add(std::bind(&CritterObject::onMovementAnimationEnded, this, std::placeholders::_1));
                         newAnimation->play();
+                        curFrameOfs = newAnimation->frameOffset();
                         animation = newAnimation.get();
                         _ui = move(newAnimation);
-                        curFrameOfs = animation->frameOffset();
 
                         // on turns, center frames on current hex
                         ofs -= curFrameOfs;
@@ -624,8 +624,8 @@ namespace Falltergeist
                 orientation()
             );
             animation->play();
-            _ui.reset(animation.get());
-            return animation.release();
+            _ui = std::move(animation);
+            return reinterpret_cast<UI::Animation*>(_ui.get());
         }
 
         bool CritterObject::canTrade() const
@@ -836,7 +836,9 @@ namespace Falltergeist
 
         UI::Animation* CritterObject::animation()
         {
-            return dynamic_cast<UI::Animation*>(ui());
+            auto e = ui();
+            auto cst = dynamic_cast<UI::Animation*>(e);
+            return cst;
         }
     }
 }

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -139,12 +139,12 @@ namespace Falltergeist
             state->emitEvent(std::make_unique<Event::State>("pop"), state->popHandler());
         }
 
-        void Game::setState(State::State* state)
+        void Game::setState(std::unique_ptr<State::State> state)
         {
-            while (!_states.empty()) {
+            while (not _states.empty()) {
                 popState();
             }
-            pushState(state);
+            pushState(state.release());
         }
 
         void Game::run()

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -64,7 +64,7 @@ namespace Falltergeist
                  */
                 State::State* topState(unsigned offset = 0) const;
                 void pushState(State::State* state);
-                void setState(State::State* state);
+                void setState(std::unique_ptr<State::State> state);
                 void popState(bool doDelete = true);
 
                 void run();

--- a/src/Game/Game.h
+++ b/src/Game/Game.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "../Base/Singleton.h"
+#include "../Game/Time.h"
+#include "../UI/IResourceManager.h"
+
 #include <memory>
 #include <string>
 #include <vector>
 #include <SDL.h>
-#include "../Base/Singleton.h"
-#include "../Game/Time.h"
-#include "../UI/IResourceManager.h"
 
 namespace Falltergeist
 {
@@ -58,14 +59,17 @@ namespace Falltergeist
                 static Game* getInstance();
 
                 void shutdown();
+
+                void setState(std::unique_ptr<State::State> state);
+                void pushState(std::unique_ptr<State::State> state);
+                void pushSharedState(std::shared_ptr<State::State> state);
+
                 /**
                  * Returns pointer to a state at the top of stack.
                  * @param offset optional offset (1 means second from the top, and so on)
                  */
-                State::State* topState(unsigned offset = 0) const;
-                void pushState(State::State* state);
-                void setState(std::unique_ptr<State::State> state);
-                void popState(bool doDelete = true);
+                State::State& topState(unsigned offset = 0) const;
+                void popState();
 
                 void run();
                 void quit();
@@ -103,10 +107,11 @@ namespace Falltergeist
                 unsigned int frame() const;
 
                 void setUIResourceManager(std::shared_ptr<UI::IResourceManager> uiResourceManager);
-            protected:
+
+            private:
                 std::vector<int> _GVARS;
-                std::vector<std::unique_ptr<State::State>> _states;
-                std::vector<std::unique_ptr<State::State>> _statesForDelete;
+                std::vector<std::shared_ptr<State::State>> _states;
+                std::vector<std::shared_ptr<State::State>> _statesForDelete;
 
                 std::shared_ptr<Time> _gameTime;
 
@@ -132,7 +137,6 @@ namespace Falltergeist
                 std::vector<State::State*> _getVisibleStates();
                 std::vector<State::State*> _getActiveStates();
 
-            private:
                 std::shared_ptr<UI::IResourceManager> uiResourceManager;
                 friend class Base::Singleton<Game>;
                 void _initGVARS();

--- a/src/Game/Object.cpp
+++ b/src/Game/Object.cpp
@@ -146,11 +146,6 @@ namespace Falltergeist
             return _ui.get();
         }
 
-        void Object::setUI(UI::Base *ui)
-        {
-            _ui.reset(ui);
-        }
-
         void Object::_generateUi()
         {
             Graphics::ObjectUIFactory uiFactory;

--- a/src/Game/Object.h
+++ b/src/Game/Object.h
@@ -141,7 +141,6 @@ namespace Falltergeist
 
                 // ActiveUI used to display object on screen and capture mouse events
                 UI::Base* ui() const;
-                void setUI(UI::Base* ui);
 
                 // Hexagon of object current position
                 Hexagon* hexagon() const;

--- a/src/Graphics/CritterAnimationFactory.cpp
+++ b/src/Graphics/CritterAnimationFactory.cpp
@@ -17,12 +17,7 @@ namespace Falltergeist
                 animName += action;
             }
 
-            auto animation = std::make_unique<UI::Animation>("art/critters/" + animName + ".frm", orientation);
-            // TODO move it elsewhere
-            //animation->animationEndedHandler().add([&animation](Event::Event* event) {
-            //    animation->setCurrentFrame(0);
-            //});
-            return animation;
+            return std::make_unique<UI::Animation>("art/critters/" + animName + ".frm", orientation);
         }
 
         std::unique_ptr<UI::Animation> CritterAnimationFactory::buildActionAnimation(uint32_t armorFID, uint32_t weaponId, uint32_t action, Game::Orientation orientation)

--- a/src/Graphics/ObjectUIFactory.cpp
+++ b/src/Graphics/ObjectUIFactory.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 #include "../Graphics/ObjectUIFactory.h"
 #include "../ResourceManager.h"
 #include "../Format/Frm/File.h"
@@ -13,7 +14,9 @@ namespace Falltergeist
         {
             auto frm = ResourceManager::getInstance()->frmFileType(fid);
             if (!frm) {
-                return nullptr;
+                std::stringstream ss;
+                ss << fid << ": invalid fid passed to buildByFID";
+                throw std::runtime_error{ss.str()};
             }
 
             if (frm->framesPerDirection() > 1 || frm->directions().size() > 1) {

--- a/src/Graphics/Point.cpp
+++ b/src/Graphics/Point.cpp
@@ -34,6 +34,12 @@ namespace Falltergeist
             _y = y;
         }
 
+        Point Point::operator +(Point rhs) const
+        {
+            rhs += *this;
+            return rhs;
+        }
+
         Point& Point::operator +=(const Point& rhs)
         {
             _x += rhs._x;
@@ -72,13 +78,7 @@ namespace Falltergeist
             return !(*this == rhs);
         }
 
-        Point operator +(Point lhs, const Point& rhs)
-        {
-            lhs += rhs;
-            return lhs;
-        }
-
-        Point operator -(Point lhs, const Point& rhs)
+        Point operator -(Point lhs, Point rhs)
         {
             lhs -= rhs;
             return lhs;
@@ -99,6 +99,11 @@ namespace Falltergeist
         Point Point::add(const Point& rhs) const
         {
             return *this + rhs;
+        }
+
+        Point Point::add(int x, int y) const
+        {
+            return add({x, y});
         }
 
         Point Point::sub(const Point& rhs) const

--- a/src/Graphics/Point.h
+++ b/src/Graphics/Point.h
@@ -25,6 +25,7 @@ namespace Falltergeist
                 void setX(int x);
                 void setY(int y);
 
+                Point operator +(Point rhs) const;
                 Point& operator +=(const Point& rhs);
                 Point& operator -=(const Point& rhs);
                 Point& operator *=(double rhs);
@@ -33,13 +34,13 @@ namespace Falltergeist
                 bool operator ==(const Point& rhs) const;
                 bool operator !=(const Point& rhs) const;
 
-                friend Point operator +(Point lhs, const Point& rhs);
-                friend Point operator -(Point lhs, const Point& rhs);
+                friend Point operator -(Point lhs, Point rhs);
                 friend Point operator *(Point lhs, double rhs);
                 friend Point operator /(Point lhs, double rhs);
 
                 // Addition of given Point
                 Point add(const Point& rhs) const;
+                Point add(int x, int y) const;
                 // Subtraction of given Point
                 Point sub(const Point& rhs) const;
                 // Multiplication by given number

--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -251,8 +251,8 @@ namespace Falltergeist
                     _fadeAlpha = (_fadeAlpha <= 0 ? 0 : 255);
                     _fadeDone = true;
 
-                    auto state = Game::getInstance()->topState();
-                    state->emitEvent(std::make_unique<Event::State>("fadedone"), state->fadeDoneHandler());
+                    auto& state = Game::getInstance()->topState();
+                    state.emitEvent(std::make_unique<Event::State>("fadedone"), state.fadeDoneHandler());
                     return;
                 }
             }

--- a/src/Helpers/StateLocationHelper.cpp
+++ b/src/Helpers/StateLocationHelper.cpp
@@ -9,14 +9,14 @@ namespace Falltergeist
 {
     namespace Helpers
     {
-        State::Location* StateLocationHelper::getInitialLocationState() const
+        std::unique_ptr<State::Location> StateLocationHelper::getInitialLocationState() const
         {
             GameLocationHelper gameLocationHelper;
             auto initialLocation = gameLocationHelper.getInitialLocation();
 
             auto game = Game::getInstance();
 
-            auto locationState = new State::Location(
+            auto locationState = std::make_unique<State::Location>(
                 game->player(),
                 game->mouse(),
                 game->settings(),

--- a/src/Helpers/StateLocationHelper.h
+++ b/src/Helpers/StateLocationHelper.h
@@ -12,7 +12,7 @@ namespace Falltergeist
         {
             public:
                 StateLocationHelper() = default;
-                State::Location* getInitialLocationState() const;
+                std::unique_ptr<State::Location> getInitialLocationState() const;
         };
     }
 }

--- a/src/Input/Mouse.cpp
+++ b/src/Input/Mouse.cpp
@@ -94,91 +94,95 @@ namespace Falltergeist
 
         void Mouse::_setType(Cursor state)
         {
-            if (this->state() == state) return;
-            _ui.reset(nullptr);
+            if (this->state() == state) {
+                return;
+            }
+
+            _ui = nullptr;
+
             switch (state)
             {
                 case Cursor::BIG_ARROW:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/stdarrow.frm"));
+                    _ui = resourceManager->getImage("art/intrface/stdarrow.frm");
                     break;
                 case Cursor::SCROLL_W:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrwest.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrwest.frm");
                     _ui->setOffset(0, -_ui->size().height() / 2);
                     break;
                 case Cursor::SCROLL_W_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrwx.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrwx.frm");
                     _ui->setOffset(0, -_ui->size().height() / 2);
                     break;
                 case Cursor::SCROLL_N:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrnorth.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrnorth.frm");
                     _ui->setOffset( -_ui->size().width() / 2, 0);
                     break;
                 case Cursor::SCROLL_N_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrnx.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrnx.frm");
                     _ui->setOffset( -_ui->size().width() / 2, 0);
                     break;
                 case Cursor::SCROLL_S:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrsouth.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrsouth.frm");
                     _ui->setOffset( -_ui->size().width() / 2, -_ui->size().height());
                     break;
                 case Cursor::SCROLL_S_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrsx.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrsx.frm");
                     _ui->setOffset(-_ui->size().width() / 2, -_ui->size().height());
                     break;
                 case Cursor::SCROLL_E:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/screast.frm"));
+                    _ui = resourceManager->getImage("art/intrface/screast.frm");
                     _ui->setOffset( -_ui->size().width(), -_ui->size().height() / 2);
                     break;
                 case Cursor::SCROLL_E_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/screx.frm"));
+                    _ui = resourceManager->getImage("art/intrface/screx.frm");
                     _ui->setOffset(-_ui->size().width(), -_ui->size().height() / 2);
                     break;
                 case Cursor::SCROLL_NW:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrnwest.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrnwest.frm");
                     break;
                 case Cursor::SCROLL_NW_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrnwx.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrnwx.frm");
                     break;
                 case Cursor::SCROLL_SW:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrswest.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrswest.frm");
                     _ui->setOffset(0, -_ui->size().height());
                     break;
                 case Cursor::SCROLL_SW_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrswx.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrswx.frm");
                     _ui->setOffset(0, -_ui->size().height());
                     break;
                 case Cursor::SCROLL_NE:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrneast.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrneast.frm");
                     _ui->setOffset(-_ui->size().width(), 0);
                     break;
                 case Cursor::SCROLL_NE_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrnex.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrnex.frm");
                     _ui->setOffset(-_ui->size().width(), 0);
                     break;
                 case Cursor::SCROLL_SE:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrseast.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrseast.frm");
                     _ui->setOffset(-_ui->size().width(), -_ui->size().height());
                     break;
                 case Cursor::SCROLL_SE_X:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/scrsex.frm"));
+                    _ui = resourceManager->getImage("art/intrface/scrsex.frm");
                     _ui->setOffset(-_ui->size().width(), -_ui->size().height());
                     break;
                 case Cursor::HEXAGON_RED:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/msef000.frm"));
+                    _ui = resourceManager->getImage("art/intrface/msef000.frm");
                     _ui->setOffset(- _ui->size().width() / 2, - _ui->size().height() / 2);
                     break;
                 case Cursor::ACTION:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/actarrow.frm"));
+                    _ui = resourceManager->getImage("art/intrface/actarrow.frm");
                     break;
                 case Cursor::HAND:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/hand.frm"));
+                    _ui = resourceManager->getImage("art/intrface/hand.frm");
                     break;
                 case Cursor::SMALL_DOWN_ARROW:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/sdnarrow.frm"));
+                    _ui = resourceManager->getImage("art/intrface/sdnarrow.frm");
                     _ui->setOffset(-5, -10);
                     break;
                 case Cursor::SMALL_UP_ARROW:
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/suparrow.frm"));
+                    _ui = resourceManager->getImage("art/intrface/suparrow.frm");
                     _ui->setOffset(-5, 0);
                     break;
                 case Cursor::WAIT:
@@ -193,7 +197,7 @@ namespace Falltergeist
                 }
                 case Cursor::USE:
                 {
-                    _ui = std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/crossuse.frm"));
+                    _ui = resourceManager->getImage("art/intrface/crossuse.frm");
                     _ui->setOffset(-10, -10);
                     break;
                 }

--- a/src/Input/Mouse.h
+++ b/src/Input/Mouse.h
@@ -96,7 +96,7 @@ namespace Falltergeist
                 bool _visible = true;
                 Cursor _type = Cursor::NONE;
                 std::vector<Cursor> _states;
-                std::unique_ptr<UI::Base> _ui;
+                std::shared_ptr<UI::Base> _ui;
                 void _setType(Cursor type);
         };
     }

--- a/src/State/Container.h
+++ b/src/State/Container.h
@@ -2,6 +2,7 @@
 
 #include "../State/State.h"
 #include "../UI/IResourceManager.h"
+#include "../UI/Factory/ImageButtonFactory.h"
 
 namespace Falltergeist
 {
@@ -13,13 +14,6 @@ namespace Falltergeist
     namespace Game
     {
         class ContainerItemObject;
-    }
-    namespace UI
-    {
-        namespace Factory
-        {
-            class ImageButtonFactory;
-        }
     }
     namespace State
     {

--- a/src/State/Credits.cpp
+++ b/src/State/Credits.cpp
@@ -87,7 +87,7 @@ namespace Falltergeist
                 tx->setSize({640, 0});
                 tx->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
                 y += tx->textSize().height() + cur_font->verticalGap() + additionalGap;
-                addUI(tx);
+                addSharedUI(tx);
                 _lines.emplace_back(std::move(tx));
             }
 

--- a/src/State/Credits.cpp
+++ b/src/State/Credits.cpp
@@ -108,7 +108,7 @@ namespace Falltergeist
 
             long int _lastY = 0;
             for (size_t i = 0; i < _lines.size(); i++) {
-                auto& ui = _lines.at(i).get();
+                auto& ui = *_lines.at(i);
                 int yPosition = _linePositions[i] - static_cast<int>(_timePassed * scrollingSpeed);
                 ui.setY(yPosition);
                 _lastY = ui.y();

--- a/src/State/Credits.cpp
+++ b/src/State/Credits.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include <sstream>
 #include "../State/Credits.h"
 #include "../CrossPlatform.h"
@@ -81,13 +82,13 @@ namespace Falltergeist
                     line = "    ";
                 }
 
-                auto tx = new UI::TextArea(line, 0, y);
+                auto tx = std::make_shared<UI::TextArea>(line, 0, y);
                 tx->setFont(cur_font, cur_color);
                 tx->setSize({640, 0});
                 tx->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-                addUI(tx);
-                _lines.push_back(tx);
                 y += tx->textSize().height() + cur_font->verticalGap() + additionalGap;
+                addUI(tx);
+                _lines.emplace_back(std::move(tx));
             }
 
             _linePositions = new int[_lines.size()];
@@ -107,10 +108,10 @@ namespace Falltergeist
 
             long int _lastY = 0;
             for (size_t i = 0; i < _lines.size(); i++) {
-                auto ui = _lines.at(i);
+                auto& ui = _lines.at(i).get();
                 int yPosition = _linePositions[i] - static_cast<int>(_timePassed * scrollingSpeed);
-                ui->setY(yPosition);
-                _lastY = ui->y();
+                ui.setY(yPosition);
+                _lastY = ui.y();
             }
 
             if (_lastY < -30) {

--- a/src/State/Credits.h
+++ b/src/State/Credits.h
@@ -24,7 +24,7 @@ namespace Falltergeist
                 void onCreditsFadeDone(Event::State* event);
                 void onStateActivate(Event::State* event) override;
             private:
-                std::vector<UI::TextArea*> _lines;
+                std::vector<std::shared_ptr<UI::TextArea>> _lines;
                 int* _linePositions = nullptr;
                 float _timePassed = 0;
         };

--- a/src/State/CritterBarter.cpp
+++ b/src/State/CritterBarter.cpp
@@ -270,7 +270,7 @@ namespace Falltergeist
 
         void CritterBarter::onTalkButtonClick(Event::Mouse*)
         {
-            if (auto interact = dynamic_cast<CritterInteract*>(Game::getInstance()->topState(1))) {
+            if (auto interact = dynamic_cast<CritterInteract*>(&Game::getInstance()->topState(1))) {
                 interact->switchSubState(CritterInteract::SubState::DIALOG);
             }
         }

--- a/src/State/CritterBarter.cpp
+++ b/src/State/CritterBarter.cpp
@@ -55,26 +55,33 @@ namespace Falltergeist
             Helpers::CritterHelper critterHelper;
             Graphics::CritterAnimationFactory animationFactory;
 
-            auto dudeCritter = animationFactory.buildStandingAnimation(
-                critterHelper.armorFID(dude.get()),
-                critterHelper.weaponId(dude.get()),
-                Game::Orientation::SC
-            );
-            dudeCritter->setPosition({30, 45});
-            addUI(dudeCritter.release());
+            {
+                auto dudeCritter = animationFactory.buildStandingAnimation(
+                        critterHelper.armorFID(dude.get()),
+                        critterHelper.weaponId(dude.get()),
+                        Game::Orientation::SC
+                );
+                dudeCritter->setPosition({30, 45});
+                addUI(std::move(dudeCritter));
+            }
 
-            auto traderCritter = animationFactory.buildStandingAnimation(
-                critterHelper.armorFID(_trader),
-                critterHelper.weaponId(_trader),
-                Game::Orientation::SC
-            );
-            traderCritter->setPosition({ 580, 45 });
-            addUI(traderCritter.release());
+            {
+                auto traderCritter = animationFactory.buildStandingAnimation(
+                        critterHelper.armorFID(_trader),
+                        critterHelper.weaponId(_trader),
+                        Game::Orientation::SC
+                );
+                traderCritter->setPosition({ 580, 45 });
+                addUI(std::move(traderCritter));
+            }
 
-            auto reaction = new UI::TextArea("", 140, -62);
-            reaction->setSize({375, 53});
-            reaction->setPadding({0, 5}, {0, 5});
-            addUI("reaction", reaction);
+            {
+                auto reaction = std::make_unique<UI::TextArea>("", 140, -62);
+                reaction->setSize({375, 53});
+                reaction->setPadding({0, 5}, {0, 5});
+                addUI("reaction", std::move(reaction));
+            }
+
 
             addUI("offerButton", imageButtonFactory->getByType(ImageButtonType::DIALOG_RED_BUTTON, {40, 162}));
             getUI("offerButton")->mouseClickHandler().add(std::bind(&CritterBarter::onOfferButtonClick, this, std::placeholders::_1));
@@ -82,84 +89,118 @@ namespace Falltergeist
             addUI("talkButton", imageButtonFactory->getByType(ImageButtonType::DIALOG_RED_BUTTON, {583, 162}));
             getUI("talkButton")->mouseClickHandler().add(std::bind(&CritterBarter::onTalkButtonClick, this, std::placeholders::_1));
 
-            auto scrollUp = [](UI::ItemsList *list) { if (list->canScrollUp()) list->scrollUp(); };
-            auto scrollDown = [](UI::ItemsList *list) { if (list->canScrollDown()) list->scrollDown(); };
+            auto scrollUp = [](UI::ItemsList& list) {
+                if (list.canScrollUp()) {
+                    list.scrollUp();
+                }
+            };
+            auto scrollDown = [](UI::ItemsList& list) {
+                if (list.canScrollDown()) {
+                    list.scrollDown();
+                }
+            };
 
-            auto mineList = new UI::ItemsList({ 104, 35 });
+            auto mineList = std::shared_ptr<UI::ItemsList>{new UI::ItemsList({ 104, 35 })};
             mineList->setSlotsNumber(3);
             mineList->setItems(Game::getInstance()->player()->inventory());
             addUI("mineList", mineList);
 
-            auto mineInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_UP_ARROW, {190, 56});
-            mineInventoryScrollUpButton->mouseClickHandler().add([=](...) { scrollUp(mineList); });
-            addUI(mineInventoryScrollUpButton);
+            {
+                auto mineInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_UP_ARROW, {190, 56});
+                mineInventoryScrollUpButton->mouseClickHandler().add([=](...) {
+                    scrollUp(*mineList);
+                });
+                addUI(std::move(mineInventoryScrollUpButton));
+            }
 
-            auto mineInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DOWN_ARROW, {190, 82});
-            mineInventoryScrollDownButton->mouseClickHandler().add([=](...) { scrollDown(mineList); });
-            addUI(mineInventoryScrollDownButton);
+            {
+                auto mineInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DOWN_ARROW, {190, 82});
+                mineInventoryScrollDownButton->mouseClickHandler().add([=](...) {
+                    scrollDown(*mineList);
+                });
+                addUI(std::move(mineInventoryScrollDownButton));
+            }
 
-            auto sellList = new UI::ItemsList({ 244, 20 });
+            auto sellList = std::shared_ptr<UI::ItemsList>{new UI::ItemsList({ 244, 20 })};
             sellList->setItems(&_itemsToSell);
             sellList->setSlotsNumber(3);
             addUI("sellList", sellList);
 
-            auto sellInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_UP_ARROW, {208, 114});
-            sellInventoryScrollUpButton->mouseClickHandler().add([=](...) { scrollUp(sellList); });
-            addUI(sellInventoryScrollUpButton);
+            {
+                auto sellInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_UP_ARROW, {208, 114});
+                sellInventoryScrollUpButton->mouseClickHandler().add([=](...) {
+                    scrollUp(*sellList);
+                });
+                addUI(std::move(sellInventoryScrollUpButton));
+            }
 
-            auto sellInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_DOWN_ARROW, {208, 137});
-            sellInventoryScrollDownButton->mouseClickHandler().add([=](...) { scrollDown(sellList); });
-            addUI(sellInventoryScrollDownButton);
+            {
+                auto sellInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_DOWN_ARROW, {208, 137});
+                sellInventoryScrollDownButton->mouseClickHandler().add([=](...) {
+                    scrollDown(*sellList);
+                });
+                addUI(std::move(sellInventoryScrollDownButton));
+            }
 
-            auto theirsList = new UI::ItemsList({ 470, 35 });
+            auto theirsList = std::shared_ptr<UI::ItemsList>{new UI::ItemsList({ 470, 35 })};
             theirsList->setItems(trader()->inventory());
             theirsList->setSlotsNumber(3);
             addUI("theirsList", theirsList);
 
-            auto theirsInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_UP_ARROW, {421, 56});
-            theirsInventoryScrollUpButton->mouseClickHandler().add([=](...) { scrollUp(theirsList); });
-            addUI(theirsInventoryScrollUpButton);
+            {
+                auto theirsInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_UP_ARROW, {421, 56});
+                theirsInventoryScrollUpButton->mouseClickHandler().add([=](...) {
+                    scrollUp(*theirsList);
+                });
+                addUI(std::move(theirsInventoryScrollUpButton));
+            }
 
-            auto theirsInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DOWN_ARROW, {421, 82});
-            theirsInventoryScrollDownButton->mouseClickHandler().add([=](...) { scrollDown(theirsList); });
-            addUI(theirsInventoryScrollDownButton);
+            {
+                auto theirsInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DOWN_ARROW, {421, 82});
+                theirsInventoryScrollDownButton->mouseClickHandler().add([=](...) {
+                    scrollDown(*theirsList);
+                });
+                addUI(std::move(theirsInventoryScrollDownButton));
+            }
 
-            auto buyList = new UI::ItemsList({ 330, 20 });
+            auto buyList = std::shared_ptr<UI::ItemsList>{new UI::ItemsList({ 330, 20 })};
             buyList->setItems(&_itemsToBuy);
             buyList->setSlotsNumber(3);
             addUI("buyList", buyList);
 
-            auto buyInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_UP_ARROW, {413, 114});
-            buyInventoryScrollUpButton->mouseClickHandler().add([=](...) { scrollUp(buyList); });
-            addUI(buyInventoryScrollUpButton);
+            {
+                auto buyInventoryScrollUpButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_UP_ARROW, {413, 114});
+                buyInventoryScrollUpButton->mouseClickHandler().add([=](...) {
+                    scrollUp(*buyList);
+                });
+                addUI(std::move(buyInventoryScrollUpButton));
+            }
 
-            auto buyInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_DOWN_ARROW, {413, 137});
-            buyInventoryScrollDownButton->mouseClickHandler().add([=](...) { scrollDown(buyList); });
-            addUI(buyInventoryScrollDownButton);
+            {
+                auto buyInventoryScrollDownButton = imageButtonFactory->getByType(ImageButtonType::INVENTORY_DOWN_ARROW, {413, 137});
+                buyInventoryScrollDownButton->mouseClickHandler().add([=](...) {
+                    scrollDown(*buyList);
+                });
+                addUI(std::move(buyInventoryScrollDownButton));
+            }
 
-            auto sellPriceText = new UI::TextArea("$0", 246, 168);
-            sellPriceText->setColor({ 255, 255, 255, 0 });
-            addUI("sellPriceText", sellPriceText);
-
-            auto buyPriceText = new UI::TextArea("$0", 334, 168);
-            buyPriceText->setColor({ 255, 255, 255, 0 });
-            addUI("buyPriceText", buyPriceText);
-
-            mineList->itemDragStopHandler().add([sellList](Event::Mouse* event){ sellList->onItemDragStop(event); });
-            sellList->itemDragStopHandler().add([mineList](Event::Mouse* event){ mineList->onItemDragStop(event); });
-            sellList->itemsListModifiedHandler().add([this, sellPriceText](Event::Event*)
-                {
+            {
+                auto sellPriceText = std::shared_ptr<UI::TextArea>{new UI::TextArea("$0", 246, 168)};
+                sellPriceText->setColor({255, 255, 255, 0});
+                sellList->itemsListModifiedHandler().add([this, sellPriceText](Event::Event*) {
                     _sellPriceTotal = 0;
                     for (const auto &v : _itemsToSell) {
                         _sellPriceTotal += v->price() * v->amount();
                     }
                     sellPriceText->setText("$" + std::to_string(_sellPriceTotal));
                 });
+                addUI("sellPriceText", sellPriceText);
+            }
 
-            theirsList->itemDragStopHandler().add([buyList](Event::Mouse* event){ buyList->onItemDragStop(event); });
-            buyList->itemDragStopHandler().add([theirsList](Event::Mouse* event){ theirsList->onItemDragStop(event); });
-            buyList->itemsListModifiedHandler().add([this, buyPriceText](Event::Event*)
-                {
+            {
+                auto buyPriceText = std::shared_ptr<UI::TextArea>{new UI::TextArea("$0", 334, 168)};
+                buyPriceText->setColor({ 255, 255, 255, 0 });
+                buyList->itemsListModifiedHandler().add([this, buyPriceText](Event::Event*) {
                     _buyPriceTotal = 0;
                     for (const auto &v : _itemsToBuy) {
                         // TODO: apply barter skill + Master Trader perk + Reaction (mood?) modifier
@@ -167,21 +208,35 @@ namespace Falltergeist
                     }
                     buyPriceText->setText("$" + std::to_string(_buyPriceTotal));
                 });
+                addUI("buyPriceText", buyPriceText);
+            }
 
+            mineList->itemDragStopHandler().add([=](Event::Mouse* event){
+                sellList->onItemDragStop(event);
+            });
+            sellList->itemDragStopHandler().add([=](Event::Mouse* event){
+                mineList->onItemDragStop(event);
+            });
+            theirsList->itemDragStopHandler().add([=](Event::Mouse* event){
+                buyList->onItemDragStop(event);
+            });
+            buyList->itemDragStopHandler().add([=](Event::Mouse* event){
+                theirsList->onItemDragStop(event);
+            });
         }
 
         void CritterBarter::resetTransaction()
         {
-            dynamic_cast<UI::TextArea*>(getUI("sellPriceText"))->setText("$0");
-            dynamic_cast<UI::TextArea*>(getUI("buyPriceText"))->setText("$0");
+            getUI<UI::TextArea>("sellPriceText")->setText("$0");
+            getUI<UI::TextArea>("buyPriceText")->setText("$0");
 
             _itemsToSell.clear();
-            dynamic_cast<UI::ItemsList*>(getUI("mineList"))->setItems(Game::getInstance()->player()->inventory());
-            dynamic_cast<UI::ItemsList*>(getUI("sellList"))->setItems(&_itemsToSell);
+            getUI<UI::ItemsList>("mineList")->setItems(Game::getInstance()->player()->inventory());
+            getUI<UI::ItemsList>("sellList")->setItems(&_itemsToSell);
 
             _itemsToBuy.clear();
-            dynamic_cast<UI::ItemsList*>(getUI("theirsList"))->setItems(_trader->inventory());
-            dynamic_cast<UI::ItemsList*>(getUI("buyList"))->setItems(&_itemsToBuy);
+            getUI<UI::ItemsList>("theirsList")->setItems(_trader->inventory());
+            getUI<UI::ItemsList>("buyList")->setItems(&_itemsToBuy);
 
             _sellPriceTotal = 0;
             _buyPriceTotal = 0;
@@ -189,7 +244,7 @@ namespace Falltergeist
 
         void CritterBarter::onOfferButtonClick(Event::Mouse*)
         {
-            auto reaction = dynamic_cast<UI::TextArea*>(getUI("reaction"));
+            auto reaction = getUI<UI::TextArea>("reaction");
 
             try {
                 if (_sellPriceTotal == 0 && _buyPriceTotal == 0) {
@@ -238,7 +293,7 @@ namespace Falltergeist
             for (const auto &v : _itemsToBuy)
                 _trader->inventory()->push_back(v);
 
-            dynamic_cast<UI::TextArea*>(getUI("reaction"))->setText("");
+            getUI<UI::TextArea>("reaction")->setText("");
 
             resetTransaction();
         }

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -48,35 +48,35 @@ namespace Falltergeist
 
             addUI("background", resourceManager->getImage("art/intrface/di_talk.frm"));
 
-            auto question = makeNamedUI<UI::TextArea>("question", 140, -62);
+            auto& question = makeNamedUI<UI::TextArea>("question", 140, -62);
             //auto question = new UI::TextArea("question", 140, -62);
-            question->setSize({375, 53});
+            question.setSize({375, 53});
             // TODO: maybe padding properties should be removed from TextArea to simplify it. Use invisible panel for mouse interactions.
-            question->setPadding({0, 5}, {0, 5});
-            question->setWordWrap(true);
+            question.setPadding({0, 5}, {0, 5});
+            question.setWordWrap(true);
 
             // TODO: maybe move text scrolling into separate UI? Though it is only in two places and works slightly differently...
-            question->mouseClickHandler().add([question](Event::Mouse* event) {
-                Point relPos = event->position() - question->position();
-                if (relPos.y() < (question->size().height() / 2))
+            question.mouseClickHandler().add([&](Event::Mouse* event) {
+                Point relPos = event->position() - question.position();
+                if (relPos.y() < (question.size().height() / 2))
                 {
-                    if (question->lineOffset() > 0)
+                    if (question.lineOffset() > 0)
                     {
-                        question->setLineOffset(question->lineOffset() - 4);
+                        question.setLineOffset(question.lineOffset() - 4);
                     }
                 }
-                else if (question->lineOffset() < question->numLines() - 4)
+                else if (question.lineOffset() < question.numLines() - 4)
                 {
-                    question->setLineOffset(question->lineOffset() + 4);
+                    question.setLineOffset(question.lineOffset() + 4);
                 }
             });
 
-            question->mouseMoveHandler().add([question](Event::Mouse* event) {
-                if (question->numLines() > 4)
+            question.mouseMoveHandler().add([&](Event::Mouse* event) {
+                if (question.numLines() > 4)
                 {
                     auto mouse = Game::getInstance()->mouse();
-                    Point relPos = event->position() - question->position();
-                    auto state = relPos.y() < (question->size().height() / 2)
+                    Point relPos = event->position() - question.position();
+                    auto state = relPos.y() < (question.size().height() / 2)
                         ? Input::Mouse::Cursor::SMALL_UP_ARROW
                         : Input::Mouse::Cursor::SMALL_DOWN_ARROW;
 
@@ -87,16 +87,16 @@ namespace Falltergeist
                 }
             });
 
-            question->mouseOutHandler().add([](Event::Mouse* event) {
+            question.mouseOutHandler().add([](Event::Mouse* event) {
                 Game::getInstance()->mouse()->setState(Input::Mouse::Cursor::BIG_ARROW);
             });
 
             // Interface buttons
-            auto reviewButton = addUI(imageButtonFactory->getByType(ImageButtonType::DIALOG_REVIEW_BUTTON, {13, 154}));
-            reviewButton->mouseClickHandler().add(std::bind(&CritterDialog::onReviewButtonClick, this, std::placeholders::_1));
+            auto& reviewButton = addUI(imageButtonFactory->getByType(ImageButtonType::DIALOG_REVIEW_BUTTON, {13, 154}));
+            reviewButton.mouseClickHandler().add(std::bind(&CritterDialog::onReviewButtonClick, this, std::placeholders::_1));
 
             auto barterButton = addUI(imageButtonFactory->getByType(ImageButtonType::DIALOG_RED_BUTTON, {593, 40}));
-            barterButton->mouseClickHandler().add(std::bind(&CritterDialog::onBarterButtonClick, this, std::placeholders::_1));
+            barterButton.mouseClickHandler().add(std::bind(&CritterDialog::onBarterButtonClick, this, std::placeholders::_1));
         }
 
         // TODO: add auto-text scrolling after 10 seconds (when it's longer than 4 lines)
@@ -245,7 +245,7 @@ namespace Falltergeist
                 y += answer->textSize().height() + 5;
             }
 
-            auto answer = makeUI<UI::TextArea>(line, 140, y);
+            auto answer = makeSharedUI<UI::TextArea>(line, 140, y);
             answer->setWordWrap(true);
             answer->setSize({370, 0});
 

--- a/src/State/CritterDialog.cpp
+++ b/src/State/CritterDialog.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <vector>
 #include "../functions.h"
 #include "../State/CritterDialog.h"
@@ -103,7 +103,7 @@ namespace Falltergeist
         void CritterDialog::setQuestion(const std::string& value)
         {
             auto game = Game::getInstance();
-            auto dialog = dynamic_cast<CritterInteract*>(game->topState(1));
+            auto dialog = dynamic_cast<CritterInteract*>(&game->topState(1));
 
             dialog->dialogReview()->addQuestion(std::string("  ") + value);
 
@@ -147,7 +147,7 @@ namespace Falltergeist
 
         void CritterDialog::onReviewButtonClick(Event::Mouse* event)
         {
-            if (auto interact = dynamic_cast<CritterInteract*>(Game::getInstance()->topState(1)))
+            if (auto interact = dynamic_cast<CritterInteract*>(&Game::getInstance()->topState(1)))
             {
                 interact->switchSubState(CritterInteract::SubState::REVIEW);
             }
@@ -155,7 +155,7 @@ namespace Falltergeist
 
         void CritterDialog::onBarterButtonClick(Event::Mouse* event)
         {
-            if (auto interact = dynamic_cast<CritterInteract*>(Game::getInstance()->topState(1)))
+            if (auto interact = dynamic_cast<CritterInteract*>(&Game::getInstance()->topState(1)))
             {
                 if (interact->critter()->canTrade()) {
                     interact->switchSubState(CritterInteract::SubState::BARTER);
@@ -209,7 +209,7 @@ namespace Falltergeist
             if (i >= _answers.size()) throw Exception("No answer with number " + std::to_string(i));
 
             auto game = Game::getInstance();
-            auto dialog = dynamic_cast<CritterInteract*>(game->topState(1));
+            auto dialog = dynamic_cast<CritterInteract*>(&game->topState(1));
 
             dialog->dialogReview()->addAnswer(_answers.at(i)->text().substr(1));
 

--- a/src/State/CritterDialog.h
+++ b/src/State/CritterDialog.h
@@ -48,7 +48,7 @@ namespace Falltergeist
             protected:
                 std::vector<int> _functions;
                 std::vector<int> _reactions;
-                std::vector<UI::TextArea*> _answers;
+                std::vector<std::shared_ptr<UI::TextArea>> _answers;
 
                 void _selectAnswer(size_t i);
 

--- a/src/State/CritterDialogReview.cpp
+++ b/src/State/CritterDialogReview.cpp
@@ -17,10 +17,11 @@ namespace Falltergeist
 
     namespace State
     {
-        CritterDialogReview::CritterDialogReview(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        CritterDialogReview::CritterDialogReview(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void CritterDialogReview::init()
@@ -50,26 +51,25 @@ namespace Falltergeist
             {
                 auto upButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_UP_ARROW, backgroundPos + Point(476, 154));
                 upButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onUpButtonClick, this, std::placeholders::_1));
-                addUI(upButton);
+                addUI(std::move(upButton));
             }
 
             {
                 auto downButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_DOWN_ARROW, backgroundPos + Point(476, 192));
                 downButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDownButtonClick, this, std::placeholders::_1));
-                addUI(downButton);
+                addUI(std::move(downButton));
             }
 
             {
-                auto list = new UI::TextAreaList(Point(88,76));
+                auto list = std::make_unique<UI::TextAreaList>(Point{88, 76});
                 list->setSize(Size(340,340));
-                addUI("list",list);
+                addUI("list", std::move(list));
             }
         }
 
         void CritterDialogReview::onStateActivate(Event::State *event)
         {
-            auto list = dynamic_cast<UI::TextAreaList*>(getUI("list"));
-            list->scrollTo(0);
+            getUI<UI::TextAreaList>("list")->scrollTo(0);
         }
 
 
@@ -83,14 +83,12 @@ namespace Falltergeist
 
         void CritterDialogReview::onUpButtonClick(Event::Mouse *event)
         {
-            auto list = dynamic_cast<UI::TextAreaList*>(getUI("list"));
-            list->scrollUp(4);
+            getUI<UI::TextAreaList>("list")->scrollUp(4);
         }
 
         void CritterDialogReview::onDownButtonClick(Event::Mouse *event)
         {
-            auto list = dynamic_cast<UI::TextAreaList*>(getUI("list"));
-            list->scrollDown(4);
+            getUI<UI::TextAreaList>("list")->scrollDown(4);
         }
 
         void CritterDialogReview::setCritterName(const std::string &value)
@@ -100,43 +98,42 @@ namespace Falltergeist
 
         void CritterDialogReview::addAnswer(const std::string &value)
         {
-            auto dudeName = new UI::TextArea(0, 0);
+            auto dudeName = std::make_unique<UI::TextArea>(0, 0);
             dudeName->setWidth(340);
             dudeName->setWordWrap(true);
             dudeName->setFont("font1.aaf", {0xa0,0xa0, 0xa0, 0xff});
             dudeName->setText(Game::getInstance()->player()->name()+":");
 
-            auto answer = new UI::TextArea(0, 0);
+            auto answer = std::make_unique<UI::TextArea>(0, 0);
             answer->setWidth(316);
             answer->setOffset(26,0);
             answer->setWordWrap(true);
             answer->setFont("font1.aaf", {0x74,0x74, 0x74, 0xff});
             answer->setText(value);
 
-            auto list = dynamic_cast<UI::TextAreaList*>(getUI("list"));
-            list->addArea(std::unique_ptr<UI::TextArea>(dudeName));
-            list->addArea(std::unique_ptr<UI::TextArea>(answer));
+            auto list = getUI<UI::TextAreaList>("list");
+            list->addArea(std::move(dudeName));
+            list->addArea(std::move(answer));
         }
 
         void CritterDialogReview::addQuestion(const std::string &value)
         {
-            auto crName = new UI::TextArea(0, 0);
+            auto crName = std::make_unique<UI::TextArea>(0, 0);
             crName->setWidth(340);
             crName->setWordWrap(true);
             crName->setFont("font1.aaf", {0x3f,0xf8, 0x00, 0xff});
             crName->setText(_critterName+":");
 
-            auto question = new UI::TextArea(0, 0);
+            auto question = std::make_unique<UI::TextArea>(0, 0);
             question->setWidth(316);
             question->setOffset(26,0);
             question->setWordWrap(true);
             question->setFont("font1.aaf", {0x00,0xa4, 0x00, 0xff});
             question->setText(value);
 
-            auto list = dynamic_cast<UI::TextAreaList*>(getUI("list"));
-            list->addArea(std::unique_ptr<UI::TextArea>(crName));
-            list->addArea(std::unique_ptr<UI::TextArea>(question));
-
+            auto list = getUI<UI::TextAreaList>("list");
+            list->addArea(std::move(crName));
+            list->addArea(std::move(question));
         }
     }
 }

--- a/src/State/CritterDialogReview.cpp
+++ b/src/State/CritterDialogReview.cpp
@@ -25,7 +25,10 @@ namespace Falltergeist
 
         void CritterDialogReview::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setFullscreen(false);
@@ -34,24 +37,33 @@ namespace Falltergeist
             auto background = resourceManager->getImage("art/intrface/review.frm");
             Point backgroundPos = Point((Game::getInstance()->renderer()->size() - background->size()) / 2);
             background->setPosition(backgroundPos);
+            addUI(std::move(background));
 
             // Interface buttons
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DONE_BUTTON, backgroundPos + Point(500, 398));
-            doneButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDoneButtonClick, this, std::placeholders::_1));
 
-            auto upButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_UP_ARROW, backgroundPos + Point(476, 154));
-            upButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onUpButtonClick, this, std::placeholders::_1));
+            {
+                auto doneButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DONE_BUTTON, backgroundPos + Point(500, 398));
+                doneButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDoneButtonClick, this, std::placeholders::_1));
+                addUI(std::move(doneButton));
+            }
 
-            auto downButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_DOWN_ARROW, backgroundPos + Point(476, 192));
-            downButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDownButtonClick, this, std::placeholders::_1));
+            {
+                auto upButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_UP_ARROW, backgroundPos + Point(476, 154));
+                upButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onUpButtonClick, this, std::placeholders::_1));
+                addUI(upButton);
+            }
 
-            addUI(background);
-            addUI(doneButton);
-            addUI(upButton);
-            addUI(downButton);
-            auto list = new UI::TextAreaList(Point(88,76));
-            list->setSize(Size(340,340));
-            addUI("list",list);
+            {
+                auto downButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_DOWN_ARROW, backgroundPos + Point(476, 192));
+                downButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDownButtonClick, this, std::placeholders::_1));
+                addUI(downButton);
+            }
+
+            {
+                auto list = new UI::TextAreaList(Point(88,76));
+                list->setSize(Size(340,340));
+                addUI("list",list);
+            }
         }
 
         void CritterDialogReview::onStateActivate(Event::State *event)

--- a/src/State/CritterDialogReview.cpp
+++ b/src/State/CritterDialogReview.cpp
@@ -75,7 +75,7 @@ namespace Falltergeist
 
         void CritterDialogReview::onDoneButtonClick(Event::Mouse* event)
         {
-            if (auto interact = dynamic_cast<CritterInteract*>(Game::getInstance()->topState(1)))
+            if (auto interact = dynamic_cast<CritterInteract*>(&Game::getInstance()->topState(1)))
             {
                 interact->switchSubState(CritterInteract::SubState::DIALOG);
             }

--- a/src/State/CritterDialogReview.cpp
+++ b/src/State/CritterDialogReview.cpp
@@ -35,35 +35,30 @@ namespace Falltergeist
             setFullscreen(false);
             setModal(false);
 
-            auto background = resourceManager->getImage("art/intrface/review.frm");
-            Point backgroundPos = Point((Game::getInstance()->renderer()->size() - background->size()) / 2);
-            background->setPosition(backgroundPos);
-            addUI(std::move(background));
+            auto& background = addUI(resourceManager->getImage("art/intrface/review.frm"));
+            Point backgroundPos = Point((Game::getInstance()->renderer()->size() - background.size()) / 2);
+            background.setPosition(backgroundPos);
 
             // Interface buttons
 
             {
-                auto doneButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_DONE_BUTTON, backgroundPos + Point(500, 398));
-                doneButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDoneButtonClick, this, std::placeholders::_1));
-                addUI(std::move(doneButton));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::DIALOG_DONE_BUTTON, backgroundPos + Point(500, 398)));
+                doneButton.mouseClickHandler().add(std::bind(&CritterDialogReview::onDoneButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto upButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_UP_ARROW, backgroundPos + Point(476, 154));
-                upButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onUpButtonClick, this, std::placeholders::_1));
-                addUI(std::move(upButton));
+                auto& upButton = addUI(imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_UP_ARROW, backgroundPos + Point(476, 154)));
+                upButton.mouseClickHandler().add(std::bind(&CritterDialogReview::onUpButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto downButton = imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_DOWN_ARROW, backgroundPos + Point(476, 192));
-                downButton->mouseClickHandler().add(std::bind(&CritterDialogReview::onDownButtonClick, this, std::placeholders::_1));
-                addUI(std::move(downButton));
+                auto& downButton = addUI(imageButtonFactory->getByType(ImageButtonType::DIALOG_BIG_DOWN_ARROW, backgroundPos + Point(476, 192)));
+                downButton.mouseClickHandler().add(std::bind(&CritterDialogReview::onDownButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto list = std::make_unique<UI::TextAreaList>(Point{88, 76});
-                list->setSize(Size(340,340));
-                addUI("list", std::move(list));
+                auto& list = makeNamedUI<UI::TextAreaList>("list", Point{88, 76});
+                list.setSize(Size(340,340));
             }
         }
 

--- a/src/State/CritterInteract.cpp
+++ b/src/State/CritterInteract.cpp
@@ -1,5 +1,3 @@
-#include <cstdio>
-#include <memory>
 #include "../State/CritterInteract.h"
 #include "../Format/Lst/File.h"
 #include "../Format/Lip/File.h"
@@ -21,6 +19,9 @@
 #include "../UI/AnimationQueue.h"
 #include "../UI/Factory/ImageButtonFactory.h"
 #include "../Audio/Mixer.h"
+
+#include <cstdio>
+#include <memory>
 
 namespace Falltergeist
 {
@@ -93,7 +94,7 @@ namespace Falltergeist
                     std::string bgImage = "art/backgrnd/" + lst->strings()->at(backgroundID());
                     auto bg = resourceManager->getImage(bgImage);
                     bg->setPosition({128, 15});
-                    addUI(std::move(bg));
+                    addSharedUI(std::move(bg));
                 }
 
                 auto headlst = ResourceManager::getInstance()->lstFileType("art/heads/heads.lst");
@@ -134,26 +135,24 @@ namespace Falltergeist
                 headImage+="gf1.frm";
 
                 {
-                    auto head = makeNamedUI<UI::AnimationQueue>("head");
-                    head->animations().push_back(std::make_unique<UI::Animation>("art/heads/" + headImage));
+                    auto& head = makeNamedUI<UI::AnimationQueue>("head");
+                    head.animations().push_back(std::make_unique<UI::Animation>("art/heads/" + headImage));
 
-                    int offset = 388/2 - head->currentAnimation()->width()/2;
-                    head->setPosition({128+offset, 15});
+                    int offset = 388/2 - head.currentAnimation()->width()/2;
+                    head.setPosition({128+offset, 15});
                 }
             }
 
             addUI("background", resourceManager->getImage("art/intrface/alltlk.frm"));
 
             {
-                auto hilight1 = resourceManager->getImage("data/hilight1.png");
-                hilight1->setPosition({423, 20});
-                addUI(std::move(hilight1));
+                auto& hilight1 = addUI(resourceManager->getImage("data/hilight1.png"));
+                hilight1.setPosition({423, 20});
             }
 
             {
-                auto hilight2 = resourceManager->getImage("data/hilight2.png");
-                hilight2->setPosition({128, 84});
-                addUI(std::move(hilight2));
+                auto& hilight2 = addUI(resourceManager->getImage("data/hilight2.png"));
+                hilight2.setPosition({128, 84});
             }
 
             // Centering camera on critter position

--- a/src/State/CritterInteract.cpp
+++ b/src/State/CritterInteract.cpp
@@ -41,9 +41,6 @@ namespace Falltergeist
         {
             auto camera = Game::getInstance()->locationState()->camera();
             camera->setCenter(_oldCameraCenter);
-            delete _dialog;
-            delete _review;
-            delete _barter;
         }
 
         void CritterInteract::onStateActivate(Event::State* event)
@@ -300,19 +297,9 @@ namespace Falltergeist
             }
         }
 
-        CritterDialog* CritterInteract::dialog()
-        {
-            return _dialog;
-        }
-
         CritterDialogReview* CritterInteract::dialogReview()
         {
-            return _review;
-        }
-
-        CritterBarter* CritterInteract::barter()
-        {
-            return _barter;
+            return _review.get();
         }
 
         void CritterInteract::switchSubState(CritterInteract::SubState state)
@@ -322,19 +309,19 @@ namespace Falltergeist
             _fidgetTimer.start(0);
             if (_state!=SubState::NONE)
             {
-                Game::getInstance()->popState(false);
+                Game::getInstance()->popState();
             }
             _state = state;
             switch (state)
             {
                 case SubState::DIALOG:
-                    Game::getInstance()->pushState(_dialog);
+                    Game::getInstance()->pushSharedState(_dialog);
                     break;
                 case SubState::BARTER:
-                    Game::getInstance()->pushState(_barter);
+                    Game::getInstance()->pushSharedState(_barter);
                     break;
                 case SubState::REVIEW:
-                    Game::getInstance()->pushState(_review);
+                    Game::getInstance()->pushSharedState(_review);
                     break;
                 default:
                     break;

--- a/src/State/CritterInteract.h
+++ b/src/State/CritterInteract.h
@@ -3,6 +3,9 @@
 #include "../State/State.h"
 #include "../Game/Timer.h"
 #include "../UI/IResourceManager.h"
+#include "CritterDialog.h"
+#include "CritterBarter.h"
+#include "CritterDialogReview.h"
 
 namespace Falltergeist
 {
@@ -34,10 +37,6 @@ namespace Falltergeist
     }
     namespace State
     {
-        class CritterDialog;
-        class CritterBarter;
-        class CritterDialogReview;
-
         class CritterInteract final : public State
         {
             public:
@@ -96,9 +95,7 @@ namespace Falltergeist
 
                 void playSpeech(const std::string& speech);
 
-                CritterDialog* dialog();
                 CritterDialogReview* dialogReview();
-                CritterBarter* barter();
                 void switchSubState(SubState state);
                 void transition(Reaction reaction);
                 void onMoodTransitionEnded(Event::Event* event);
@@ -124,9 +121,9 @@ namespace Falltergeist
                 int32_t _badFidgets;
                 Game::Timer _fidgetTimer;
 
-                CritterDialog* _dialog;
-                CritterBarter* _barter;
-                CritterDialogReview* _review;
+                std::shared_ptr<CritterDialog> _dialog;
+                std::shared_ptr<CritterBarter> _barter;
+                std::shared_ptr<CritterDialogReview> _review;
 
                 SubState _state = SubState::NONE;
         };

--- a/src/State/CritterInteract.h
+++ b/src/State/CritterInteract.h
@@ -103,6 +103,8 @@ namespace Falltergeist
                 void transition(Reaction reaction);
                 void onMoodTransitionEnded(Event::Event* event);
 
+            private:
+                std::shared_ptr<UI::IResourceManager> resourceManager;
 
             protected:
                 Point _oldCameraCenter;
@@ -127,8 +129,6 @@ namespace Falltergeist
                 CritterDialogReview* _review;
 
                 SubState _state = SubState::NONE;
-            private:
-                std::shared_ptr<UI::IResourceManager> resourceManager;
         };
     }
 }

--- a/src/State/CursorDropdown.cpp
+++ b/src/State/CursorDropdown.cpp
@@ -117,9 +117,9 @@ namespace Falltergeist
                         throw Exception("CursorDropdown::init() - unknown icon type");
 
                 }
-                _activeIcons.push_back(std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/" + activeSurface)));
+                _activeIcons.push_back(resourceManager->getImage("art/intrface/" + activeSurface));
                 _activeIcons.back()->setY(40*i);
-                _inactiveIcons.push_back(std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/" + inactiveSurface)));
+                _inactiveIcons.push_back(resourceManager->getImage("art/intrface/" + inactiveSurface));
                 _inactiveIcons.back()->setY(40*i);
                 i++;
             }

--- a/src/State/CursorDropdown.cpp
+++ b/src/State/CursorDropdown.cpp
@@ -17,17 +17,17 @@ namespace Falltergeist
     namespace State
     {
         CursorDropdown::CursorDropdown(
-            std::shared_ptr<UI::IResourceManager> resourceManager,
+            std::shared_ptr<UI::IResourceManager> _resourceManager,
             std::vector<Input::Mouse::Icon>&& icons,
-            bool onlyIcon
-        ) : State()
+            bool onlyIcon) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            _icons{std::move(icons)},
+            _onlyShowIcon{onlyIcon}
         {
-            this->resourceManager = resourceManager;
-            if (icons.size() == 0) {
+            if (_icons.empty()) {
                 throw Exception("CursorDropdown::CursorDropdown() - empty icons list!");
             }
-            _icons = icons;
-            _onlyShowIcon = onlyIcon;
             if (onlyIcon && _icons.size() > 1) {
                 _icons.resize(1);
             }
@@ -38,8 +38,10 @@ namespace Falltergeist
             if (_initialized) {
                 return;
             }
+
             State::init();
             setFullscreen(false);
+
             if (!_onlyShowIcon) {
                 setModal(true);
             }
@@ -146,7 +148,7 @@ namespace Falltergeist
                 _iconsPos.setY(_iconsPos.y() - deltaY);
             }
             _cursor->setPosition({_initialX, _initialY});
-            addUI(_cursor);
+            addSharedUI(_cursor);
 
             if (!_onlyShowIcon) {
                 if (deltaY > 0) {

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -49,8 +49,8 @@ namespace Falltergeist
                 int _initialX;
                 int _initialY;
                 int _currentIcon = 0;
-                std::vector<std::unique_ptr<UI::Base>> _activeIcons;
-                std::vector<std::unique_ptr<UI::Base>> _inactiveIcons;
+                std::vector<std::shared_ptr<UI::Base>> _activeIcons;
+                std::vector<std::shared_ptr<UI::Base>> _inactiveIcons;
                 std::shared_ptr<UI::Base> _cursor = nullptr;
                 Point _iconsPos;
                 bool _deactivated = false;

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -51,7 +51,7 @@ namespace Falltergeist
                 int _currentIcon = 0;
                 std::vector<std::unique_ptr<UI::Base>> _activeIcons;
                 std::vector<std::unique_ptr<UI::Base>> _inactiveIcons;
-                UI::Base* _cursor = nullptr;
+                std::shared_ptr<UI::Base> _cursor = nullptr;
                 Point _iconsPos;
                 bool _deactivated = false;
                 unsigned int _initialMouseStack;

--- a/src/State/CursorDropdown.h
+++ b/src/State/CursorDropdown.h
@@ -42,10 +42,12 @@ namespace Falltergeist
                 void onStateActivate(Event::State* event) override;
                 void onStateDeactivate(Event::State* event) override;
 
+            private:
+                std::shared_ptr<UI::IResourceManager> resourceManager;
             protected:
                 Game::Object* _object = nullptr;
-                bool _onlyShowIcon;
                 std::vector<Input::Mouse::Icon> _icons;
+                bool _onlyShowIcon;
                 int _initialX;
                 int _initialY;
                 int _currentIcon = 0;
@@ -59,8 +61,6 @@ namespace Falltergeist
                 Event::MouseHandler _mouseDownHandler, _mouseUpHandler, _mouseMoveHandler;
 
                 void showMenu();
-            private:
-                std::shared_ptr<UI::IResourceManager> resourceManager;
         };
     }
 }

--- a/src/State/ExitConfirm.cpp
+++ b/src/State/ExitConfirm.cpp
@@ -29,6 +29,7 @@ namespace Falltergeist
             if (_initialized) {
                 return;
             }
+
             State::init();
 
             setModal(true);
@@ -36,43 +37,40 @@ namespace Falltergeist
 
             auto background = resourceManager->getImage("art/intrface/lgdialog.frm");
             auto panelHeight = Game::getInstance()->locationState()->playerPanel()->size().height();
-
             auto backgroundPos = (Game::getInstance()->renderer()->size() - background->size() - Point(0, panelHeight)) / 2;
+            background->setPosition(backgroundPos);
+            addUI(std::move(background));
 
-            auto box1 = resourceManager->getImage("art/intrface/donebox.frm");
-            auto box2 = resourceManager->getImage("art/intrface/donebox.frm");
-            box1->setPosition(backgroundPos + Point(38, 98));
-            box2->setPosition(backgroundPos + Point(170, 98));
+            auto& box1 = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+            box1.setPosition(backgroundPos + Point(38, 98));
 
-            auto yesButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(50, 102));
-            auto noButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(183, 102));
-            yesButton->mouseClickHandler().add([this](Event::Event* event){ this->doYes(); });
-            noButton->mouseClickHandler().add( [this](Event::Event* event){ this->doNo(); });
+            auto& box2 = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+            box2.setPosition(backgroundPos + Point(170, 98));
+
+            auto& yesButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(50, 102)));
+            yesButton.mouseClickHandler().add([this](Event::Event* event){
+                this->doYes();
+            });
+
+            auto& noButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(183, 102)));
+            noButton.mouseClickHandler().add( [this](Event::Event* event){
+                this->doNo();
+            });
 
             // label: Are you sure you want to quit?
-            auto quitLabel = new UI::TextArea(_t(MSG_MISC, 0), backgroundPos + Point(30, 52));
-            quitLabel->setFont("font1.aaf", {0xb8,0x9c, 0x28, 0xff});
-            quitLabel->setSize({244, 0});
-            quitLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            auto& quitLabel = *makeUI<UI::TextArea>(_t(MSG_MISC, 0), backgroundPos + Point(30, 52));
+            quitLabel.setFont("font1.aaf", {0xb8,0x9c, 0x28, 0xff});
+            quitLabel.setSize({244, 0});
+            quitLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
 
             // label: yes & no
             // label: yes 101
-            auto yesButtonLabel = new UI::TextArea(_t(MSG_DIALOG_BOX, 101), backgroundPos + Point(74, 101));
-            yesButtonLabel->setFont("font3.aaf", {0xb8,0x9c,0x28,0xff});
+            auto& yesButtonLabel = *makeUI<UI::TextArea>(_t(MSG_DIALOG_BOX, 101), backgroundPos + Point(74, 101));
+            yesButtonLabel.setFont("font3.aaf", {0xb8,0x9c,0x28,0xff});
+
             // label: no 102
-            auto noButtonLabel = new UI::TextArea(_t(MSG_DIALOG_BOX, 102), backgroundPos + Point(204, 101));
-            noButtonLabel->setFont("font3.aaf", {0xb8,0x9c,0x28,0xff});
-
-            background->setPosition(backgroundPos);
-
-            addUI(background);
-            addUI(box1);
-            addUI(box2);
-            addUI(yesButton);
-            addUI(noButton);
-            addUI(quitLabel);
-            addUI(yesButtonLabel);
-            addUI(noButtonLabel);
+            auto& noButtonLabel = *makeUI<UI::TextArea>(_t(MSG_DIALOG_BOX, 102), backgroundPos + Point(204, 101));
+            noButtonLabel.setFont("font3.aaf", {0xb8,0x9c,0x28,0xff});
         }
 
         void ExitConfirm::doYes()

--- a/src/State/ExitConfirm.cpp
+++ b/src/State/ExitConfirm.cpp
@@ -75,7 +75,7 @@ namespace Falltergeist
 
         void ExitConfirm::doYes()
         {
-            Game::getInstance()->setState(new MainMenu(resourceManager));
+            Game::getInstance()->setState(std::make_unique<MainMenu>(resourceManager));
         }
 
         void ExitConfirm::doNo()

--- a/src/State/ExitConfirm.cpp
+++ b/src/State/ExitConfirm.cpp
@@ -18,10 +18,11 @@ namespace Falltergeist
 
     namespace State
     {
-        ExitConfirm::ExitConfirm(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        ExitConfirm::ExitConfirm(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void ExitConfirm::init()
@@ -39,37 +40,37 @@ namespace Falltergeist
             auto panelHeight = Game::getInstance()->locationState()->playerPanel()->size().height();
             auto backgroundPos = (Game::getInstance()->renderer()->size() - background->size() - Point(0, panelHeight)) / 2;
             background->setPosition(backgroundPos);
-            addUI(std::move(background));
+            addSharedUI(std::move(background));
 
-            auto& box1 = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+            auto& box1 = addUI(resourceManager->getImage("art/intrface/donebox.frm"));
             box1.setPosition(backgroundPos + Point(38, 98));
 
-            auto& box2 = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+            auto& box2 = addUI(resourceManager->getImage("art/intrface/donebox.frm"));
             box2.setPosition(backgroundPos + Point(170, 98));
 
-            auto& yesButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(50, 102)));
+            auto& yesButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(50, 102)));
             yesButton.mouseClickHandler().add([this](Event::Event* event){
                 this->doYes();
             });
 
-            auto& noButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(183, 102)));
+            auto& noButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, backgroundPos + Point(183, 102)));
             noButton.mouseClickHandler().add( [this](Event::Event* event){
                 this->doNo();
             });
 
             // label: Are you sure you want to quit?
-            auto& quitLabel = *makeUI<UI::TextArea>(_t(MSG_MISC, 0), backgroundPos + Point(30, 52));
+            auto& quitLabel = makeUI<UI::TextArea>(_t(MSG_MISC, 0), backgroundPos + Point(30, 52));
             quitLabel.setFont("font1.aaf", {0xb8,0x9c, 0x28, 0xff});
             quitLabel.setSize({244, 0});
             quitLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
 
             // label: yes & no
             // label: yes 101
-            auto& yesButtonLabel = *makeUI<UI::TextArea>(_t(MSG_DIALOG_BOX, 101), backgroundPos + Point(74, 101));
+            auto& yesButtonLabel = makeUI<UI::TextArea>(_t(MSG_DIALOG_BOX, 101), backgroundPos + Point(74, 101));
             yesButtonLabel.setFont("font3.aaf", {0xb8,0x9c,0x28,0xff});
 
             // label: no 102
-            auto& noButtonLabel = *makeUI<UI::TextArea>(_t(MSG_DIALOG_BOX, 102), backgroundPos + Point(204, 101));
+            auto& noButtonLabel = makeUI<UI::TextArea>(_t(MSG_DIALOG_BOX, 102), backgroundPos + Point(204, 101));
             noButtonLabel.setFont("font3.aaf", {0xb8,0x9c,0x28,0xff});
         }
 

--- a/src/State/GameMenu.cpp
+++ b/src/State/GameMenu.cpp
@@ -30,77 +30,101 @@ namespace Falltergeist
 
         void GameMenu::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setModal(true);
             setFullscreen(false);
 
-            auto background = resourceManager->getImage("art/intrface/opbase.frm");
             auto panelHeight = Game::getInstance()->locationState()->playerPanel()->size().height();
 
+            auto background = addUI(resourceManager->getImage("art/intrface/opbase.frm"));
             auto backgroundPos = (Game::getInstance()->renderer()->size() - background->size() - Point(0, panelHeight)) / 2;
+            background->setPosition(backgroundPos);
+
             int backgroundX = backgroundPos.x();
             int backgroundY = backgroundPos.y();
 
-            auto saveGameButton    = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18});
-            auto loadGameButton    = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37});
-            auto preferencesButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 2});
-            auto exitGameButton    = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 3});
-            auto doneButton        = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 4});
+            {
+                auto& saveGameButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18}));
+                saveGameButton.mouseClickHandler().add([this](Event::Event* event){
+                    this->doSaveGame();
+                });
+            }
 
-            preferencesButton->mouseClickHandler().add([this](Event::Event* event){ this->doPreferences(); });
-            exitGameButton->mouseClickHandler().add(   [this](Event::Event* event){ this->doExit(); });
-            doneButton->mouseClickHandler().add(       [this](Event::Event* event){ this->closeMenu(); });
+            {
+                auto& loadGameButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37}));
+                loadGameButton.mouseClickHandler().add([this](Event::Event* event){
+                    this->doLoadGame();
+                });
+            }
+
+            {
+                auto& preferencesButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 2}));
+                preferencesButton.mouseClickHandler().add([this](Event::Event* event){
+                    this->doPreferences();
+                });
+            }
+
+            {
+                auto& exitGameButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 3}));
+                exitGameButton.mouseClickHandler().add(   [this](Event::Event* event){
+                    this->doExit();
+                });
+            }
+
+            {
+                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 4}));
+                doneButton.mouseClickHandler().add([this](Event::Event* event){
+                    this->closeMenu();
+                });
+            }
 
             auto font = ResourceManager::getInstance()->font("font3.aaf");
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
             // label: save game
-            auto saveGameButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 0), backgroundX+8, backgroundY+26);
-            saveGameButtonLabel->setFont(font, color);
-            saveGameButtonLabel->setSize({150, 0});
-            saveGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-            saveGameButton->mouseClickHandler().add([this](Event::Event* event){ this->doSaveGame(); });
+            {
+                auto& saveGameButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 0), backgroundX+8, backgroundY+26);
+                saveGameButtonLabel.setFont(font, color);
+                saveGameButtonLabel.setSize({150, 0});
+                saveGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: load game
-            auto loadGameButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 1), backgroundX+8, backgroundY+26+37);
-            loadGameButtonLabel->setFont(font, color);
-            loadGameButtonLabel->setSize({150, 0});
-            loadGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-            loadGameButton->mouseClickHandler().add([this](Event::Event* event){ this->doLoadGame(); });
+            {
+                auto& loadGameButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 1), backgroundX+8, backgroundY+26+37);
+                loadGameButtonLabel.setFont(font, color);
+                loadGameButtonLabel.setSize({150, 0});
+                loadGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: preferences
-            auto preferencesButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 2), backgroundX+8, backgroundY+26+37*2);
-            preferencesButtonLabel->setFont(font, color);
-            preferencesButtonLabel->setSize({150, 0});
-            preferencesButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& preferencesButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 2), backgroundX+8, backgroundY+26+37*2);
+                preferencesButtonLabel.setFont(font, color);
+                preferencesButtonLabel.setSize({150, 0});
+                preferencesButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: exit game
-            auto exitGameButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 3), backgroundX+8, backgroundY+26+37*3);
-            exitGameButtonLabel->setFont(font, color);
-            exitGameButtonLabel->setSize({150, 0});
-            exitGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& exitGameButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 3), backgroundX+8, backgroundY+26+37*3);
+                exitGameButtonLabel.setFont(font, color);
+                exitGameButtonLabel.setSize({150, 0});
+                exitGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: done
-            auto doneButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 4), backgroundX+8, backgroundY+26+37*4);
-            doneButtonLabel->setFont(font, color);
-            doneButtonLabel->setSize({150, 0});
-            doneButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-
-            background->setPosition(backgroundPos);
-
-            addUI(background);
-            addUI(saveGameButton);
-            addUI(loadGameButton);
-            addUI(preferencesButton);
-            addUI(exitGameButton);
-            addUI(doneButton);
-            addUI(saveGameButtonLabel);
-            addUI(loadGameButtonLabel);
-            addUI(preferencesButtonLabel);
-            addUI(exitGameButtonLabel);
-            addUI(doneButtonLabel);
+            {
+                auto& doneButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 4), backgroundX+8, backgroundY+26+37*4);
+                doneButtonLabel.setFont(font, color);
+                doneButtonLabel.setSize({150, 0});
+                doneButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
         }
 
         void GameMenu::doSaveGame()

--- a/src/State/GameMenu.cpp
+++ b/src/State/GameMenu.cpp
@@ -22,10 +22,11 @@ namespace Falltergeist
 
     namespace State
     {
-        GameMenu::GameMenu(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        GameMenu::GameMenu(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void GameMenu::init()
@@ -41,43 +42,43 @@ namespace Falltergeist
 
             auto panelHeight = Game::getInstance()->locationState()->playerPanel()->size().height();
 
-            auto background = addUI(resourceManager->getImage("art/intrface/opbase.frm"));
-            auto backgroundPos = (Game::getInstance()->renderer()->size() - background->size() - Point(0, panelHeight)) / 2;
-            background->setPosition(backgroundPos);
+            auto& background = addUI(resourceManager->getImage("art/intrface/opbase.frm"));
+            auto backgroundPos = (Game::getInstance()->renderer()->size() - background.size() - Point(0, panelHeight)) / 2;
+            background.setPosition(backgroundPos);
 
             int backgroundX = backgroundPos.x();
             int backgroundY = backgroundPos.y();
 
             {
-                auto& saveGameButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18}));
+                auto& saveGameButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18}));
                 saveGameButton.mouseClickHandler().add([this](Event::Event* event){
                     this->doSaveGame();
                 });
             }
 
             {
-                auto& loadGameButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37}));
+                auto& loadGameButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37}));
                 loadGameButton.mouseClickHandler().add([this](Event::Event* event){
                     this->doLoadGame();
                 });
             }
 
             {
-                auto& preferencesButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 2}));
+                auto& preferencesButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 2}));
                 preferencesButton.mouseClickHandler().add([this](Event::Event* event){
                     this->doPreferences();
                 });
             }
 
             {
-                auto& exitGameButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 3}));
+                auto& exitGameButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 3}));
                 exitGameButton.mouseClickHandler().add(   [this](Event::Event* event){
                     this->doExit();
                 });
             }
 
             {
-                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 4}));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 4}));
                 doneButton.mouseClickHandler().add([this](Event::Event* event){
                     this->closeMenu();
                 });
@@ -88,7 +89,7 @@ namespace Falltergeist
 
             // label: save game
             {
-                auto& saveGameButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 0), backgroundX+8, backgroundY+26);
+                auto& saveGameButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 0), backgroundX+8, backgroundY+26);
                 saveGameButtonLabel.setFont(font, color);
                 saveGameButtonLabel.setSize({150, 0});
                 saveGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -96,7 +97,7 @@ namespace Falltergeist
 
             // label: load game
             {
-                auto& loadGameButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 1), backgroundX+8, backgroundY+26+37);
+                auto& loadGameButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 1), backgroundX+8, backgroundY+26+37);
                 loadGameButtonLabel.setFont(font, color);
                 loadGameButtonLabel.setSize({150, 0});
                 loadGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -104,7 +105,7 @@ namespace Falltergeist
 
             // label: preferences
             {
-                auto& preferencesButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 2), backgroundX+8, backgroundY+26+37*2);
+                auto& preferencesButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 2), backgroundX+8, backgroundY+26+37*2);
                 preferencesButtonLabel.setFont(font, color);
                 preferencesButtonLabel.setSize({150, 0});
                 preferencesButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -112,7 +113,7 @@ namespace Falltergeist
 
             // label: exit game
             {
-                auto& exitGameButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 3), backgroundX+8, backgroundY+26+37*3);
+                auto& exitGameButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 3), backgroundX+8, backgroundY+26+37*3);
                 exitGameButtonLabel.setFont(font, color);
                 exitGameButtonLabel.setSize({150, 0});
                 exitGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -120,7 +121,7 @@ namespace Falltergeist
 
             // label: done
             {
-                auto& doneButtonLabel = *makeUI<UI::TextArea>(_t(MSG_OPTIONS, 4), backgroundX+8, backgroundY+26+37*4);
+                auto& doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 4), backgroundX+8, backgroundY+26+37*4);
                 doneButtonLabel.setFont(font, color);
                 doneButtonLabel.setSize({150, 0});
                 doneButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);

--- a/src/State/GameMenu.cpp
+++ b/src/State/GameMenu.cpp
@@ -129,22 +129,22 @@ namespace Falltergeist
 
         void GameMenu::doSaveGame()
         {
-            Game::getInstance()->pushState(new SaveGame(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<SaveGame>(resourceManager));
         }
 
         void GameMenu::doLoadGame()
         {
-            Game::getInstance()->pushState(new LoadGame(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<LoadGame>(resourceManager));
         }
 
         void GameMenu::doPreferences()
         {
-            Game::getInstance()->pushState(new SettingsMenu(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<SettingsMenu>(resourceManager));
         }
 
         void GameMenu::doExit()
         {
-            Game::getInstance()->pushState(new ExitConfirm(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<ExitConfirm>(resourceManager));
         }
 
         void GameMenu::closeMenu()

--- a/src/State/Inventory.cpp
+++ b/src/State/Inventory.cpp
@@ -403,7 +403,7 @@ namespace Falltergeist
             if (Game::getInstance()->mouse()->state() == Input::Mouse::Cursor::HAND)
             {
                 auto itemUi = dynamic_cast<UI::ImageList*>(event->target());
-                Game::getInstance()->pushState(new InventoryDragItem(itemUi));
+                Game::getInstance()->pushState(std::make_unique<InventoryDragItem>(itemUi));
             }
             else
             {
@@ -417,7 +417,7 @@ namespace Falltergeist
             if (Game::getInstance()->mouse()->state() == Input::Mouse::Cursor::HAND)
             {
                 auto itemUi = dynamic_cast<UI::ImageList*>(event->target());
-                Game::getInstance()->pushState(new InventoryDragItem(itemUi));
+                Game::getInstance()->pushState(std::make_unique<InventoryDragItem>(itemUi));
             }
             else
             {
@@ -431,7 +431,7 @@ namespace Falltergeist
             if (Game::getInstance()->mouse()->state() == Input::Mouse::Cursor::HAND)
             {
                 auto itemUi = dynamic_cast<UI::ImageList*>(event->target());
-                Game::getInstance()->pushState(new InventoryDragItem(itemUi));
+                Game::getInstance()->pushState(std::make_unique<InventoryDragItem>(itemUi));
             }
             else
             {

--- a/src/State/Inventory.cpp
+++ b/src/State/Inventory.cpp
@@ -36,11 +36,11 @@ namespace Falltergeist
 
     namespace State
     {
-        Inventory::Inventory(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        Inventory::Inventory(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
-
             pushHandler().add([](Event::State* ev) {
                 Game::getInstance()->mouse()->pushState(Input::Mouse::Cursor::ACTION);
             });
@@ -70,28 +70,28 @@ namespace Falltergeist
             setPosition((game->renderer()->size() - Point(499, 377 + panelHeight)) / 2); // 499x377 = art/intrface/invbox.frm
 
             addUI("background", resourceManager->getImage("art/intrface/invbox.frm"))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->backgroundRightClick(e);
                 });
 
             addUI("button_up",   imageButtonFactory->getByType(ImageButtonType::INVENTORY_UP_ARROW,   {128, 40}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onScrollUpButtonClick(e);
                 });
 
             addUI("button_down", imageButtonFactory->getByType(ImageButtonType::INVENTORY_DOWN_ARROW, {128, 65}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onScrollDownButtonClick(e);
                 });
 
             addUI("button_up_disabled", resourceManager->getImage("art/intrface/invdnds.frm"))
-                ->setPosition({128, 40});
+                .setPosition({128, 40});
 
             addUI("button_down_disabled", resourceManager->getImage("art/intrface/invupds.frm"))
-                ->setPosition({128, 65});
+                .setPosition({128, 65});
 
             addUI("button_done", imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {438, 328}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onDoneButtonClick(e);
                 });
 
@@ -136,7 +136,7 @@ namespace Falltergeist
                 ss << player->hitPoints();
                 ss << "/";
                 ss << player->hitPointsMax();
-                auto& hpui = *makeNamedUI<UI::TextArea>("hitPointsLabel", ss.str(), screenPos.add({94, 20}));
+                auto& hpui = makeNamedUI<UI::TextArea>("hitPointsLabel", ss.str(), screenPos.add({94, 20}));
                 hpui.setWidth(46);
                 hpui.setHorizontalAlign(UI::TextArea::HorizontalAlign::RIGHT);
             }
@@ -145,7 +145,7 @@ namespace Falltergeist
             {
                 std::stringstream ss;
                 ss << player->armorClass();
-                auto& armorClassLabel = *makeNamedUI<UI::TextArea>("armorClassLabel", ss.str(), screenPos.add({94, 30}));
+                auto& armorClassLabel = makeNamedUI<UI::TextArea>("armorClassLabel", ss.str(), screenPos.add({94, 30}));
                 armorClassLabel.setWidth(46);
                 armorClassLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::RIGHT);
             }
@@ -171,7 +171,7 @@ namespace Falltergeist
                     ss << player->damageThreshold(DAMAGE::PLASMA) <<"/\n";
                     ss << player->damageThreshold(DAMAGE::EXPLOSIVE) <<"/";
                 }
-                auto& damageThresholdLabel = *makeNamedUI<UI::TextArea>("damageThresholdLabel", ss.str(), screenPos.add({94, 40}));
+                auto& damageThresholdLabel = makeNamedUI<UI::TextArea>("damageThresholdLabel", ss.str(), screenPos.add({94, 40}));
                 damageThresholdLabel.setWidth(26);
                 damageThresholdLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::RIGHT);
             }
@@ -220,7 +220,7 @@ namespace Falltergeist
 
             // label: weight
             {
-                auto& weightLabel = *makeNamedUI<UI::TextArea>(
+                auto& weightLabel = makeNamedUI<UI::TextArea>(
                         "weightLabel",
                         std::to_string(weight),
                         screenPos.add({70, 180}));
@@ -257,7 +257,7 @@ namespace Falltergeist
 
             // screen info
             {
-                auto& screenLabel = *makeNamedUI<UI::TextArea>(
+                auto& screenLabel = makeNamedUI<UI::TextArea>(
                         "screenLabel",
                         "",
                         screenPos.add({0, 20}));
@@ -266,7 +266,7 @@ namespace Falltergeist
                 screenLabel.setWordWrap(true);
             }
 
-            auto& inventoryList = *makeNamedUI<UI::ItemsList>("inventory_list", Point{40, 40});
+            auto& inventoryList = makeNamedUI<UI::ItemsList>("inventory_list", Point{40, 40});
             inventoryList.setItems(game->player()->inventory());
 
             // TODO: this is a rotating animation in the vanilla engine
@@ -280,14 +280,14 @@ namespace Falltergeist
                         critterHelper.armorFID(dude.get()),
                         critterHelper.weaponId(dude.get()),
                         Game::Orientation::SC
-                ))->setPosition({188, 52});
+                )).setPosition({188, 52});
             }
 
             // BIG ICONS
 
             // icon: armor
             {
-                auto& inventoryItem = *makeUI<UI::InventoryItem>(playerArmor, Point{154, 183});
+                auto& inventoryItem = makeUI<UI::InventoryItem>(playerArmor, Point{154, 183});
                 inventoryItem.setType(UI::InventoryItem::Type::SLOT);
                 inventoryItem.itemDragStopHandler().add([&](Event::Mouse* event){
                     inventoryList.onItemDragStop(event);
@@ -299,7 +299,7 @@ namespace Falltergeist
 
             // icon: left hand
             {
-                auto& inventoryItem = *makeUI<UI::InventoryItem>(leftHand, Point{154, 286});
+                auto& inventoryItem = makeUI<UI::InventoryItem>(leftHand, Point{154, 286});
                 inventoryItem.setType(UI::InventoryItem::Type::SLOT);
                 inventoryItem.itemDragStopHandler().add([&](Event::Mouse* event){
                     inventoryList.onItemDragStop(event, HAND::LEFT);
@@ -311,7 +311,7 @@ namespace Falltergeist
 
             // icon: right hand
             {
-                auto& inventoryItem = *makeUI<UI::InventoryItem>(rightHand, Point{247, 286});
+                auto& inventoryItem = makeUI<UI::InventoryItem>(rightHand, Point{247, 286});
                 inventoryItem.setType(UI::InventoryItem::Type::SLOT);
                 inventoryItem.itemDragStopHandler().add([&](Event::Mouse* event){
                     inventoryList.onItemDragStop(event, HAND::RIGHT);

--- a/src/State/LoadGame.cpp
+++ b/src/State/LoadGame.cpp
@@ -22,30 +22,32 @@ namespace Falltergeist
 
     namespace State
     {
-        LoadGame::LoadGame(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        LoadGame::LoadGame(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void LoadGame::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setModal(true);
             setFullscreen(true);
 
             auto game = Game::getInstance();
-            //auto player = Game::getInstance()->player();
 
             // background
-            auto bg = resourceManager->getImage("art/intrface/lsgame.frm");
+            auto bg = addUI(resourceManager->getImage("art/intrface/lsgame.frm"));
             Point bgPos = Point((game->renderer()->size() - bg->size()) / 2);
             auto bgX = bgPos.x();
             auto bgY = bgPos.y();
             bg->setPosition(bgPos);
-            addUI(bg);
 
             // BUTTONS
 
@@ -55,14 +57,16 @@ namespace Falltergeist
             addUI("button_down", imageButtonFactory->getByType(ImageButtonType::SMALL_DOWN_ARROW, {bgX + 35, bgY + 72}));
 
             // button: Done
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 391, bgY + 349});
-            doneButton->mouseClickHandler().add(std::bind(&LoadGame::onDoneButtonClick, this, std::placeholders::_1));
-            addUI(doneButton);
+            addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 391, bgY + 349}))
+                ->mouseClickHandler().add([this](Event::Mouse* event) {
+                    this->onDoneButtonClick(event);
+                });
 
             // button: Cancel
-            auto cancelButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 495, bgY + 349});
-            cancelButton->mouseClickHandler().add([this](Event::Event* event){ this->doCancel(); });
-            addUI(cancelButton);
+            addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 495, bgY + 349}))
+                ->mouseClickHandler().add([this](Event::Event* event){
+                    this->doCancel();
+                });
 
             // LABELS
 
@@ -70,19 +74,16 @@ namespace Falltergeist
             SDL_Color color = {0x90, 0x78, 0x24, 0xff};
 
             // LOAD GAME LABEL
-            auto saveGameLabel = new UI::TextArea(_t(MSG_LOAD_SAVE, 110), bgX+48, bgY+27);
-            saveGameLabel->setFont(font3_907824ff, color);
-            addUI(saveGameLabel);
+            makeUI<UI::TextArea>(_t(MSG_LOAD_SAVE, 110), bgX+48, bgY+27)
+                    ->setFont(font3_907824ff, color);
 
             // DONE BUTTON LABEL
-            auto doneButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 300), bgX+410, bgY+348);
-            doneButtonLabel->setFont(font3_907824ff, color);
-            addUI(doneButtonLabel);
+            makeUI<UI::TextArea>(_t(MSG_OPTIONS, 300), bgX+410, bgY+348)
+                    ->setFont(font3_907824ff, color);
 
             // CANCEL BUTTON LABEL
-            auto cancelButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 121), bgX+515, bgY+348);
-            cancelButtonLabel->setFont(font3_907824ff, color);
-            addUI(cancelButtonLabel);
+            makeUI<UI::TextArea>(_t(MSG_OPTIONS, 121), bgX+515, bgY+348)
+                    ->setFont(font3_907824ff, color);
         }
 
         void LoadGame::onDoneButtonClick(Event::Mouse* event)

--- a/src/State/LoadGame.cpp
+++ b/src/State/LoadGame.cpp
@@ -43,11 +43,11 @@ namespace Falltergeist
             auto game = Game::getInstance();
 
             // background
-            auto bg = addUI(resourceManager->getImage("art/intrface/lsgame.frm"));
-            Point bgPos = Point((game->renderer()->size() - bg->size()) / 2);
+            auto& bg = addUI(resourceManager->getImage("art/intrface/lsgame.frm"));
+            Point bgPos = Point((game->renderer()->size() - bg.size()) / 2);
             auto bgX = bgPos.x();
             auto bgY = bgPos.y();
-            bg->setPosition(bgPos);
+            bg.setPosition(bgPos);
 
             // BUTTONS
 
@@ -58,13 +58,13 @@ namespace Falltergeist
 
             // button: Done
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 391, bgY + 349}))
-                ->mouseClickHandler().add([this](Event::Mouse* event) {
+                .mouseClickHandler().add([this](Event::Mouse* event) {
                     this->onDoneButtonClick(event);
                 });
 
             // button: Cancel
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 495, bgY + 349}))
-                ->mouseClickHandler().add([this](Event::Event* event){
+                .mouseClickHandler().add([this](Event::Event* event){
                     this->doCancel();
                 });
 
@@ -75,15 +75,15 @@ namespace Falltergeist
 
             // LOAD GAME LABEL
             makeUI<UI::TextArea>(_t(MSG_LOAD_SAVE, 110), bgX+48, bgY+27)
-                    ->setFont(font3_907824ff, color);
+                    .setFont(font3_907824ff, color);
 
             // DONE BUTTON LABEL
             makeUI<UI::TextArea>(_t(MSG_OPTIONS, 300), bgX+410, bgY+348)
-                    ->setFont(font3_907824ff, color);
+                    .setFont(font3_907824ff, color);
 
             // CANCEL BUTTON LABEL
             makeUI<UI::TextArea>(_t(MSG_OPTIONS, 121), bgX+515, bgY+348)
-                    ->setFont(font3_907824ff, color);
+                    .setFont(font3_907824ff, color);
         }
 
         void LoadGame::onDoneButtonClick(Event::Mouse* event)

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -933,9 +933,9 @@ namespace Falltergeist
                             debug << " exitDirection: " << exitGrid->exitDirection() << std::endl << std::endl;
 
                             if (exitGrid->exitMapNumber() < 0) {
-                                auto worldMapState = new WorldMap(resourceManager);
+                                auto worldMapState = std::make_unique<WorldMap>(resourceManager);
                                 // TODO delegate state manipulation to some kind of state manager
-                                Game::getInstance()->setState(worldMapState);
+                                Game::getInstance()->setState(std::move(worldMapState));
                                 return;
                             }
 
@@ -949,10 +949,17 @@ namespace Falltergeist
                             location->setDefaultElevationIndex(exitGrid->exitElevationNumber());
 
                             // TODO move this instantiation to StateLocationHelper or some kind of state manager
-                            auto state = new Location(player, mouse, settings, renderer, audioMixer, gameTime, resourceManager);
+                            auto state = std::make_unique<Location>(
+                                    player,
+                                    mouse,
+                                    settings,
+                                    renderer,
+                                    audioMixer,
+                                    gameTime,
+                                    resourceManager);
                             state->setLocation(location);
                             // TODO delegate state manipulation to some kind of state manager
-                            Game::getInstance()->setState(state);
+                            Game::getInstance()->setState(std::move(state));
 
                             return;
                         }

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -336,12 +336,6 @@ namespace Falltergeist
 
         void Location::initializePlayerTestAppareance(std::shared_ptr<Game::DudeObject> player) const
         {
-            static bool equipped;
-            if (equipped) {
-                return;
-            }
-
-            equipped = true;
             player->setArmorSlot(nullptr);
             auto powerArmor = (Game::ItemObject*) Game::ObjectFactory::getInstance()->createObject(PID_POWERED_ARMOR);
             auto leatherJacket = (Game::ItemObject*) Game::ObjectFactory::getInstance()->createObject(PID_LEATHER_JACKET);
@@ -357,7 +351,7 @@ namespace Falltergeist
             player->inventory()->push_back(purpleRobe);
             player->setLeftHandSlot(miniGun);
             player->setRightHandSlot(spear);
-            player->setActionAnimation("aa")->stop();
+            player->setActionAnimation("aa")->stop();  // TODO: this is important, because the player's FID isn't initialized: will segfault otherwise
             player->setPID(0x01000001);
         }
 

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -57,16 +57,16 @@ namespace Falltergeist
             std::shared_ptr<Graphics::Renderer> renderer,
             std::shared_ptr<Audio::Mixer> audioMixer,
             std::shared_ptr<Game::Time> gameTime,
-            std::shared_ptr<UI::IResourceManager> resourceManager
+            std::shared_ptr<UI::IResourceManager> _resourceManager
         ) : State(),
             player(std::move(player)),
             mouse(std::move(mouse)),
             settings(std::move(settings)),
             renderer(std::move(renderer)),
             audioMixer(std::move(audioMixer)),
-            gameTime(std::move(gameTime))
+            gameTime(std::move(gameTime)),
+            resourceManager{std::move(_resourceManager)}
         {
-            this->resourceManager = resourceManager;
         }
 
         void Location::init()
@@ -180,7 +180,7 @@ namespace Falltergeist
 
             initLight();
 
-            _playerPanel = makeUI<UI::PlayerPanel>();
+            _playerPanel = makeSharedUI<UI::PlayerPanel>();
 
             _mouseDownHandler.add(std::bind(&Location::onMouseDown, this, std::placeholders::_1));
             _mouseUpHandler.add(std::bind(&Location::onMouseUp, this, std::placeholders::_1));

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -1136,7 +1136,7 @@ namespace Falltergeist
 
         UI::PlayerPanel *Location::playerPanel()
         {
-            return _playerPanel;
+            return _playerPanel.get();
         }
 
         void Location::addTimerEvent(Game::Object *obj, int ticks, int fixedParam)

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -201,12 +201,12 @@ namespace Falltergeist
                     auto icons = getCursorIconsForObject(_objectUnderCursor);
                     if (!icons.empty()) {
                         // TODO delegate state manipulation to some kind of state manager
-                        if (dynamic_cast<CursorDropdown *>(Game::getInstance()->topState()) != nullptr) {
+                        if (dynamic_cast<CursorDropdown *>(&Game::getInstance()->topState()) != nullptr) {
                             Game::getInstance()->popState();
                         }
-                        auto state = new CursorDropdown(resourceManager, std::move(icons), !_actionCursorButtonPressed);
+                        auto state = std::make_unique<CursorDropdown>(resourceManager, std::move(icons), !_actionCursorButtonPressed);
                         state->setObject(_objectUnderCursor);
-                        Game::getInstance()->pushState(state);
+                        Game::getInstance()->pushState(std::move(state));
                     }
                 }
                 _actionCursorButtonPressed = false;

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -176,7 +176,7 @@ namespace Falltergeist
                 Game::Object* _objectUnderCursor = nullptr;
                 Game::Object* _actionCursorLastObject = nullptr;
                 bool _actionCursorButtonPressed = false;
-                UI::PlayerPanel* _playerPanel;
+                std::shared_ptr<UI::PlayerPanel> _playerPanel;
 
                 SKILL _skillInUse = SKILL::NONE;
 

--- a/src/State/Location.h
+++ b/src/State/Location.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <list>
-#include <memory>
 #include "../Format/Map/File.h"
 #include "../Game/DudeObject.h"
 #include "../Game/Object.h"
@@ -11,6 +9,12 @@
 #include "../State/State.h"
 #include "../UI/ImageButton.h"
 #include "../UI/IResourceManager.h"
+#include "../PathFinding/HexagonGrid.h"
+#include "LocationCamera.h"
+#include "../UI/TextArea.h"
+
+#include <list>
+#include <memory>
 
 namespace Falltergeist
 {
@@ -47,8 +51,6 @@ namespace Falltergeist
         class StackValue;
     }
     class Hexagon;
-    class HexagonGrid;
-    class LocationCamera;
     class Settings;
 
     namespace State

--- a/src/State/MainMenu.cpp
+++ b/src/State/MainMenu.cpp
@@ -151,7 +151,7 @@ namespace Falltergeist
 
         void MainMenu::doSettings()
         {
-            Game::getInstance()->pushState(new SettingsMenu(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<SettingsMenu>(resourceManager));
         }
 
         void MainMenu::doIntro()
@@ -188,7 +188,7 @@ namespace Falltergeist
         void MainMenu::onNewGameStart(Event::State* event)
         {
             fadeDoneHandler().clear();
-            Game::getInstance()->pushState(new NewGame(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<NewGame>(resourceManager));
         }
 
         void MainMenu::onLoadGameButtonClick(Event::Mouse* event)
@@ -199,7 +199,7 @@ namespace Falltergeist
         void MainMenu::onLoadGameStart(Event::State* event)
         {
             fadeDoneHandler().clear();
-            Game::getInstance()->pushState(new LoadGame(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<LoadGame>(resourceManager));
         }
 
         void MainMenu::onSettingsButtonClick(Event::Mouse* event)
@@ -215,8 +215,8 @@ namespace Falltergeist
         void MainMenu::onIntroStart(Event::State* event)
         {
             fadeDoneHandler().clear();
-            Game::getInstance()->pushState(new Movie(17));
-            Game::getInstance()->pushState(new Movie(1));
+            Game::getInstance()->pushState(std::make_unique<Movie>(17));
+            Game::getInstance()->pushState(std::make_unique<Movie>(1));
         }
 
         void MainMenu::onCreditsButtonClick(Event::Mouse* event)
@@ -227,7 +227,7 @@ namespace Falltergeist
         void MainMenu::onCreditsStart(Event::State* event)
         {
             fadeDoneHandler().clear();
-            Game::getInstance()->pushState(new Credits());
+            Game::getInstance()->pushState(std::make_unique<Credits>());
         }
 
         void MainMenu::onKeyDown(Event::Keyboard* event)

--- a/src/State/MainMenu.cpp
+++ b/src/State/MainMenu.cpp
@@ -25,10 +25,11 @@ namespace Falltergeist
 
     namespace State
     {
-        MainMenu::MainMenu(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        MainMenu::MainMenu(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         MainMenu::~MainMenu()
@@ -54,34 +55,34 @@ namespace Falltergeist
 
             // intro button
             addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19}))
-                ->mouseClickHandler().add(std::bind(&MainMenu::onIntroButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&MainMenu::onIntroButtonClick, this, std::placeholders::_1));
 
             // new game button
             addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41}))
-                ->mouseClickHandler().add(std::bind(&MainMenu::onNewGameButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&MainMenu::onNewGameButtonClick, this, std::placeholders::_1));
 
             // load game button
             addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 2}))
-                ->mouseClickHandler().add(std::bind(&MainMenu::onLoadGameButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&MainMenu::onLoadGameButtonClick, this, std::placeholders::_1));
 
             // settings button
             addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 3}))
-                ->mouseClickHandler().add(std::bind(&MainMenu::onSettingsButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&MainMenu::onSettingsButtonClick, this, std::placeholders::_1));
 
             // credits button
             addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 4}))
-                ->mouseClickHandler().add(std::bind(&MainMenu::onCreditsButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&MainMenu::onCreditsButtonClick, this, std::placeholders::_1));
 
             // exit button
             addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 5}))
-                ->mouseClickHandler().add(std::bind(&MainMenu::onExitButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&MainMenu::onExitButtonClick, this, std::placeholders::_1));
 
             auto font4 = ResourceManager::getInstance()->font("font4.aaf");
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
             // "Intro" label
             {
-                auto& introButtonLabel = *makeUI<UI::TextArea>("INTRO", 50, 20);
+                auto& introButtonLabel = makeUI<UI::TextArea>("INTRO", 50, 20);
                 introButtonLabel.setFont(font4, color);
                 introButtonLabel.setWidth(150);
                 introButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -89,7 +90,7 @@ namespace Falltergeist
 
             // "New Game" label
             {
-                auto& newGameButtonLabel = *makeUI<UI::TextArea>("NEW GAME", 50, 20 + 41);
+                auto& newGameButtonLabel = makeUI<UI::TextArea>("NEW GAME", 50, 20 + 41);
                 newGameButtonLabel.setFont(font4, color);
                 newGameButtonLabel.setWidth(150);
                 newGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -97,7 +98,7 @@ namespace Falltergeist
 
             // "Load Game" label
             {
-                auto& loadGameButtonLabel = *makeUI<UI::TextArea>("LOAD GAME", 50, 20 + 41*2);
+                auto& loadGameButtonLabel = makeUI<UI::TextArea>("LOAD GAME", 50, 20 + 41*2);
                 loadGameButtonLabel.setFont(font4, color);
                 loadGameButtonLabel.setWidth(150);
                 loadGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -105,7 +106,7 @@ namespace Falltergeist
 
             // "Options" label
             {
-                auto& optionsButtonLabel = *makeUI<UI::TextArea>("OPTIONS", 50, 20 + 41*3);
+                auto& optionsButtonLabel = makeUI<UI::TextArea>("OPTIONS", 50, 20 + 41*3);
                 optionsButtonLabel.setFont(font4, color);
                 optionsButtonLabel.setWidth(150);
                 optionsButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -113,7 +114,7 @@ namespace Falltergeist
 
             // "Credits" label
             {
-                auto& creditsButtonLabel = *makeUI<UI::TextArea>("CREDITS", 50, 20 + 41*4);
+                auto& creditsButtonLabel = makeUI<UI::TextArea>("CREDITS", 50, 20 + 41*4);
                 creditsButtonLabel.setFont(font4, color);
                 creditsButtonLabel.setWidth(150);
                 creditsButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
@@ -121,7 +122,7 @@ namespace Falltergeist
 
             // "Exit" label
             {
-                auto& exitButtonLabel = *makeUI<UI::TextArea>("EXIT", 50, 20 + 41*5);
+                auto& exitButtonLabel = makeUI<UI::TextArea>("EXIT", 50, 20 + 41*5);
                 exitButtonLabel.setFont(font4, color);
                 exitButtonLabel.setWidth(150);
                 exitButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);

--- a/src/State/MainMenu.cpp
+++ b/src/State/MainMenu.cpp
@@ -38,7 +38,10 @@ namespace Falltergeist
 
         void MainMenu::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setModal(true);
@@ -50,75 +53,79 @@ namespace Falltergeist
             addUI("background", resourceManager->getImage("art/intrface/mainmenu.frm"));
 
             // intro button
-            auto introButton = addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19}));
-            introButton->mouseClickHandler().add(std::bind(&MainMenu::onIntroButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19}))
+                ->mouseClickHandler().add(std::bind(&MainMenu::onIntroButtonClick, this, std::placeholders::_1));
 
             // new game button
-            auto newGameButton = addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41}));
-            newGameButton->mouseClickHandler().add(std::bind(&MainMenu::onNewGameButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41}))
+                ->mouseClickHandler().add(std::bind(&MainMenu::onNewGameButtonClick, this, std::placeholders::_1));
 
             // load game button
-            auto loadGameButton = addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 2}));
-            loadGameButton->mouseClickHandler().add(std::bind(&MainMenu::onLoadGameButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 2}))
+                ->mouseClickHandler().add(std::bind(&MainMenu::onLoadGameButtonClick, this, std::placeholders::_1));
 
             // settings button
-            auto settingsButton = addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 3}));
-            settingsButton->mouseClickHandler().add(std::bind(&MainMenu::onSettingsButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 3}))
+                ->mouseClickHandler().add(std::bind(&MainMenu::onSettingsButtonClick, this, std::placeholders::_1));
 
             // credits button
-            auto creditsButton = addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 4}));
-            creditsButton->mouseClickHandler().add(std::bind(&MainMenu::onCreditsButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 4}))
+                ->mouseClickHandler().add(std::bind(&MainMenu::onCreditsButtonClick, this, std::placeholders::_1));
 
             // exit button
-            auto exitButton = addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 5}));
-            exitButton->mouseClickHandler().add(std::bind(&MainMenu::onExitButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::MENU_RED_CIRCLE, {30, 19 + 41 * 5}))
+                ->mouseClickHandler().add(std::bind(&MainMenu::onExitButtonClick, this, std::placeholders::_1));
 
             auto font4 = ResourceManager::getInstance()->font("font4.aaf");
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
             // "Intro" label
-            auto introButtonLabel = new UI::TextArea("INTRO", 50, 20);
-            introButtonLabel->setFont(font4, color);
-            introButtonLabel->setWidth(150);
-            introButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& introButtonLabel = *makeUI<UI::TextArea>("INTRO", 50, 20);
+                introButtonLabel.setFont(font4, color);
+                introButtonLabel.setWidth(150);
+                introButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // "New Game" label
-            auto newGameButtonLabel = new UI::TextArea("NEW GAME", 50, 20 + 41);
-            newGameButtonLabel->setFont(font4, color);
-            newGameButtonLabel->setWidth(150);
-            newGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& newGameButtonLabel = *makeUI<UI::TextArea>("NEW GAME", 50, 20 + 41);
+                newGameButtonLabel.setFont(font4, color);
+                newGameButtonLabel.setWidth(150);
+                newGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // "Load Game" label
-            auto loadGameButtonLabel = new UI::TextArea("LOAD GAME", 50, 20 + 41*2);
-            loadGameButtonLabel->setFont(font4, color);
-            loadGameButtonLabel->setWidth(150);
-            loadGameButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& loadGameButtonLabel = *makeUI<UI::TextArea>("LOAD GAME", 50, 20 + 41*2);
+                loadGameButtonLabel.setFont(font4, color);
+                loadGameButtonLabel.setWidth(150);
+                loadGameButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // "Options" label
-            auto optionsButtonLabel = new UI::TextArea("OPTIONS", 50, 20 + 41*3);
-            optionsButtonLabel->setFont(font4, color);
-            optionsButtonLabel->setWidth(150);
-            optionsButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& optionsButtonLabel = *makeUI<UI::TextArea>("OPTIONS", 50, 20 + 41*3);
+                optionsButtonLabel.setFont(font4, color);
+                optionsButtonLabel.setWidth(150);
+                optionsButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // "Credits" label
-            auto creditsButtonLabel = new UI::TextArea("CREDITS", 50, 20 + 41*4);
-            creditsButtonLabel->setFont(font4, color);
-            creditsButtonLabel->setWidth(150);
-            creditsButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto& creditsButtonLabel = *makeUI<UI::TextArea>("CREDITS", 50, 20 + 41*4);
+                creditsButtonLabel.setFont(font4, color);
+                creditsButtonLabel.setWidth(150);
+                creditsButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // "Exit" label
-            auto exitButtonLabel = new UI::TextArea("EXIT", 50, 20 + 41*5);
-            exitButtonLabel->setFont(font4, color);
-            exitButtonLabel->setWidth(150);
-            exitButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-
-            // Text areas
-            addUI(introButtonLabel);
-            addUI(newGameButtonLabel);
-            addUI(loadGameButtonLabel);
-            addUI(optionsButtonLabel);
-            addUI(creditsButtonLabel);
-            addUI(exitButtonLabel);
+            {
+                auto& exitButtonLabel = *makeUI<UI::TextArea>("EXIT", 50, 20 + 41*5);
+                exitButtonLabel.setFont(font4, color);
+                exitButtonLabel.setWidth(150);
+                exitButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
         }
 
         void MainMenu::doExit()

--- a/src/State/Movie.cpp
+++ b/src/State/Movie.cpp
@@ -21,18 +21,16 @@ namespace Falltergeist
 {
     namespace State
     {
-        Movie::Movie(int id) : State()
-        {
-            _id = id;
-        }
-
-        Movie::~Movie()
+        Movie::Movie(int id) : State{}, _id{id}
         {
         }
 
         void Movie::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setFullscreen(true);
@@ -85,15 +83,17 @@ namespace Falltergeist
                 _subs = ResourceManager::getInstance()->sveFileType(subfile);
                 if (_subs) _hasSubs = true;
             }
-            addUI("movie", new UI::MvePlayer(ResourceManager::getInstance()->mveFileType(movie)));
+
+            makeNamedUI<UI::MvePlayer>("movie", ResourceManager::getInstance()->mveFileType(movie));
 
             auto font0_ffffffff = ResourceManager::getInstance()->font("font1.aaf");
-            auto subLabel = new UI::TextArea("", 0, 320+35);
 
-            subLabel->setFont(font0_ffffffff, {0xFF, 0xFF, 0xFF, 0xFF});
-            subLabel->setWidth(640);
-            subLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-            addUI("subs",subLabel);
+            {
+                auto& subLabel = *makeNamedUI<UI::TextArea>("subs", "", 0, 320+35);
+                subLabel.setFont(font0_ffffffff, {0xFF, 0xFF, 0xFF, 0xFF});
+                subLabel.setWidth(640);
+                subLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             if (_hasSubs)
                 _nextSubLine = _subs->getSubLine(0);
@@ -109,11 +109,13 @@ namespace Falltergeist
                 return;
             }
 
-            unsigned int frame = dynamic_cast<UI::MvePlayer*>(getUI("movie"))->frame();
+            unsigned int frame = getUI<UI::MvePlayer>("movie")->frame();
             if ( frame >= _nextSubLine.first)
             {
-                dynamic_cast<UI::TextArea*>(getUI("subs"))->setText(_nextSubLine.second);
-                if (_hasSubs) _nextSubLine = _subs->getSubLine(dynamic_cast<UI::MvePlayer*>(getUI("movie"))->frame());
+                getUI<UI::TextArea>("subs")->setText(_nextSubLine.second);
+                if (_hasSubs) {
+                    _nextSubLine = _subs->getSubLine(getUI<UI::MvePlayer>("movie")->frame());
+                }
             }
             if (_effect_index<_effects.size() && frame>=_effects[_effect_index].frame)
             {
@@ -130,10 +132,10 @@ namespace Falltergeist
 
             if (!_started)
             {
-                Game::getInstance()->mixer()->playMovieMusic(dynamic_cast<UI::MvePlayer*>(getUI("movie")));
+                Game::getInstance()->mixer()->playMovieMusic(getUI<UI::MvePlayer>("movie").get());
                 _started = true;
             }
-            if ((dynamic_cast<UI::MvePlayer*>(getUI("movie")))->finished())
+            if (getUI<UI::MvePlayer>("movie")->finished())
             {
                 this->onVideoFinished();
             }

--- a/src/State/Movie.cpp
+++ b/src/State/Movie.cpp
@@ -89,7 +89,7 @@ namespace Falltergeist
             auto font0_ffffffff = ResourceManager::getInstance()->font("font1.aaf");
 
             {
-                auto& subLabel = *makeNamedUI<UI::TextArea>("subs", "", 0, 320+35);
+                auto& subLabel = makeNamedUI<UI::TextArea>("subs", "", 0, 320+35);
                 subLabel.setFont(font0_ffffffff, {0xFF, 0xFF, 0xFF, 0xFF});
                 subLabel.setWidth(640);
                 subLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);

--- a/src/State/Movie.h
+++ b/src/State/Movie.h
@@ -29,7 +29,7 @@ namespace Falltergeist
         {
             public:
                 Movie(int id);
-                ~Movie() override;
+                virtual ~Movie() override = default;
 
                 void init() override;
                 void think(const float &deltaTime) override;

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -110,7 +110,7 @@ namespace Falltergeist
         {
             Game::getInstance()->setPlayer(std::move(_characters.at(_selectedCharacter)));
             _characters.clear();
-            Game::getInstance()->pushState(new PlayerCreate(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<PlayerCreate>(resourceManager));
         }
 
         void NewGame::doCreate()
@@ -118,7 +118,7 @@ namespace Falltergeist
             auto none = std::make_unique<Game::DudeObject>();
             none->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/blank.gcd"));
             Game::getInstance()->setPlayer(std::move(none));
-            Game::getInstance()->pushState(new PlayerCreate(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<PlayerCreate>(resourceManager));
         }
 
         void NewGame::doBack()

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -280,20 +280,26 @@ namespace Falltergeist
 
         void NewGame::onStateActivate(Event::State* event)
         {
-            auto combat = std::make_unique<Game::DudeObject>();
-            combat->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/combat.gcd"));
-            combat->setBiography(ResourceManager::getInstance()->bioFileType("premade/combat.bio")->text());
-            _characters.emplace_back(std::move(combat));
+            {
+                auto combat = std::make_unique<Game::DudeObject>();
+                combat->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/combat.gcd"));
+                combat->setBiography(ResourceManager::getInstance()->bioFileType("premade/combat.bio")->text());
+                _characters.emplace_back(std::move(combat));
+            }
 
-            auto stealth = std::make_unique<Game::DudeObject>();
-            stealth->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/stealth.gcd"));
-            stealth->setBiography(ResourceManager::getInstance()->bioFileType("premade/stealth.bio")->text());
-            _characters.emplace_back(std::move(stealth));
+            {
+                auto stealth = std::make_unique<Game::DudeObject>();
+                stealth->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/stealth.gcd"));
+                stealth->setBiography(ResourceManager::getInstance()->bioFileType("premade/stealth.bio")->text());
+                _characters.emplace_back(std::move(stealth));
+            }
 
-            auto diplomat = std::make_unique<Game::DudeObject>();
-            diplomat->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/diplomat.gcd"));
-            diplomat->setBiography(ResourceManager::getInstance()->bioFileType("premade/diplomat.bio")->text());
-            _characters.emplace_back(std::move(diplomat));
+            {
+                auto diplomat = std::make_unique<Game::DudeObject>();
+                diplomat->loadFromGCDFile(ResourceManager::getInstance()->gcdFileType("premade/diplomat.gcd"));
+                diplomat->setBiography(ResourceManager::getInstance()->bioFileType("premade/diplomat.bio")->text());
+                _characters.emplace_back(std::move(diplomat));
+            }
 
             _changeCharacter();
 

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -72,7 +72,7 @@ namespace Falltergeist
                 ->mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onNextCharacterButtonClick(e);
                 });
-            makeNamedUI<UI::ImageList>("images", Point{27, 23}, std::vector<std::unique_ptr<UI::Image>>{
+            makeNamedUI<UI::ImageList>("images", Point{27, 23}, std::vector<std::shared_ptr<UI::Image>>{
                 resourceManager->getImage("art/intrface/combat.frm"),
                 resourceManager->getImage("art/intrface/stealth.frm"),
                 resourceManager->getImage("art/intrface/diplomat.frm")

--- a/src/State/NewGame.cpp
+++ b/src/State/NewGame.cpp
@@ -48,28 +48,29 @@ namespace Falltergeist
             setPosition((renderer->size() - Point(640, 480)) / 2);
 
             addUI("background", resourceManager->getImage("art/intrface/pickchar.frm"));
+
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {81, 322}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onBeginGameButtonClick(e);
                 });
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {436, 319}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onEditButtonClick(e);
                 });
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {81, 424}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onCreateButtonClick(e);
                 });
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {461, 424}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onBackButtonClick(e);
                 });
             addUI(imageButtonFactory->getByType(ImageButtonType::LEFT_ARROW, {292, 320}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onPrevCharacterButtonClick(e);
                 });
             addUI(imageButtonFactory->getByType(ImageButtonType::RIGHT_ARROW, {318, 320}))
-                ->mouseClickHandler().add([this](Event::Mouse* e) {
+                .mouseClickHandler().add([this](Event::Mouse* e) {
                     this->onNextCharacterButtonClick(e);
                 });
             makeNamedUI<UI::ImageList>("images", Point{27, 23}, std::vector<std::shared_ptr<UI::Image>>{
@@ -80,7 +81,7 @@ namespace Falltergeist
             makeNamedUI<UI::TextArea>("name", 300, 40);
 
             {
-                auto& stats1 = *makeNamedUI<UI::TextArea>("stats_1", 0, 70);
+                auto& stats1 = makeNamedUI<UI::TextArea>("stats_1", 0, 70);
                 stats1.setWidth(362);
                 stats1.setHorizontalAlign(UI::TextArea::HorizontalAlign::RIGHT);
             }
@@ -89,7 +90,7 @@ namespace Falltergeist
             makeNamedUI<UI::TextArea>("bio", 437, 40);
 
             {
-                auto& stats3 = *makeNamedUI<UI::TextArea>("stats_3", 294, 150);
+                auto& stats3 = makeNamedUI<UI::TextArea>("stats_3", 294, 150);
                 stats3.setWidth(85);
                 stats3.setHorizontalAlign(UI::TextArea::HorizontalAlign::RIGHT);
             }

--- a/src/State/NewGame.h
+++ b/src/State/NewGame.h
@@ -3,13 +3,10 @@
 #include <vector>
 #include "../State/State.h"
 #include "../UI/IResourceManager.h"
+#include "../Game/DudeObject.h"
 
 namespace Falltergeist
 {
-    namespace Game
-    {
-        class DudeObject;
-    }
     namespace UI
     {
         namespace Factory

--- a/src/State/PipBoy.cpp
+++ b/src/State/PipBoy.cpp
@@ -30,7 +30,10 @@ namespace Falltergeist
 
         void PipBoy::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setModal(true);
@@ -39,61 +42,50 @@ namespace Falltergeist
             Game::getInstance()->mouse()->pushState(Input::Mouse::Cursor::BIG_ARROW);
 
             // Background
-            auto background = resourceManager->getImage("art/intrface/pip.frm");
-            Point backgroundPos = Point((Game::getInstance()->renderer()->size() - background->size()) / 2);
-            int backgroundX = backgroundPos.x();
-            int backgroundY = backgroundPos.y();
-            background->setPosition(backgroundPos);
+            auto& background = *addUI(resourceManager->getImage("art/intrface/pip.frm"));
+            Point bgPos = Point((Game::getInstance()->renderer()->size() - background.size()) / 2);
+            background.setPosition(bgPos);
 
             // Buttons
-            auto alarmButton = imageButtonFactory->getByType(ImageButtonType::PIPBOY_ALARM_BUTTON, {backgroundX + 124, backgroundY + 13});
-            auto statusButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 53, backgroundY + 340});
-            auto automapsButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 53, backgroundY + 394});
-            auto archivesButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 53, backgroundY + 423});
-            auto closeButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 53, backgroundY + 448});
-            closeButton->mouseClickHandler().add(std::bind(&PipBoy::onCloseButtonClick, this, std::placeholders::_1));
+            addUI(imageButtonFactory->getByType(ImageButtonType::PIPBOY_ALARM_BUTTON, bgPos.add(124, 13)));
+            addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 340)));
+            addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 394)));
+            addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 432)));
+            addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 448)))
+                ->mouseClickHandler().add(std::bind(&PipBoy::onCloseButtonClick, this, std::placeholders::_1));
+
             // Date and time
 
             // Date
             auto gameTime = Game::getInstance()->gameTime();
 
-            auto day = new UI::SmallCounter(backgroundPos + Point(21, 17));
-            day->setLength(2);
-            day->setNumber(gameTime->day());
-            day->setColor(UI::SmallCounter::Color::WHITE);
-            day->setType(UI::SmallCounter::Type::UNSIGNED);
+            {
+                auto& day = *makeUI<UI::SmallCounter>(bgPos.add(21, 17));
+                day.setLength(2);
+                day.setNumber(gameTime->day());
+                day.setColor(UI::SmallCounter::Color::WHITE);
+                day.setType(UI::SmallCounter::Type::UNSIGNED);
+            }
 
-            auto month = new UI::MonthCounter(
+            makeUI<UI::MonthCounter>(
                 static_cast<UI::MonthCounter::Month>(gameTime->month()),
-                backgroundPos + Point(46, 18)
-            );
+            bgPos.add(46, 18));
 
-            auto year = new UI::SmallCounter(backgroundPos + Point(84, 17));
-            year->setLength(4);
-            year->setNumber(gameTime->year());
-            year->setColor(UI::SmallCounter::Color::WHITE);
-            year->setType(UI::SmallCounter::Type::UNSIGNED);
+            {
+                auto& year = *makeUI<UI::SmallCounter>(bgPos.add(84, 17));
+                year.setLength(4);
+                year.setNumber(gameTime->year());
+                year.setColor(UI::SmallCounter::Color::WHITE);
+                year.setType(UI::SmallCounter::Type::UNSIGNED);
+            }
 
-            // Time
-            auto time = new UI::SmallCounter(backgroundPos + Point(160, 17));
-            time->setLength(4);
-            time->setNumber((gameTime->hours() * 100) + gameTime->minutes());
-            time->setColor(UI::SmallCounter::Color::WHITE);
-            time->setType(UI::SmallCounter::Type::UNSIGNED);
-
-            addUI(background);
-
-            addUI(alarmButton);
-            addUI(statusButton);
-            addUI(automapsButton);
-            addUI(archivesButton);
-
-            addUI(day);
-            addUI(month);
-            addUI(year);
-            addUI(time);
-
-            addUI(closeButton);
+            {
+                auto& time = *makeUI<UI::SmallCounter>(bgPos.add(160, 17));
+                time.setLength(4);
+                time.setNumber((gameTime->hours() * 100) + gameTime->minutes());
+                time.setColor(UI::SmallCounter::Color::WHITE);
+                time.setType(UI::SmallCounter::Type::UNSIGNED);
+            }
         }
 
         void PipBoy::onCloseButtonClick(Event::Mouse* event)

--- a/src/State/PipBoy.cpp
+++ b/src/State/PipBoy.cpp
@@ -17,10 +17,11 @@ namespace Falltergeist
 
     namespace State
     {
-        PipBoy::PipBoy(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PipBoy::PipBoy(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         PipBoy::~PipBoy()
@@ -42,7 +43,7 @@ namespace Falltergeist
             Game::getInstance()->mouse()->pushState(Input::Mouse::Cursor::BIG_ARROW);
 
             // Background
-            auto& background = *addUI(resourceManager->getImage("art/intrface/pip.frm"));
+            auto& background = addUI(resourceManager->getImage("art/intrface/pip.frm"));
             Point bgPos = Point((Game::getInstance()->renderer()->size() - background.size()) / 2);
             background.setPosition(bgPos);
 
@@ -52,7 +53,7 @@ namespace Falltergeist
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 394)));
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 432)));
             addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(53, 448)))
-                ->mouseClickHandler().add(std::bind(&PipBoy::onCloseButtonClick, this, std::placeholders::_1));
+                .mouseClickHandler().add(std::bind(&PipBoy::onCloseButtonClick, this, std::placeholders::_1));
 
             // Date and time
 
@@ -60,7 +61,7 @@ namespace Falltergeist
             auto gameTime = Game::getInstance()->gameTime();
 
             {
-                auto& day = *makeUI<UI::SmallCounter>(bgPos.add(21, 17));
+                auto& day = makeUI<UI::SmallCounter>(bgPos.add(21, 17));
                 day.setLength(2);
                 day.setNumber(gameTime->day());
                 day.setColor(UI::SmallCounter::Color::WHITE);
@@ -72,7 +73,7 @@ namespace Falltergeist
             bgPos.add(46, 18));
 
             {
-                auto& year = *makeUI<UI::SmallCounter>(bgPos.add(84, 17));
+                auto& year = makeUI<UI::SmallCounter>(bgPos.add(84, 17));
                 year.setLength(4);
                 year.setNumber(gameTime->year());
                 year.setColor(UI::SmallCounter::Color::WHITE);
@@ -80,7 +81,7 @@ namespace Falltergeist
             }
 
             {
-                auto& time = *makeUI<UI::SmallCounter>(bgPos.add(160, 17));
+                auto& time = makeUI<UI::SmallCounter>(bgPos.add(160, 17));
                 time.setLength(4);
                 time.setNumber((gameTime->hours() * 100) + gameTime->minutes());
                 time.setColor(UI::SmallCounter::Color::WHITE);

--- a/src/State/PlayerCreate.cpp
+++ b/src/State/PlayerCreate.cpp
@@ -519,9 +519,9 @@ namespace Falltergeist
 
                         if (!_traitToggle(number - 1))
                         {
-                            auto state = new PlayerEditAlert(resourceManager);
+                            auto state = std::make_unique<PlayerEditAlert>(resourceManager);
                             state->setMessage(_t(MSG_EDITOR, 148) + "\n" + _t(MSG_EDITOR, 149));
-                            Game::getInstance()->pushState(state);
+                            Game::getInstance()->pushState(std::move(state));
                         }
                     }
 
@@ -533,9 +533,9 @@ namespace Falltergeist
                         _selectedImage = _images.at(name);
                         if (!_skillToggle(number - 1))
                         {
-                            auto state = new PlayerEditAlert(resourceManager);
+                            auto state = std::make_unique<PlayerEditAlert>(resourceManager);
                             state->setMessage(_t(MSG_EDITOR, 140) + "\n" + _t(MSG_EDITOR, 141));
-                            Game::getInstance()->pushState(state);
+                            Game::getInstance()->pushState(std::move(state));
                         }
                     }
                 }
@@ -612,7 +612,7 @@ namespace Falltergeist
 
         void PlayerCreate::doAge()
         {
-            Game::getInstance()->pushState(new PlayerEditAge(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<PlayerEditAge>(resourceManager));
         }
 
         void PlayerCreate::doBack()
@@ -631,17 +631,17 @@ namespace Falltergeist
 
         void PlayerCreate::doGender()
         {
-            Game::getInstance()->pushState(new PlayerEditGender(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<PlayerEditGender>(resourceManager));
         }
 
         void PlayerCreate::doName()
         {
-            Game::getInstance()->pushState(new PlayerEditName(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<PlayerEditName>(resourceManager));
         }
 
         void PlayerCreate::doOptions()
         {
-            Game::getInstance()->pushState(new PlayerCreateOptions(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<PlayerCreateOptions>(resourceManager));
         }
 
         void PlayerCreate::onKeyDown(Event::Keyboard* event)

--- a/src/State/PlayerCreate.cpp
+++ b/src/State/PlayerCreate.cpp
@@ -222,8 +222,10 @@ namespace Falltergeist
             _title->setFont("font2.aaf", {0,0,0,0xff});
             addUI(_title);
 
-            auto line = new UI::Rectangle(backgroundPos + Point(350, 300), Graphics::Size(270, 2), { 0x00, 0x00, 0x00, 0xff });
-            addUI(line);
+            makeUI<UI::Rectangle>(
+                    backgroundPos + Point(350, 300),
+                    Graphics::Size(270, 2),
+                    SDL_Color{ 0x00, 0x00, 0x00, 0xff });
 
             _description = std::make_shared<UI::TextArea>("", backgroundX+350, backgroundY+315);
             _description->setFont("font1.aaf", {0,0,0,0xff});

--- a/src/State/PlayerCreate.cpp
+++ b/src/State/PlayerCreate.cpp
@@ -59,14 +59,14 @@ namespace Falltergeist
                 _addTitle(ss.str(), _t(MSG_STATS, 100 + i));       // stat title
                 _addDescription(ss.str(), _t(MSG_STATS, 200 + i)); // stat description
                 _addImage(ss.str(), resourceManager->getImage("art/skilldex/" + imagesStats[i] + ".frm")); // stat image
-                _addLabel(ss.str(), new UI::TextArea("", backgroundX+104, backgroundY+46+33*i));      // stat value label
-                _addCounter(ss.str(), new UI::BigCounter({backgroundX + 59, static_cast<int>(backgroundY + 37 + 33 * i)}));       // stat value counter
-                _addMask(ss.str(), new UI::HiddenMask(133, 29, backgroundX+14, backgroundY+36+33*i)); // stat click mask
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>("", backgroundX+104, backgroundY+46+33*i));      // stat value label
+                _addCounter(ss.str(), std::make_shared<UI::BigCounter>(Point{backgroundX + 59, static_cast<int>(backgroundY + 37 + 33 * i)}));       // stat value counter
+                _addMask(ss.str(), std::make_shared<UI::HiddenMask>(133, 29, backgroundX+14, backgroundY+36+33*i)); // stat click mask
                 _addButton(ss.str() + "_increase", imageButtonFactory->getByType(ImageButtonType::PLUS,  {backgroundX + 149, static_cast<int>(backgroundY + 38 + 33 * i)})); // stat increase button
                 _addButton(ss.str() + "_decrease", imageButtonFactory->getByType(ImageButtonType::MINUS, {backgroundX + 149, static_cast<int>(backgroundY + 49 + 33 * i)})); // stat decrease button
             }
 
-            _addCounter("statsPoints", new UI::BigCounter({backgroundX + 126, backgroundY + 282})); // Free stats points counter
+            _addCounter("statsPoints", std::make_shared<UI::BigCounter>(backgroundPos.add(126, 282)));
 
             // TRAITS
             std::string imagesTraits[] =  { "fastmeta", "bruiser", "smlframe", "onehand", "finesse",  "kamikaze", "heavyhnd", "fastshot",
@@ -81,16 +81,16 @@ namespace Falltergeist
                 // left column
                 if (i <= 7)
                 {
-                    _addLabel(ss.str(),  new UI::TextArea(_t(MSG_TRAITS, 100 + i), backgroundX+48, backgroundY+353+13*i)); // trate label
+                    _addLabel(ss.str(), std::make_shared<UI::TextArea>(_t(MSG_TRAITS, 100 + i), backgroundX+48, backgroundY+353+13*i)); // trate label
                     _addButton(ss.str(), imageButtonFactory->getByType(ImageButtonType::SKILL_TOGGLE, {backgroundX + 23, static_cast<int>(backgroundY + 352 + 13 * i)})); // trate toggle button
                 }
                 //right column
                 else
                 {
-                    auto label = new UI::TextArea(_t(MSG_TRAITS, 100 + i), backgroundX+169, backgroundY+353+13*(i-8));
+                    auto label = std::make_unique<UI::TextArea>(_t(MSG_TRAITS, 100 + i), backgroundX+169, backgroundY+353+13*(i-8));
                     label->setWidth(122);
                     label->setHorizontalAlign(UI::TextArea::HorizontalAlign::RIGHT);
-                    _addLabel(ss.str(),  label); // trate label
+                    _addLabel(ss.str(),  std::move(label)); // trate label
                     _addButton(ss.str(), imageButtonFactory->getByType(ImageButtonType::SKILL_TOGGLE, {backgroundX + 299, static_cast<int>(backgroundY + 352 + 13 * (i - 8))})); // trate toggle button
                 }
             }
@@ -106,16 +106,16 @@ namespace Falltergeist
                 _addDescription(ss.str(), _t(MSG_SKILLS, 200 + i));
                 _addImage(ss.str(),  resourceManager->getImage("art/skilldex/" + imagesSkills[i] + ".frm"));
                 _addButton(ss.str(), imageButtonFactory->getByType(ImageButtonType::SKILL_TOGGLE, {backgroundX + 347, static_cast<int>(backgroundY + 26 + 11 * i)}));
-                _addLabel(ss.str(),  new UI::TextArea(_t(MSG_SKILLS, 100 + i), backgroundX+377, backgroundY+27+11*i))->setWidth(240);
-                _addLabel(ss.str() + "_value",  new UI::TextArea("", backgroundX+577, backgroundY+27+11*i));
+                _addLabel(ss.str(),  std::make_shared<UI::TextArea>(_t(MSG_SKILLS, 100 + i), backgroundX+377, backgroundY+27+11*i))->setWidth(240);
+                _addLabel(ss.str() + "_value",  std::make_shared<UI::TextArea>("", backgroundX+577, backgroundY+27+11*i));
             }
             // Free skill points counts
-            _addCounter("skillsPoints", new UI::BigCounter({backgroundX + 522, backgroundY + 228}));
+            _addCounter("skillsPoints", std::make_shared<UI::BigCounter>(backgroundPos.add(522, 228)));
 
             // HEALTH CONDITION
             std::string imagesHealth[] = { "hitpoint", "poisoned", "radiated", "eyedamag", "armright", "armleft", "legright", "legleft"};
             _addTitle("health_1", _t(MSG_EDITOR, 300));
-            _addLabel("health_1",  new UI::TextArea(_t(MSG_EDITOR, 300), backgroundX+194, backgroundY+46)); //health
+            _addLabel("health_1", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 300), backgroundX+194, backgroundY+46)); //health
             _addDescription("health_1", _t(MSG_STATS, 207));
             _addImage("health_1", resourceManager->getImage("art/skilldex/" + imagesHealth[0] + ".frm"));
 
@@ -125,7 +125,7 @@ namespace Falltergeist
                 ss << "health_" << (i+2);
                 _addTitle(ss.str(), _t(MSG_EDITOR, 312 + i));
                 _addDescription(ss.str(), _t(MSG_EDITOR, 400 + i));
-                _addLabel(ss.str(), new UI::TextArea(_t(MSG_EDITOR, 312 + i), backgroundX+194, backgroundY+46+13*(i+1)))->setFont("font1.aaf", {0x18, 0x30, 0x18, 0xff});
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 312 + i), backgroundX+194, backgroundY+46+13*(i+1)))->setFont("font1.aaf", {0x18, 0x30, 0x18, 0xff});
                 _addImage(ss.str(), resourceManager->getImage("art/skilldex/" + imagesHealth[i+1] + ".frm"));
             }
 
@@ -140,8 +140,8 @@ namespace Falltergeist
                 _addTitle(ss.str(), _t(MSG_STATS, params[i]));
                 _addDescription(ss.str(), _t(MSG_STATS, params[i] + 100));
                 _addImage(ss.str(), resourceManager->getImage("art/skilldex/" + imagesParams[i] + ".frm"));
-                _addLabel(ss.str(), new UI::TextArea(_t(MSG_EDITOR, labels[i]), backgroundX + 194, backgroundY + 179 + 13*i));
-                _addLabel(ss.str() + "_value", new UI::TextArea("", backgroundX + 288, backgroundY + 179 + 13*i));
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>(_t(MSG_EDITOR, labels[i]), backgroundX + 194, backgroundY + 179 + 13*i));
+                _addLabel(ss.str() + "_value", std::make_shared<UI::TextArea>("", backgroundX + 288, backgroundY + 179 + 13*i));
             }
 
             _addButton("options", imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 345, backgroundY + 454}));
@@ -151,19 +151,19 @@ namespace Falltergeist
             auto font3_b89c28ff = ResourceManager::getInstance()->font("font3.aaf");
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
-            _addLabel("options", new UI::TextArea(_t(MSG_EDITOR, 101), backgroundX+365, backgroundY+453))->setFont(font3_b89c28ff, color);
-            _addLabel("next",    new UI::TextArea(_t(MSG_EDITOR, 100), backgroundX+473, backgroundY+453))->setFont(font3_b89c28ff, color);
-            _addLabel("cancel",  new UI::TextArea(_t(MSG_EDITOR, 102), backgroundX+571, backgroundY+453))->setFont(font3_b89c28ff, color);
-            auto label = _addLabel("name",    new UI::TextArea(Game::getInstance()->player()->name(), backgroundX+17, backgroundY+7));
+            _addLabel("options", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 101), backgroundX+365, backgroundY+453))->setFont(font3_b89c28ff, color);
+            _addLabel("next",    std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 100), backgroundX+473, backgroundY+453))->setFont(font3_b89c28ff, color);
+            _addLabel("cancel",  std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 102), backgroundX+571, backgroundY+453))->setFont(font3_b89c28ff, color);
+            auto label = _addLabel("name",    std::make_shared<UI::TextArea>(Game::getInstance()->player()->name(), backgroundX+17, backgroundY+7));
             label->setWidth(150);
             label->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             label->setFont(font3_b89c28ff, color);
-            _addLabel("age",     new UI::TextArea(_t(MSG_EDITOR, 104), backgroundX+163, backgroundY+7))->setFont(font3_b89c28ff, color);
-            _addLabel("gender",  new UI::TextArea(_t(MSG_EDITOR, Game::getInstance()->player()->gender() == GENDER::MALE ? 107 : 108), backgroundX+250, backgroundY+7))->setFont(font3_b89c28ff, color);
-            _addLabel("label_1", new UI::TextArea(_t(MSG_EDITOR, 116), backgroundX+14, backgroundY+286))->setFont(font3_b89c28ff, color);  // char points
-            _addLabel("label_2", new UI::TextArea(_t(MSG_EDITOR, 139), backgroundX+50, backgroundY+326))->setFont(font3_b89c28ff, color);  // optinal traits
-            _addLabel("label_3", new UI::TextArea(_t(MSG_EDITOR, 117), backgroundX+383, backgroundY+5))->setFont(font3_b89c28ff, color);   // skills
-            _addLabel("label_4", new UI::TextArea(_t(MSG_EDITOR, 138), backgroundX+428, backgroundY+233))->setFont(font3_b89c28ff, color); // tag skills
+            _addLabel("age",     std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 104), backgroundX+163, backgroundY+7))->setFont(font3_b89c28ff, color);
+            _addLabel("gender",  std::make_shared<UI::TextArea>(_t(MSG_EDITOR, Game::getInstance()->player()->gender() == GENDER::MALE ? 107 : 108), backgroundX+250, backgroundY+7))->setFont(font3_b89c28ff, color);
+            _addLabel("label_1", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 116), backgroundX+14, backgroundY+286))->setFont(font3_b89c28ff, color);  // char points
+            _addLabel("label_2", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 139), backgroundX+50, backgroundY+326))->setFont(font3_b89c28ff, color);  // optinal traits
+            _addLabel("label_3", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 117), backgroundX+383, backgroundY+5))->setFont(font3_b89c28ff, color);   // skills
+            _addLabel("label_4", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 138), backgroundX+428, backgroundY+233))->setFont(font3_b89c28ff, color); // tag skills
             _addTitle("label_1", _t(MSG_EDITOR, 120));
             _addTitle("label_2", _t(MSG_EDITOR, 146));
             _addTitle("label_3", _t(MSG_EDITOR, 150));
@@ -218,57 +218,57 @@ namespace Falltergeist
             _selectedLabel = _labels.at("stats_1");
             _selectedImage->setPosition(backgroundPos + Point(480, 310));
 
-            _title = new UI::TextArea("", backgroundX+350, backgroundY+275);
+            _title = std::make_shared<UI::TextArea>("", backgroundX+350, backgroundY+275);
             _title->setFont("font2.aaf", {0,0,0,0xff});
             addUI(_title);
 
             auto line = new UI::Rectangle(backgroundPos + Point(350, 300), Graphics::Size(270, 2), { 0x00, 0x00, 0x00, 0xff });
             addUI(line);
 
-            _description = new UI::TextArea("", backgroundX+350, backgroundY+315);
+            _description = std::make_shared<UI::TextArea>("", backgroundX+350, backgroundY+315);
             _description->setFont("font1.aaf", {0,0,0,0xff});
             _description->setSize({140, 120});
             _description->setWordWrap(true);
         //    addUI(_description);
         }
 
-        UI::TextArea* PlayerCreate::_addLabel(const std::string& name, UI::TextArea* label)
+        std::shared_ptr<UI::TextArea> PlayerCreate::_addLabel(const std::string& name, std::shared_ptr<UI::TextArea> label)
         {
-            _labels.insert(std::pair<std::string,UI::TextArea*>(name, label));
+            _labels.insert({ name, label });
             return label;
         }
 
-        UI::ImageButton* PlayerCreate::_addButton(const std::string& name, UI::ImageButton* button)
+        std::shared_ptr<UI::ImageButton> PlayerCreate::_addButton(const std::string& name, std::shared_ptr<UI::ImageButton> button)
         {
-            _buttons.insert(std::pair<std::string,UI::ImageButton*>(name, button));
+            _buttons.insert({ name, button });
             return button;
         }
 
-        UI::BigCounter* PlayerCreate::_addCounter(const std::string& name, UI::BigCounter* counter)
+        std::shared_ptr<UI::BigCounter> PlayerCreate::_addCounter(const std::string& name, std::shared_ptr<UI::BigCounter> counter)
         {
-            _counters.insert(std::pair<std::string,UI::BigCounter*>(name, counter));
+            _counters.insert({ name, counter });
             return counter;
         }
 
-        UI::HiddenMask* PlayerCreate::_addMask(const std::string& name, UI::HiddenMask* mask)
+        std::shared_ptr<UI::HiddenMask> PlayerCreate::_addMask(const std::string& name, std::shared_ptr<UI::HiddenMask> mask)
         {
-            _masks.insert(std::pair<std::string,UI::HiddenMask*>(name, mask));
+            _masks.insert({ name, mask });
             return mask;
         }
 
         void PlayerCreate::_addTitle(const std::string& name, std::string title)
         {
-            _titles.insert(std::pair<std::string,std::string>(name, title));
+            _titles.insert({ name, std::move(title) });
         }
 
         void PlayerCreate::_addDescription(const std::string& name, std::string description)
         {
-            _descriptions.insert(std::pair<std::string,std::string>(name, description));
+            _descriptions.insert({ name, std::move(description) });
         }
 
-        void PlayerCreate::_addImage(const std::string& name, UI::Image* image)
+        void PlayerCreate::_addImage(const std::string& name, std::shared_ptr<UI::Image> image)
         {
-            _images.insert(std::pair<std::string, UI::Image*>(name, image));
+            _images.insert({ name, std::move(image) });
         }
 
         void PlayerCreate::think(const float &deltaTime)
@@ -484,7 +484,7 @@ namespace Falltergeist
 
             for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
             {
-                if (it->second == sender)
+                if (it->second.get() == sender)
                 {
                     std::string name = it->first;
 
@@ -547,7 +547,7 @@ namespace Falltergeist
             for(auto it = _labels.begin(); it != _labels.end(); ++it)
             {
                 std::string name = it->first;
-                if (it->second == event->target())
+                if (it->second.get() == event->target())
                 {
                     if (name.find("stats_") == 0 || name.find("traits_") == 0 || name.find("skills_") == 0 || name.find("health_") == 0 || name.find("params_") == 0 || name.find("label_") == 0)
                     {
@@ -567,7 +567,7 @@ namespace Falltergeist
         {
             for(auto it = _masks.begin(); it != _masks.end(); ++it)
             {
-                if (it->second == event->target())
+                if (it->second.get() == event->target())
                 {
                     std::string name = it->first;
                     if (name.find("stats_") == 0)

--- a/src/State/PlayerCreate.cpp
+++ b/src/State/PlayerCreate.cpp
@@ -27,15 +27,19 @@ namespace Falltergeist
 
     namespace State
     {
-        PlayerCreate::PlayerCreate(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PlayerCreate::PlayerCreate(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void PlayerCreate::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setFullscreen(true);
@@ -47,7 +51,7 @@ namespace Falltergeist
             int backgroundX = backgroundPos.x();
             int backgroundY = backgroundPos.y();
             background->setPosition(backgroundPos);
-            addUI("bg",background);
+            addUI("bg", background);
 
             // STATS
             std::string imagesStats[] = { "strength", "perceptn", "endur", "charisma", "intel", "agility", "luck"};
@@ -190,7 +194,7 @@ namespace Falltergeist
             for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
             {
                 it->second->mouseClickHandler().add(std::bind(&PlayerCreate::onButtonClick, this, std::placeholders::_1));
-                addUI(it->second);
+                addSharedUI(it->second);
             }
 
             // add labels to the state
@@ -198,20 +202,20 @@ namespace Falltergeist
             for(auto it = _labels.rbegin(); it != _labels.rend(); ++it)
             {
                 it->second->mouseDownHandler().add(std::bind(&PlayerCreate::onLabelClick, this, std::placeholders::_1));
-                addUI(it->second);
+                addSharedUI(it->second);
             }
 
             // add counters to the state
             for(auto it = _counters.begin(); it != _counters.end(); ++it)
             {
-                addUI(it->second);
+                addSharedUI(it->second);
             }
 
             // add hidden masks
             for(auto it = _masks.begin(); it != _masks.end(); ++it)
             {
                 it->second->mouseDownHandler().add(std::bind(&PlayerCreate::onMaskClick, this, std::placeholders::_1));
-                addUI(it->second);
+                addSharedUI(it->second);
             }
 
             _selectedImage = _images.at("stats_1");
@@ -220,7 +224,7 @@ namespace Falltergeist
 
             _title = std::make_shared<UI::TextArea>("", backgroundX+350, backgroundY+275);
             _title->setFont("font2.aaf", {0,0,0,0xff});
-            addUI(_title);
+            addSharedUI(_title);
 
             makeUI<UI::Rectangle>(
                     backgroundPos + Point(350, 300),

--- a/src/State/PlayerCreate.h
+++ b/src/State/PlayerCreate.h
@@ -49,26 +49,26 @@ namespace Falltergeist
                 void onKeyDown(Event::Keyboard* event) override;
 
             protected:
-                UI::TextArea* _selectedLabel = nullptr;
-                UI::TextArea* _title = nullptr;
-                UI::TextArea* _description = nullptr;
-                UI::Image* _selectedImage = nullptr;
+                std::shared_ptr<UI::TextArea> _selectedLabel = nullptr;
+                std::shared_ptr<UI::TextArea> _title = nullptr;
+                std::shared_ptr<UI::TextArea> _description = nullptr;
+                std::shared_ptr<UI::Image> _selectedImage = nullptr;
 
-                std::map<std::string, UI::TextArea*> _labels;
-                std::map<std::string, UI::BigCounter*> _counters;
-                std::map<std::string, UI::ImageButton*> _buttons;
-                std::map<std::string, UI::HiddenMask*> _masks;
+                std::map<std::string, std::shared_ptr<UI::TextArea>> _labels;
+                std::map<std::string, std::shared_ptr<UI::BigCounter>> _counters;
+                std::map<std::string, std::shared_ptr<UI::ImageButton>> _buttons;
+                std::map<std::string, std::shared_ptr<UI::HiddenMask>> _masks;
                 std::map<std::string, std::string> _titles;
                 std::map<std::string, std::string> _descriptions;
-                std::map<std::string, UI::Image*> _images;
+                std::map<std::string, std::shared_ptr<UI::Image>> _images;
 
-                UI::TextArea* _addLabel(const std::string& name, UI::TextArea* label);
-                UI::ImageButton* _addButton(const std::string& name, UI::ImageButton* button);
-                UI::BigCounter* _addCounter(const std::string& name, UI::BigCounter* counter);
-                UI::HiddenMask* _addMask(const std::string& name, UI::HiddenMask* mask);
+                std::shared_ptr<UI::TextArea> _addLabel(const std::string& name, std::shared_ptr<UI::TextArea> label);
+                std::shared_ptr<UI::ImageButton> _addButton(const std::string& name, std::shared_ptr<UI::ImageButton> button);
+                std::shared_ptr<UI::BigCounter> _addCounter(const std::string& name, std::shared_ptr<UI::BigCounter> counter);
+                std::shared_ptr<UI::HiddenMask> _addMask(const std::string& name, std::shared_ptr<UI::HiddenMask> mask);
                 void _addTitle(const std::string& name, std::string title);
                 void _addDescription(const std::string& name, std::string description);
-                void _addImage(const std::string& name, UI::Image* image);
+                void _addImage(const std::string& name, std::shared_ptr<UI::Image> image);
 
                 bool _statIncrease(unsigned int num);
                 bool _statDecrease(unsigned int num);

--- a/src/State/PlayerCreateOptions.cpp
+++ b/src/State/PlayerCreateOptions.cpp
@@ -20,10 +20,11 @@ namespace Falltergeist
 
     namespace State
     {
-        PlayerCreateOptions::PlayerCreateOptions(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PlayerCreateOptions::PlayerCreateOptions(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void PlayerCreateOptions::init()
@@ -31,43 +32,39 @@ namespace Falltergeist
             if (_initialized) {
                 return;
             }
+
             State::init();
 
             setModal(true);
             setFullscreen(false);
 
-            auto& background = *addUI(resourceManager->getImage("art/intrface/opbase.frm"));
+            auto& background = addUI(resourceManager->getImage("art/intrface/opbase.frm"));
             Point bgPos = Point((Game::getInstance()->renderer()->size() - background.size()) / 2);
             background.setPosition(bgPos);
 
             {
-                auto saveButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18));
-                saveButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onSaveButtonClick, this, std::placeholders::_1));
-                addUI(std::move(saveButton));
+                auto& saveButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18)));
+                saveButton.mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onSaveButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto loadButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37));
-                loadButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onLoadButtonClick, this, std::placeholders::_1));
-                addUI(std::move(loadButton));
+                auto& loadButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37)));
+                loadButton.mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onLoadButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto printToFileButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 2));
-                printToFileButton->mouseClickHandler().add(std::bind(&PlayerCreateOptions::onPrintToFileButtonClick, this, std::placeholders::_1));
-                addUI(std::move(printToFileButton));
+                auto& printToFileButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 2)));
+                printToFileButton.mouseClickHandler().add(std::bind(&PlayerCreateOptions::onPrintToFileButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto eraseButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 3));
-                eraseButton->mouseClickHandler().add(      std::bind(&PlayerCreateOptions::onEraseButtonClick, this, std::placeholders::_1));
-                addUI(std::move(eraseButton));
+                auto& eraseButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 3)));
+                eraseButton.mouseClickHandler().add(      std::bind(&PlayerCreateOptions::onEraseButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto doneButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 4));
-                doneButton->mouseClickHandler().add(       std::bind(&PlayerCreateOptions::onDoneButtonClick, this, std::placeholders::_1));
-                addUI(std::move(doneButton));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 4)));
+                doneButton.mouseClickHandler().add(       std::bind(&PlayerCreateOptions::onDoneButtonClick, this, std::placeholders::_1));
             }
 
             auto font = ResourceManager::getInstance()->font("font3.aaf");
@@ -75,42 +72,42 @@ namespace Falltergeist
 
             // label: save
             {
-                auto saveButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 600), bgPos.add(8, 26));
-                saveButtonLabel->setFont(font, color);
-                saveButtonLabel->setWidth(150);
-                saveButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& saveButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 600), bgPos.add(8, 26));
+                saveButtonLabel.setFont(font, color);
+                saveButtonLabel.setWidth(150);
+                saveButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: load
             {
-                auto loadButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 601), bgPos.add(8, 26 + 37));
-                loadButtonLabel->setFont(font, color);
-                loadButtonLabel->setWidth(150);
-                loadButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& loadButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 601), bgPos.add(8, 26 + 37));
+                loadButtonLabel.setFont(font, color);
+                loadButtonLabel.setWidth(150);
+                loadButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: print to file
             {
-                auto printToFileButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 602), bgPos.add(8, 26 + 37 * 2));
-                printToFileButtonLabel->setFont(font, color);
-                printToFileButtonLabel->setWidth(150);
-                printToFileButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& printToFileButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 602), bgPos.add(8, 26 + 37 * 2));
+                printToFileButtonLabel.setFont(font, color);
+                printToFileButtonLabel.setWidth(150);
+                printToFileButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: erase
             {
-                auto eraseButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 603), bgPos.add(8, 26 + 37 * 3));
-                eraseButtonLabel->setFont(font, color);
-                eraseButtonLabel->setWidth(150);
-                eraseButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& eraseButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 603), bgPos.add(8, 26 + 37 * 3));
+                eraseButtonLabel.setFont(font, color);
+                eraseButtonLabel.setWidth(150);
+                eraseButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: done
             {
-                auto doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 604), bgPos.add(8, 26 + 37 * 4));
-                doneButtonLabel->setFont(font, color);
-                doneButtonLabel->setWidth(150);
-                doneButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 604), bgPos.add(8, 26 + 37 * 4));
+                doneButtonLabel.setFont(font, color);
+                doneButtonLabel.setWidth(150);
+                doneButtonLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
         }
 

--- a/src/State/PlayerCreateOptions.cpp
+++ b/src/State/PlayerCreateOptions.cpp
@@ -28,78 +28,90 @@ namespace Falltergeist
 
         void PlayerCreateOptions::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
             State::init();
 
             setModal(true);
             setFullscreen(false);
 
-            auto background = resourceManager->getImage("art/intrface/opbase.frm");
+            auto& background = *addUI(resourceManager->getImage("art/intrface/opbase.frm"));
+            Point bgPos = Point((Game::getInstance()->renderer()->size() - background.size()) / 2);
+            background.setPosition(bgPos);
 
-            Point backgroundPos = Point((Game::getInstance()->renderer()->size() - background->size()) / 2);
-            int backgroundX = backgroundPos.x();
-            int backgroundY = backgroundPos.y();
+            {
+                auto saveButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18));
+                saveButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onSaveButtonClick, this, std::placeholders::_1));
+                addUI(std::move(saveButton));
+            }
 
-            auto saveButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18});
-            auto loadButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37});
-            auto printToFileButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 2});
-            auto eraseButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 3});
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, {backgroundX + 14, backgroundY + 18 + 37 * 4});
+            {
+                auto loadButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37));
+                loadButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onLoadButtonClick, this, std::placeholders::_1));
+                addUI(std::move(loadButton));
+            }
 
-            saveButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onSaveButtonClick, this, std::placeholders::_1));
-            loadButton->mouseClickHandler().add(   std::bind(&PlayerCreateOptions::onLoadButtonClick, this, std::placeholders::_1));
-            printToFileButton->mouseClickHandler().add(std::bind(&PlayerCreateOptions::onPrintToFileButtonClick, this, std::placeholders::_1));
-            eraseButton->mouseClickHandler().add(      std::bind(&PlayerCreateOptions::onEraseButtonClick, this, std::placeholders::_1));
-            doneButton->mouseClickHandler().add(       std::bind(&PlayerCreateOptions::onDoneButtonClick, this, std::placeholders::_1));
+            {
+                auto printToFileButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 2));
+                printToFileButton->mouseClickHandler().add(std::bind(&PlayerCreateOptions::onPrintToFileButtonClick, this, std::placeholders::_1));
+                addUI(std::move(printToFileButton));
+            }
+
+            {
+                auto eraseButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 3));
+                eraseButton->mouseClickHandler().add(      std::bind(&PlayerCreateOptions::onEraseButtonClick, this, std::placeholders::_1));
+                addUI(std::move(eraseButton));
+            }
+
+            {
+                auto doneButton = imageButtonFactory->getByType(ImageButtonType::OPTIONS_BUTTON, bgPos.add(14, 18 + 37 * 4));
+                doneButton->mouseClickHandler().add(       std::bind(&PlayerCreateOptions::onDoneButtonClick, this, std::placeholders::_1));
+                addUI(std::move(doneButton));
+            }
 
             auto font = ResourceManager::getInstance()->font("font3.aaf");
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
             // label: save
-            auto saveButtonLabel = new UI::TextArea(_t(MSG_EDITOR, 600), backgroundX+8, backgroundY+26);
-            saveButtonLabel->setFont(font, color);
-            saveButtonLabel->setWidth(150);
-            saveButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto saveButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 600), bgPos.add(8, 26));
+                saveButtonLabel->setFont(font, color);
+                saveButtonLabel->setWidth(150);
+                saveButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: load
-            auto loadButtonLabel = new UI::TextArea(_t(MSG_EDITOR, 601), backgroundX+8, backgroundY+26+37);
-            loadButtonLabel->setFont(font, color);
-            loadButtonLabel->setWidth(150);
-            loadButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto loadButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 601), bgPos.add(8, 26 + 37));
+                loadButtonLabel->setFont(font, color);
+                loadButtonLabel->setWidth(150);
+                loadButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: print to file
-            auto printToFileButtonLabel = new UI::TextArea(_t(MSG_EDITOR, 602), backgroundX+8, backgroundY+26+37*2);
-            printToFileButtonLabel->setFont(font, color);
-            printToFileButtonLabel->setWidth(150);
-            printToFileButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto printToFileButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 602), bgPos.add(8, 26 + 37 * 2));
+                printToFileButtonLabel->setFont(font, color);
+                printToFileButtonLabel->setWidth(150);
+                printToFileButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: erase
-            auto eraseButtonLabel = new UI::TextArea(_t(MSG_EDITOR, 603), backgroundX+8, backgroundY+26+37*3);
-            eraseButtonLabel->setFont(font, color);
-            eraseButtonLabel->setWidth(150);
-            eraseButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto eraseButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 603), bgPos.add(8, 26 + 37 * 3));
+                eraseButtonLabel->setFont(font, color);
+                eraseButtonLabel->setWidth(150);
+                eraseButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: done
-            auto doneButtonLabel = new UI::TextArea(_t(MSG_EDITOR, 604), backgroundX+8, backgroundY+26+37*4);
-            doneButtonLabel->setFont(font, color);
-            doneButtonLabel->setWidth(150);
-            doneButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-
-            background->setPosition(backgroundPos);
-
-            addUI(background);
-
-            addUI(std::move(saveButton));
-            addUI(std::move(loadButton));
-            addUI(std::move(printToFileButton));
-            addUI(std::move(eraseButton));
-            addUI(std::move(doneButton));
-
-            addUI(saveButtonLabel);
-            addUI(loadButtonLabel);
-            addUI(printToFileButtonLabel);
-            addUI(eraseButtonLabel);
-            addUI(doneButtonLabel);
+            {
+                auto doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 604), bgPos.add(8, 26 + 37 * 4));
+                doneButtonLabel->setFont(font, color);
+                doneButtonLabel->setWidth(150);
+                doneButtonLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
         }
 
         void PlayerCreateOptions::onSaveButtonClick(Event::Mouse* event)

--- a/src/State/PlayerCreateOptions.cpp
+++ b/src/State/PlayerCreateOptions.cpp
@@ -89,11 +89,11 @@ namespace Falltergeist
 
             addUI(background);
 
-            addUI(saveButton);
-            addUI(loadButton);
-            addUI(printToFileButton);
-            addUI(eraseButton);
-            addUI(doneButton);
+            addUI(std::move(saveButton));
+            addUI(std::move(loadButton));
+            addUI(std::move(printToFileButton));
+            addUI(std::move(eraseButton));
+            addUI(std::move(doneButton));
 
             addUI(saveButtonLabel);
             addUI(loadButtonLabel);

--- a/src/State/PlayerEdit.cpp
+++ b/src/State/PlayerEdit.cpp
@@ -59,9 +59,9 @@ namespace Falltergeist
                 _addTitle(ss.str(), _t(MSG_STATS, 100 + i));       // stat title
                 _addDescription(ss.str(), _t(MSG_STATS, 200 + i)); // stat description
                 _addImage(ss.str(), resourceManager->getImage("art/skilldex/" + imagesStats[i] + ".frm")); // stat image
-                _addLabel(ss.str(), new UI::TextArea(backgroundX+104, backgroundY+46+33*i));          // stat value label
-                _addCounter(ss.str(), new UI::BigCounter({backgroundX + 59, static_cast<int>(backgroundY + 37 + 33 * i)}));       // stat value counter
-                _addMask(ss.str(), new UI::HiddenMask(133, 29, backgroundX+14, backgroundY+36+33*i)); // stat click mask
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>(backgroundX+104, backgroundY+46+33*i));          // stat value label
+                _addCounter(ss.str(), std::make_shared<UI::BigCounter>(Point{backgroundX + 59, static_cast<int>(backgroundY + 37 + 33 * i)}));       // stat value counter
+                _addMask(ss.str(), std::make_shared<UI::HiddenMask>(133, 29, backgroundX+14, backgroundY+36+33*i)); // stat click mask
             }
 
             // LEVEL window
@@ -117,7 +117,7 @@ namespace Falltergeist
                         tmp << expNext;
                         break;
                 }
-                _addLabel(ss.str(), new UI::TextArea(tmp.str(), backgroundX + 32, backgroundY + 280 + 11*i));            // stat value label
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>(tmp.str(), backgroundX + 32, backgroundY + 280 + 11*i));            // stat value label
             }
 
             // SKILLS
@@ -130,16 +130,16 @@ namespace Falltergeist
                 _addTitle(ss.str(), _t(MSG_SKILLS, 100 + i));
                 _addDescription(ss.str(), _t(MSG_SKILLS, 200 + i));
                 _addImage(ss.str(),  resourceManager->getImage("art/skilldex/" + imagesSkills[i] + ".frm"));
-                _addLabel(ss.str(),  new UI::TextArea(_t(MSG_SKILLS, 100 + i), backgroundX+377, backgroundY+27+11*i))->setWidth(240);
-                _addLabel(ss.str() + "_value",  new UI::TextArea("", backgroundX+577, backgroundY+27+11*i));
+                _addLabel(ss.str(),  std::make_shared<UI::TextArea>(_t(MSG_SKILLS, 100 + i), backgroundX+377, backgroundY+27+11*i))->setWidth(240);
+                _addLabel(ss.str() + "_value",  std::make_shared<UI::TextArea>("", backgroundX+577, backgroundY+27+11*i));
             }
             // Free skill points counts
-            _addCounter("skillsPoints", new UI::BigCounter({backgroundX + 522, backgroundY + 228}));
+            _addCounter("skillsPoints", std::make_shared<UI::BigCounter>(backgroundPos.add(522, 228)));
 
             // HEALTH CONDITION
             std::string imagesHealth[] = { "hitpoint", "poisoned", "radiated", "eyedamag", "armright", "armleft", "legright", "legleft"};
             _addTitle("health_1", _t(MSG_EDITOR, 300));
-            _addLabel("health_1", new UI::TextArea(_t(MSG_EDITOR, 300), backgroundX+194, backgroundY+46)); //health
+            _addLabel("health_1", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 300), backgroundX+194, backgroundY+46)); //health
             _addDescription("health_1", _t(MSG_STATS, 207));
             _addImage("health_1", resourceManager->getImage("art/skilldex/" + imagesHealth[0] + ".frm"));
 
@@ -149,7 +149,7 @@ namespace Falltergeist
                 ss << "health_" << (i+2);
                 _addTitle(ss.str(), _t(MSG_EDITOR, 312 + i));
                 _addDescription(ss.str(), _t(MSG_EDITOR, 400 + i));
-                _addLabel(ss.str(), new UI::TextArea(_t(MSG_EDITOR, 312+i), backgroundX+194, backgroundY+46+13*(i+1)))->setFont("font1.aaf", {0x18, 0x30, 0x18, 0xff});
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 312+i), backgroundX+194, backgroundY+46+13*(i+1)))->setFont("font1.aaf", {0x18, 0x30, 0x18, 0xff});
                 _addImage(ss.str(), resourceManager->getImage("art/skilldex/" + imagesHealth[i+1] + ".frm"));
             }
 
@@ -164,8 +164,8 @@ namespace Falltergeist
                 _addTitle(ss.str(), _t(MSG_STATS, params[i]));
                 _addDescription(ss.str(), _t(MSG_STATS, params[i] + 100));
                 _addImage(ss.str(), resourceManager->getImage("art/skilldex/" + imagesParams[i] + ".frm"));
-                _addLabel(ss.str(), new UI::TextArea(_t(MSG_EDITOR, labels[i]), backgroundX + 194, backgroundY + 179 + 13*i));
-                _addLabel(ss.str() + "_value",  new UI::TextArea("", backgroundX + 288, backgroundY + 179 + 13*i));
+                _addLabel(ss.str(), std::make_shared<UI::TextArea>(_t(MSG_EDITOR, labels[i]), backgroundX + 194, backgroundY + 179 + 13*i));
+                _addLabel(ss.str() + "_value",  std::make_shared<UI::TextArea>("", backgroundX + 288, backgroundY + 179 + 13*i));
             }
 
             _addButton("print", imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 345, backgroundY + 454}));
@@ -175,18 +175,18 @@ namespace Falltergeist
             auto font3_b89c28ff = ResourceManager::getInstance()->font("font3.aaf");
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
-            _addLabel("print", new UI::TextArea(_t(MSG_EDITOR, 103), backgroundX+365, backgroundY+453))->setFont(font3_b89c28ff, color);
-            _addLabel("next",  new UI::TextArea(_t(MSG_EDITOR, 100), backgroundX+473, backgroundY+453))->setFont(font3_b89c28ff, color);
-            _addLabel("cancel",new UI::TextArea(_t(MSG_EDITOR, 102), backgroundX+571, backgroundY+453))->setFont(font3_b89c28ff, color);
-            auto label = _addLabel("name", new UI::TextArea(Game::getInstance()->player()->name(), backgroundX+17, backgroundY+7));
+            _addLabel("print", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 103), backgroundX+365, backgroundY+453))->setFont(font3_b89c28ff, color);
+            _addLabel("next",  std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 100), backgroundX+473, backgroundY+453))->setFont(font3_b89c28ff, color);
+            _addLabel("cancel",std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 102), backgroundX+571, backgroundY+453))->setFont(font3_b89c28ff, color);
+            auto label = _addLabel("name", std::make_shared<UI::TextArea>(Game::getInstance()->player()->name(), backgroundX+17, backgroundY+7));
             label->setWidth(150);
             label->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             label->setFont(font3_b89c28ff, color);
-            _addLabel("age",     new UI::TextArea(_t(MSG_EDITOR, 104), backgroundX+163, backgroundY+7))->setFont(font3_b89c28ff, color);
-            _addLabel("gender",  new UI::TextArea(_t(MSG_EDITOR, Game::getInstance()->player()->gender() == GENDER::MALE ? 107 : 108), backgroundX+250, backgroundY+7))->setFont(font3_b89c28ff, color);
+            _addLabel("age",     std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 104), backgroundX+163, backgroundY+7))->setFont(font3_b89c28ff, color);
+            _addLabel("gender",  std::make_shared<UI::TextArea>(_t(MSG_EDITOR, Game::getInstance()->player()->gender() == GENDER::MALE ? 107 : 108), backgroundX+250, backgroundY+7))->setFont(font3_b89c28ff, color);
 
-            _addLabel("label_1", new UI::TextArea(_t(MSG_EDITOR, 112), backgroundX+398, backgroundY+233))->setFont(font3_b89c28ff, color); // skill points on tag skills place!
-            _addLabel("label_3", new UI::TextArea(_t(MSG_EDITOR, 117), backgroundX+383, backgroundY+5))->setFont(font3_b89c28ff, color);  // skills
+            _addLabel("label_1", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 112), backgroundX+398, backgroundY+233))->setFont(font3_b89c28ff, color); // skill points on tag skills place!
+            _addLabel("label_3", std::make_shared<UI::TextArea>(_t(MSG_EDITOR, 117), backgroundX+383, backgroundY+5))->setFont(font3_b89c28ff, color);  // skills
 
             _addTitle("label_1", _t(MSG_EDITOR, 112));
             _addTitle("label_2", _t(MSG_EDITOR, 146));
@@ -251,14 +251,14 @@ namespace Falltergeist
             _selectedLabel = _labels.at("stats_1");
             _selectedImage->setPosition(backgroundPos + Point(480, 310));
 
-            _title = new UI::TextArea("", backgroundX+350, backgroundY+275);
+            _title = std::make_shared<UI::TextArea>("", backgroundX+350, backgroundY+275);
             _title->setFont("font2.aaf", {0,0,0,0xff});
             addUI(_title);
 
             auto line = new UI::Rectangle(backgroundPos + Point(350, 300), Graphics::Size(270, 2), { 0x00, 0x00, 0x00, 0xff });
             addUI(line);
 
-            _description = new UI::TextArea("", backgroundX+350, backgroundY+315);
+            _description = std::make_shared<UI::TextArea>("", backgroundX+350, backgroundY+315);
             _description->setFont("font1.aaf", {0,0,0,0xff});
             _description->setSize({140, 120});
             _description->setWordWrap(true);
@@ -276,7 +276,7 @@ namespace Falltergeist
             for (unsigned int i = 0; i < 3; i++) {
                 auto tab = addUI("tab_" + std::to_string(i),
                                      new UI::TextArea(_t(MSG_EDITOR, 109+i), backgroundX+10+35+(100*i), backgroundY+325+7+(i == 0 ? -1 : 1)));
-                dynamic_cast<UI::TextArea*>(tab)->setFont(font3_b89c28ff, color);
+                tab->setFont(font3_b89c28ff, color);
             }
 
             Point tabContentPos = tabs->position() + Point(25, 45);
@@ -336,70 +336,74 @@ namespace Falltergeist
             addUI("tab_kills_enemies", killEnemyNames);
             addUI("tab_kills_score", killEnemyScore);
 
-            auto tabsArrowUp = imageButtonFactory->getByType(ImageButtonType::SMALL_UP_ARROW, {backgroundX + 317, backgroundY + 363});
-            tabsArrowUp->mouseClickHandler().add([=](...) {
-                switch (tabs->currentImage()) {
-                case 0: perksAndTraits->scrollUp();
-                    break;
-                case 1: karma->scrollUp();
-                    break;
-                case 2: killEnemyNames->scrollUp(); killEnemyScore->scrollUp();
-                    break;
-                }
-            });
-            addUI(tabsArrowUp);
+            {
+                auto tabsArrowUp = imageButtonFactory->getByType(ImageButtonType::SMALL_UP_ARROW, {backgroundX + 317, backgroundY + 363});
+                tabsArrowUp->mouseClickHandler().add([=](...) {
+                    switch (tabs->currentImage()) {
+                        case 0: perksAndTraits->scrollUp();
+                            break;
+                        case 1: karma->scrollUp();
+                            break;
+                        case 2: killEnemyNames->scrollUp(); killEnemyScore->scrollUp();
+                            break;
+                    }
+                });
+                addUI(std::move(tabsArrowUp));
+            }
 
-            auto tabsArrowDown = imageButtonFactory->getByType(ImageButtonType::SMALL_DOWN_ARROW, {backgroundX + 317, backgroundY + 376});
-            tabsArrowDown->mouseClickHandler().add([=](...) {
-                switch (tabs->currentImage()) {
-                case 0: perksAndTraits->scrollDown();
-                    break;
-                case 1: karma->scrollDown();
-                    break;
-                case 2: killEnemyNames->scrollDown(); killEnemyScore->scrollDown();
-                    break;
-                }
-            });
-            addUI(tabsArrowDown);
+            {
+                auto tabsArrowDown = imageButtonFactory->getByType(ImageButtonType::SMALL_DOWN_ARROW, {backgroundX + 317, backgroundY + 376});
+                tabsArrowDown->mouseClickHandler().add([=](...) {
+                    switch (tabs->currentImage()) {
+                        case 0: perksAndTraits->scrollDown();
+                            break;
+                        case 1: karma->scrollDown();
+                            break;
+                        case 2: killEnemyNames->scrollDown(); killEnemyScore->scrollDown();
+                            break;
+                    }
+                });
+                addUI(std::move(tabsArrowDown));
+            }
         }
 
-        UI::TextArea* PlayerEdit::_addLabel(const std::string& name, UI::TextArea* label)
+        std::shared_ptr<UI::TextArea> PlayerEdit::_addLabel(std::string name, std::shared_ptr<UI::TextArea> label)
         {
-            _labels.insert(std::pair<std::string,UI::TextArea*>(name, label));
+            _labels.insert({ std::move(name), label });
             return label;
         }
 
-        UI::ImageButton* PlayerEdit::_addButton(const std::string& name, UI::ImageButton* button)
+        std::shared_ptr<UI::ImageButton> PlayerEdit::_addButton(std::string name, std::shared_ptr<UI::ImageButton> button)
         {
-            _buttons.insert(std::pair<std::string,UI::ImageButton*>(name, button));
+            _buttons.insert({ std::move(name), button });
             return button;
         }
 
-        UI::BigCounter* PlayerEdit::_addCounter(const std::string& name, UI::BigCounter* counter)
+        std::shared_ptr<UI::BigCounter> PlayerEdit::_addCounter(std::string name, std::shared_ptr<UI::BigCounter> counter)
         {
-            _counters.insert(std::pair<std::string,UI::BigCounter*>(name, counter));
+            _counters.insert({ std::move(name), counter });
             return counter;
         }
 
-        UI::HiddenMask* PlayerEdit::_addMask(const std::string& name, UI::HiddenMask* mask)
+        std::shared_ptr<UI::HiddenMask> PlayerEdit::_addMask(std::string name, std::shared_ptr<UI::HiddenMask> mask)
         {
-            _masks.insert(std::pair<std::string,UI::HiddenMask*>(name, mask));
+            _masks.insert({ std::move(name), mask });
             return mask;
         }
 
         void PlayerEdit::_addTitle(const std::string& name, std::string title)
         {
-            _titles.insert(std::pair<std::string,std::string>(name, title));
+            _titles.insert({ name, std::move(title) });
         }
 
         void PlayerEdit::_addDescription(const std::string& name, std::string description)
         {
-            _descriptions.insert(std::pair<std::string,std::string>(name, description));
+            _descriptions.insert({ name, std::move(description) });
         }
 
-        void PlayerEdit::_addImage(const std::string& name, UI::Image* image)
+        void PlayerEdit::_addImage(const std::string& name, std::shared_ptr<UI::Image> image)
         {
-            _images.insert(std::pair<std::string, UI::Image*>(name, image));
+            _images.insert({ name, std::move(image) });
         }
 
         void PlayerEdit::think(const float &deltaTime)
@@ -534,7 +538,7 @@ namespace Falltergeist
 
             for(auto it = _buttons.begin(); it != _buttons.end(); ++it)
             {
-                if (it->second == sender)
+                if (it->second.get() == sender)
                 {
                     std::string name = it->first;
 
@@ -551,7 +555,7 @@ namespace Falltergeist
             {
                 std::string name = it->first;
         //        if (it->second.get() == event->target())
-                if (it->second == event->target())
+                if (it->second.get() == event->target())
                 {
                     // name.find("traits_") == 0 ||
                     if (name.find("stats_") == 0 || name.find("skills_") == 0 || name.find("health_") == 0 || name.find("params_") == 0 || name.find("label_") == 0 || name.find("level_") == 0 )
@@ -573,7 +577,7 @@ namespace Falltergeist
         {
             for(auto it = _masks.begin(); it != _masks.end(); ++it)
             {
-                if (it->second == event->target())
+                if (it->second.get() == event->target())
                 {
                     std::string name = it->first;
                     if (name.find("stats_") == 0)
@@ -592,7 +596,7 @@ namespace Falltergeist
          */
         void PlayerEdit::onTabClick(Event::Mouse* event)
         {
-            auto tabs = dynamic_cast<UI::ImageList*>(getUI("tabs"));
+            auto tabs = getUI<UI::ImageList>("tabs");
             unsigned int clickX = static_cast<unsigned>(event->position().x() - tabs->position().x());
 
             for (unsigned int i = 0, tabEnd = 0; i < 3; i++) {
@@ -600,7 +604,7 @@ namespace Falltergeist
                 // selected width = 120, unselected width = 100
                 tabEnd += (i == tabs->currentImage() ? 120 : 100);
 
-                auto tab = dynamic_cast<UI::TextArea*>(getUI("tab_" + std::to_string(i)));
+                auto tab = getUI<UI::TextArea>("tab_" + std::to_string(i));
                 const auto tabsY = tabs->position().y() + 7;
 
                 // Slightly raise the selected tab and lower the others

--- a/src/State/PlayerEdit.h
+++ b/src/State/PlayerEdit.h
@@ -47,25 +47,25 @@ namespace Falltergeist
                 void onKeyDown(Event::Keyboard* event) override;
 
             protected:
-                UI::TextArea* _selectedLabel = nullptr;
-                UI::TextArea* _title = nullptr;
-                UI::TextArea* _description = nullptr;
-                UI::Image* _selectedImage = nullptr;
-                std::map<std::string, UI::TextArea*> _labels;
-                std::map<std::string, UI::BigCounter*> _counters;
-                std::map<std::string, UI::ImageButton*> _buttons;
-                std::map<std::string, UI::HiddenMask*> _masks;
+                std::shared_ptr<UI::TextArea> _selectedLabel = nullptr;
+                std::shared_ptr<UI::TextArea> _title = nullptr;
+                std::shared_ptr<UI::TextArea> _description = nullptr;
+                std::shared_ptr<UI::Image> _selectedImage = nullptr;
+                std::map<std::string, std::shared_ptr<UI::TextArea>> _labels;
+                std::map<std::string, std::shared_ptr<UI::BigCounter>> _counters;
+                std::map<std::string, std::shared_ptr<UI::ImageButton>> _buttons;
+                std::map<std::string, std::shared_ptr<UI::HiddenMask>> _masks;
                 std::map<std::string, std::string> _titles;
                 std::map<std::string, std::string> _descriptions;
-                std::map<std::string, UI::Image*> _images;
+                std::map<std::string, std::shared_ptr<UI::Image>> _images;
 
-                UI::TextArea* _addLabel(const std::string& name, UI::TextArea* label);
-                UI::ImageButton* _addButton(const std::string& name, UI::ImageButton* button);
-                UI::BigCounter* _addCounter(const std::string& name, UI::BigCounter* counter);
-                UI::HiddenMask* _addMask(const std::string& name, UI::HiddenMask* mask);
+                std::shared_ptr<UI::TextArea> _addLabel(std::string name, std::shared_ptr<UI::TextArea> label);
+                std::shared_ptr<UI::ImageButton> _addButton(std::string name, std::shared_ptr<UI::ImageButton> button);
+                std::shared_ptr<UI::BigCounter> _addCounter(std::string name, std::shared_ptr<UI::BigCounter> counter);
+                std::shared_ptr<UI::HiddenMask> _addMask(std::string name, std::shared_ptr<UI::HiddenMask> mask);
                 void _addTitle(const std::string& name, std::string title);
                 void _addDescription(const std::string& name, std::string description);
-                void _addImage(const std::string& name, UI::Image* image);
+                void _addImage(const std::string& name, std::shared_ptr<UI::Image> image);
 
                 bool _statIncrease(unsigned int num);
                 bool _statDecrease(unsigned int num);

--- a/src/State/PlayerEditAge.cpp
+++ b/src/State/PlayerEditAge.cpp
@@ -16,58 +16,62 @@ namespace Falltergeist
 
     namespace State
     {
-        PlayerEditAge::PlayerEditAge(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PlayerEditAge::PlayerEditAge(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager(std::move(_resourceManager)),
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void PlayerEditAge::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
             State::init();
 
             setFullscreen(false);
             setModal(true);
 
-            Point backgroundPos = Point((Game::getInstance()->renderer()->size() - Point(640, 480)) / 2);
-            int backgroundX = backgroundPos.x();
-            int backgroundY = backgroundPos.y();
+            Point bgPos = Point((Game::getInstance()->renderer()->size() - Point(640, 480)) / 2);
 
-            auto bg = resourceManager->getImage("art/intrface/charwin.frm");
-            bg->setPosition(backgroundPos + Point(160, 0));
+            {
+                auto& bg = *addUI(resourceManager->getImage("art/intrface/charwin.frm"));
+                bg.setPosition(bgPos.add(160, 0));
+            }
 
-            auto ageBox = resourceManager->getImage("art/intrface/agebox.frm");
-            ageBox->setPosition(backgroundPos + Point(168, 10));
+            {
+                auto& ageBox = *addUI(resourceManager->getImage("art/intrface/agebox.frm"));
+                ageBox.setPosition(bgPos.add(168, 10));
+            }
 
-            auto doneBox = resourceManager->getImage("art/intrface/donebox.frm");
-            doneBox->setPosition(backgroundPos + Point(175, 40));
+            {
+                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                doneBox.setPosition(bgPos.add(175, 40));
+            }
 
-            auto decButton = imageButtonFactory->getByType(ImageButtonType::LEFT_ARROW, {backgroundX + 178, backgroundY + 14});
-            decButton->mouseClickHandler().add(std::bind(&PlayerEditAge::onDecButtonClick, this, std::placeholders::_1));
+            {
+                auto& decButton = *addUI(imageButtonFactory->getByType(ImageButtonType::LEFT_ARROW, bgPos.add(178, 14)));
+                decButton.mouseClickHandler().add(std::bind(&PlayerEditAge::onDecButtonClick, this, std::placeholders::_1));
+            }
 
-            auto incButton = imageButtonFactory->getByType(ImageButtonType::RIGHT_ARROW, {backgroundX + 262, backgroundY + 14});
-            incButton->mouseClickHandler().add(std::bind(&PlayerEditAge::onIncButtonClick, this, std::placeholders::_1));
+            {
+                auto& incButton = *addUI(imageButtonFactory->getByType(ImageButtonType::RIGHT_ARROW, bgPos.add(262, 14)));
+                incButton.mouseClickHandler().add(std::bind(&PlayerEditAge::onIncButtonClick, this, std::placeholders::_1));
+            }
 
-            auto doneButton= imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 188, backgroundY + 43});
-            doneButton->mouseClickHandler().add(std::bind(&PlayerEditAge::onDoneButtonClick, this, std::placeholders::_1));
+            {
+                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(188, 43)));
+                doneButton.mouseClickHandler().add(std::bind(&PlayerEditAge::onDoneButtonClick, this, std::placeholders::_1));
+            }
 
-            auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), backgroundX+210, backgroundY+43);
+            {
+                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgPos.add(210, 43));
+                doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
+            }
 
-            doneLabel->setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
-
-            _counter = new UI::BigCounter({backgroundX + 215, backgroundY + 13});
+            _counter = makeUI<UI::BigCounter>(bgPos.add(215, 13));
             _counter->setNumber(Game::getInstance()->player()->age());
-
-            addUI(bg);
-            addUI(ageBox);
-            addUI(doneBox);
-            addUI(std::move(incButton));
-            addUI(std::move(decButton));
-            addUI(doneLabel);
-            addUI(std::move(doneButton));
-            addUI(_counter);
-
         }
 
         void PlayerEditAge::onDecButtonClick(Event::Mouse* event)

--- a/src/State/PlayerEditAge.cpp
+++ b/src/State/PlayerEditAge.cpp
@@ -62,10 +62,10 @@ namespace Falltergeist
             addUI(bg);
             addUI(ageBox);
             addUI(doneBox);
-            addUI(incButton);
-            addUI(decButton);
+            addUI(std::move(incButton));
+            addUI(std::move(decButton));
             addUI(doneLabel);
-            addUI(doneButton);
+            addUI(std::move(doneButton));
             addUI(_counter);
 
         }

--- a/src/State/PlayerEditAge.cpp
+++ b/src/State/PlayerEditAge.cpp
@@ -36,41 +36,41 @@ namespace Falltergeist
             Point bgPos = Point((Game::getInstance()->renderer()->size() - Point(640, 480)) / 2);
 
             {
-                auto& bg = *addUI(resourceManager->getImage("art/intrface/charwin.frm"));
+                auto& bg = *addSharedUI(resourceManager->getImage("art/intrface/charwin.frm"));
                 bg.setPosition(bgPos.add(160, 0));
             }
 
             {
-                auto& ageBox = *addUI(resourceManager->getImage("art/intrface/agebox.frm"));
+                auto& ageBox = *addSharedUI(resourceManager->getImage("art/intrface/agebox.frm"));
                 ageBox.setPosition(bgPos.add(168, 10));
             }
 
             {
-                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                auto& doneBox = *addSharedUI(resourceManager->getImage("art/intrface/donebox.frm"));
                 doneBox.setPosition(bgPos.add(175, 40));
             }
 
             {
-                auto& decButton = *addUI(imageButtonFactory->getByType(ImageButtonType::LEFT_ARROW, bgPos.add(178, 14)));
+                auto& decButton = addUI(imageButtonFactory->getByType(ImageButtonType::LEFT_ARROW, bgPos.add(178, 14)));
                 decButton.mouseClickHandler().add(std::bind(&PlayerEditAge::onDecButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto& incButton = *addUI(imageButtonFactory->getByType(ImageButtonType::RIGHT_ARROW, bgPos.add(262, 14)));
+                auto& incButton = addUI(imageButtonFactory->getByType(ImageButtonType::RIGHT_ARROW, bgPos.add(262, 14)));
                 incButton.mouseClickHandler().add(std::bind(&PlayerEditAge::onIncButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(188, 43)));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, bgPos.add(188, 43)));
                 doneButton.mouseClickHandler().add(std::bind(&PlayerEditAge::onDoneButtonClick, this, std::placeholders::_1));
             }
 
             {
-                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgPos.add(210, 43));
+                auto& doneLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgPos.add(210, 43));
                 doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
             }
 
-            _counter = makeUI<UI::BigCounter>(bgPos.add(215, 13));
+            _counter = makeSharedUI<UI::BigCounter>(bgPos.add(215, 13));
             _counter->setNumber(Game::getInstance()->player()->age());
         }
 

--- a/src/State/PlayerEditAge.h
+++ b/src/State/PlayerEditAge.h
@@ -33,7 +33,7 @@ namespace Falltergeist
                 void onKeyDown(Event::Keyboard* event) override;
 
             protected:
-                UI::BigCounter* _counter = nullptr;
+                std::shared_ptr<UI::BigCounter> _counter = nullptr;
 
             private:
                 std::shared_ptr<UI::IResourceManager> resourceManager;

--- a/src/State/PlayerEditAlert.cpp
+++ b/src/State/PlayerEditAlert.cpp
@@ -14,10 +14,11 @@ namespace Falltergeist
 
     namespace State
     {
-        PlayerEditAlert::PlayerEditAlert(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PlayerEditAlert::PlayerEditAlert(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void PlayerEditAlert::setMessage(const std::string& message)
@@ -42,29 +43,29 @@ namespace Falltergeist
             int bgY = bgPos.y();
 
             bg->setPosition(bgPos.add(164, 173));
-            addUI(bg);
+            addSharedUI(bg);
 
             {
-                auto& message = *makeUI<UI::TextArea>(_message.c_str(), bgPos.add(194, 213));
+                auto& message = makeUI<UI::TextArea>(_message.c_str(), bgPos.add(194, 213));
                 message.setWidth(250);
                 message.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
                 message.setFont("font1.aaf", {0xff, 0x9f, 0x48, 0xff});
             }
 
             {
-                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                auto& doneBox = *addSharedUI(resourceManager->getImage("art/intrface/donebox.frm"));
                 doneBox.setPosition(bgPos + Point(254, 270));
             }
 
             {
-                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 264, bgY + 273}));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 264, bgY + 273}));
                 doneButton.mouseClickHandler().add([this](Event::Mouse* event) {
                                                         this->onDoneButtonClick(event);
                                                     });
             }
 
             {
-                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX + 284, bgY + 273);
+                auto& doneLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX + 284, bgY + 273);
                 doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
             }
         }

--- a/src/State/PlayerEditAlert.cpp
+++ b/src/State/PlayerEditAlert.cpp
@@ -27,7 +27,9 @@ namespace Falltergeist
 
         void PlayerEditAlert::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
             State::init();
 
             setFullscreen(false);
@@ -39,31 +41,32 @@ namespace Falltergeist
             int bgX = bgPos.x();
             int bgY = bgPos.y();
 
-            bg->setPosition(bgPos + Point(164, 173));
-
-
-            auto message = new UI::TextArea(_message.c_str(), bgPos + Point(194, 213));
-            message->setWidth(250);
-            message->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
-            message->setFont("font1.aaf", {0xff, 0x9f, 0x48, 0xff});
-
-            auto doneBox = resourceManager->getImage("art/intrface/donebox.frm");
-            doneBox->setPosition(bgPos + Point(254, 270));
-
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 264, bgY + 273});
-            doneButton->mouseClickHandler().add([this](Event::Mouse* event)
-            {
-                this->onDoneButtonClick(event);
-            });
-
-            auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), bgX + 284, bgY + 273);
-            doneLabel->setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
-
+            bg->setPosition(bgPos.add(164, 173));
             addUI(bg);
-            addUI(message);
-            addUI(doneBox);
-            addUI(std::move(doneButton));
-            addUI(doneLabel);
+
+            {
+                auto& message = *makeUI<UI::TextArea>(_message.c_str(), bgPos.add(194, 213));
+                message.setWidth(250);
+                message.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                message.setFont("font1.aaf", {0xff, 0x9f, 0x48, 0xff});
+            }
+
+            {
+                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                doneBox.setPosition(bgPos + Point(254, 270));
+            }
+
+            {
+                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 264, bgY + 273}));
+                doneButton.mouseClickHandler().add([this](Event::Mouse* event) {
+                                                        this->onDoneButtonClick(event);
+                                                    });
+            }
+
+            {
+                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX + 284, bgY + 273);
+                doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
+            }
         }
 
         void PlayerEditAlert::onDoneButtonClick(Event::Mouse* event)

--- a/src/State/PlayerEditAlert.cpp
+++ b/src/State/PlayerEditAlert.cpp
@@ -62,7 +62,7 @@ namespace Falltergeist
             addUI(bg);
             addUI(message);
             addUI(doneBox);
-            addUI(doneButton);
+            addUI(std::move(doneButton));
             addUI(doneLabel);
         }
 

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -16,15 +16,19 @@ namespace Falltergeist
 
     namespace State
     {
-        PlayerEditGender::PlayerEditGender(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PlayerEditGender::PlayerEditGender(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void PlayerEditGender::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
+
             State::init();
 
             setFullscreen(false);
@@ -34,36 +38,46 @@ namespace Falltergeist
             int bgX = bgPos.x();
             int bgY = bgPos.y();
 
-            auto bg = resourceManager->getImage("art/intrface/charwin.frm");
-            bg->setPosition(bgPos + Point(236, 0));
+            {
+                auto& bg = *addUI(resourceManager->getImage("art/intrface/charwin.frm"));
+                bg.setPosition(bgPos.add(236, 0));
+            }
 
-            _maleImage = new UI::ImageList({bgX + 260, bgY +2}, {
-                resourceManager->getImage("art/intrface/maleoff.frm"),
-                resourceManager->getImage("art/intrface/maleon.frm")
-            });
-            _maleImage->mouseClickHandler().add(std::bind(&PlayerEditGender::onMaleButtonPress, this, std::placeholders::_1));
+            {
+                _maleImage = makeUI<UI::ImageList>(
+                        bgPos.add(260, 2),
+                        std::vector<std::shared_ptr<UI::Image>> {
+                                resourceManager->getImage("art/intrface/maleoff.frm"),
+                                resourceManager->getImage("art/intrface/maleon.frm")
+                        });
+                _maleImage->mouseClickHandler().add(std::bind(&PlayerEditGender::onMaleButtonPress, this, std::placeholders::_1));
+            }
 
-            _femaleImage = new UI::ImageList({bgX + 310, bgY + 2}, {
-                resourceManager->getImage("art/intrface/femoff.frm"),
-                resourceManager->getImage("art/intrface/femon.frm")
-            });
-            _femaleImage->mouseClickHandler().add(std::bind(&PlayerEditGender::onFemaleButtonPress, this, std::placeholders::_1));
+            {
+                _femaleImage = makeUI<UI::ImageList>(
+                        bgPos.add(310, 2),
+                        std::vector<std::shared_ptr<UI::Image>>{
+                                resourceManager->getImage("art/intrface/femoff.frm"),
+                                resourceManager->getImage("art/intrface/femon.frm")
+                        });
+                _femaleImage->mouseClickHandler().add(std::bind(&PlayerEditGender::onFemaleButtonPress, this, std::placeholders::_1));
+            }
 
-            auto doneBox = resourceManager->getImage("art/intrface/donebox.frm");
-            doneBox->setPosition(bgPos + Point(250, 42));
+            {
+                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                doneBox.setPosition(bgPos.add(250, 42));
+            }
 
-            auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), bgX+281, bgY+45);
-            doneLabel->setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
+            {
+                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX+281, bgY+45);
+                doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
+            }
 
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 260, bgY + 45});
-            doneButton->mouseClickHandler().add(std::bind(&PlayerEditGender::onDoneButtonClick, this, std::placeholders::_1));
+            {
+                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 260, bgY + 45}));
+                doneButton.mouseClickHandler().add(std::bind(&PlayerEditGender::onDoneButtonClick, this, std::placeholders::_1));
+            }
 
-            addUI(bg);
-            addUI(doneBox);
-            addUI(std::move(doneButton));
-            addUI(doneLabel);
-            addUI(_maleImage);
-            addUI(_femaleImage);
             setGender(Game::getInstance()->player()->gender());
         }
 

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -39,12 +39,12 @@ namespace Falltergeist
             int bgY = bgPos.y();
 
             {
-                auto& bg = *addUI(resourceManager->getImage("art/intrface/charwin.frm"));
+                auto& bg = *addSharedUI(resourceManager->getImage("art/intrface/charwin.frm"));
                 bg.setPosition(bgPos.add(236, 0));
             }
 
             {
-                _maleImage = makeUI<UI::ImageList>(
+                _maleImage = makeSharedUI<UI::ImageList>(
                         bgPos.add(260, 2),
                         std::vector<std::shared_ptr<UI::Image>> {
                                 resourceManager->getImage("art/intrface/maleoff.frm"),
@@ -54,7 +54,7 @@ namespace Falltergeist
             }
 
             {
-                _femaleImage = makeUI<UI::ImageList>(
+                _femaleImage = makeSharedUI<UI::ImageList>(
                         bgPos.add(310, 2),
                         std::vector<std::shared_ptr<UI::Image>>{
                                 resourceManager->getImage("art/intrface/femoff.frm"),
@@ -64,17 +64,17 @@ namespace Falltergeist
             }
 
             {
-                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                auto& doneBox = *addSharedUI(resourceManager->getImage("art/intrface/donebox.frm"));
                 doneBox.setPosition(bgPos.add(250, 42));
             }
 
             {
-                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX+281, bgY+45);
+                auto& doneLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX+281, bgY+45);
                 doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
             }
 
             {
-                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 260, bgY + 45}));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 260, bgY + 45}));
                 doneButton.mouseClickHandler().add(std::bind(&PlayerEditGender::onDoneButtonClick, this, std::placeholders::_1));
             }
 

--- a/src/State/PlayerEditGender.cpp
+++ b/src/State/PlayerEditGender.cpp
@@ -60,7 +60,7 @@ namespace Falltergeist
 
             addUI(bg);
             addUI(doneBox);
-            addUI(doneButton);
+            addUI(std::move(doneButton));
             addUI(doneLabel);
             addUI(_maleImage);
             addUI(_femaleImage);

--- a/src/State/PlayerEditGender.h
+++ b/src/State/PlayerEditGender.h
@@ -31,8 +31,8 @@ namespace Falltergeist
                 void setGender(GENDER gender);
 
             protected:
-                UI::ImageList* _maleImage = nullptr;
-                UI::ImageList* _femaleImage = nullptr;
+                std::shared_ptr<UI::ImageList> _maleImage = nullptr;
+                std::shared_ptr<UI::ImageList> _femaleImage = nullptr;
                 GENDER _gender = GENDER::MALE;
 
             private:

--- a/src/State/PlayerEditName.cpp
+++ b/src/State/PlayerEditName.cpp
@@ -17,15 +17,18 @@ namespace Falltergeist
 
     namespace State
     {
-        PlayerEditName::PlayerEditName(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        PlayerEditName::PlayerEditName(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void PlayerEditName::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
             State::init();
 
             setFullscreen(false);
@@ -72,33 +75,35 @@ namespace Falltergeist
             _keyCodes.insert(std::make_pair(SDLK_9, '9'));
             _keyCodes.insert(std::make_pair(SDLK_0, '0'));
 
-            auto bg = resourceManager->getImage("art/intrface/charwin.frm");
-            bg->setPosition(bgPos + Point(22, 0));
+            {
+                auto& bg = *addUI(resourceManager->getImage("art/intrface/charwin.frm"));
+                bg.setPosition(bgPos + Point(22, 0));
+            }
 
-            auto nameBox = resourceManager->getImage("art/intrface/namebox.frm");
-            nameBox->setPosition(bgPos + Point(35, 10));
+            {
+                auto& nameBox = *addUI(resourceManager->getImage("art/intrface/namebox.frm"));
+                nameBox.setPosition(bgPos + Point(35, 10));
+            }
 
-            auto doneBox = resourceManager->getImage("art/intrface/donebox.frm");
-            doneBox->setPosition(bgPos + Point(35, 40));
+            {
+                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                doneBox.setPosition(bgPos + Point(35, 40));
+            }
 
-            auto doneLabel = new UI::TextArea(_t(MSG_EDITOR, 100), bgX+65, bgY+43);
-            doneLabel->setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
+            {
+                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX+65, bgY+43);
+                doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
+            }
 
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 45, bgY + 43});
-            doneButton->mouseClickHandler().add(std::bind(&PlayerEditName::onDoneButtonClick, this, std::placeholders::_1));
+            {
+                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 45, bgY + 43}));
+                doneButton.mouseClickHandler().add(std::bind(&PlayerEditName::onDoneButtonClick, this, std::placeholders::_1));
+            }
 
-            _name = new UI::TextArea(Game::getInstance()->player()->name(), bgX+43, bgY+15);
+            _name = makeUI<UI::TextArea>(Game::getInstance()->player()->name(), bgX+43, bgY+15);
             _name->keyDownHandler().add([this](Event::Event* event){ this->onTextAreaKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
 
-            _cursor = new UI::Rectangle(bgPos + Point(83, 15) ,{5,8}, {0x3F, 0xF8, 0x00, 0xFF});
-
-            addUI(bg);
-            addUI(nameBox);
-            addUI(doneBox);
-            addUI(doneLabel);
-            addUI(std::move(doneButton));
-            addUI(_name);
-            addUI(_cursor);
+            _cursor = makeUI<UI::Rectangle>(bgPos + Point(83, 15) , UI::Size{5,8}, SDL_Color{0x3F, 0xF8, 0x00, 0xFF});
         }
 
         void PlayerEditName::onTextAreaKeyDown(Event::Keyboard* event)

--- a/src/State/PlayerEditName.cpp
+++ b/src/State/PlayerEditName.cpp
@@ -96,7 +96,7 @@ namespace Falltergeist
             addUI(nameBox);
             addUI(doneBox);
             addUI(doneLabel);
-            addUI(doneButton);
+            addUI(std::move(doneButton));
             addUI(_name);
             addUI(_cursor);
         }

--- a/src/State/PlayerEditName.cpp
+++ b/src/State/PlayerEditName.cpp
@@ -76,34 +76,34 @@ namespace Falltergeist
             _keyCodes.insert(std::make_pair(SDLK_0, '0'));
 
             {
-                auto& bg = *addUI(resourceManager->getImage("art/intrface/charwin.frm"));
+                auto& bg = *addSharedUI(resourceManager->getImage("art/intrface/charwin.frm"));
                 bg.setPosition(bgPos + Point(22, 0));
             }
 
             {
-                auto& nameBox = *addUI(resourceManager->getImage("art/intrface/namebox.frm"));
+                auto& nameBox = *addSharedUI(resourceManager->getImage("art/intrface/namebox.frm"));
                 nameBox.setPosition(bgPos + Point(35, 10));
             }
 
             {
-                auto& doneBox = *addUI(resourceManager->getImage("art/intrface/donebox.frm"));
+                auto& doneBox = *addSharedUI(resourceManager->getImage("art/intrface/donebox.frm"));
                 doneBox.setPosition(bgPos + Point(35, 40));
             }
 
             {
-                auto& doneLabel = *makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX+65, bgY+43);
+                auto& doneLabel = makeUI<UI::TextArea>(_t(MSG_EDITOR, 100), bgX+65, bgY+43);
                 doneLabel.setFont("font3.aaf", {0xb8, 0x9c, 0x28, 0xff});
             }
 
             {
-                auto& doneButton = *addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 45, bgY + 43}));
+                auto& doneButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 45, bgY + 43}));
                 doneButton.mouseClickHandler().add(std::bind(&PlayerEditName::onDoneButtonClick, this, std::placeholders::_1));
             }
 
-            _name = makeUI<UI::TextArea>(Game::getInstance()->player()->name(), bgX+43, bgY+15);
+            _name = makeSharedUI<UI::TextArea>(Game::getInstance()->player()->name(), bgX+43, bgY+15);
             _name->keyDownHandler().add([this](Event::Event* event){ this->onTextAreaKeyDown(dynamic_cast<Event::Keyboard*>(event)); });
 
-            _cursor = makeUI<UI::Rectangle>(bgPos + Point(83, 15) , UI::Size{5,8}, SDL_Color{0x3F, 0xF8, 0x00, 0xFF});
+            _cursor = makeSharedUI<UI::Rectangle>(bgPos + Point(83, 15) , UI::Size{5,8}, SDL_Color{0x3F, 0xF8, 0x00, 0xFF});
         }
 
         void PlayerEditName::onTextAreaKeyDown(Event::Keyboard* event)

--- a/src/State/PlayerEditName.h
+++ b/src/State/PlayerEditName.h
@@ -34,8 +34,8 @@ namespace Falltergeist
 
             protected:
                 float _blinkingCursorMillisecondsTracked = 0;
-                UI::TextArea* _name = nullptr;
-                UI::Rectangle* _cursor = nullptr;
+                std::shared_ptr<UI::TextArea> _name = nullptr;
+                std::shared_ptr<UI::Rectangle> _cursor = nullptr;
                 std::map<char,char> _keyCodes;
 
             private:

--- a/src/State/SaveGame.cpp
+++ b/src/State/SaveGame.cpp
@@ -42,7 +42,7 @@ namespace Falltergeist
             int bgX = bgPos.x();
             int bgY = bgPos.y();
             bg->setPosition(bgPos);
-            addUI(bg);
+            addSharedUI(bg);
 
             // BUTTONS
 
@@ -67,20 +67,20 @@ namespace Falltergeist
 
             // SAVE GAME LABEL
             {
-                auto saveGameLabel = makeUI<UI::TextArea>(_t(MSG_LOAD_SAVE, 109), bgX+48, bgY+27);
-                saveGameLabel->setFont(font3_907824ff, color);
+                auto& saveGameLabel = makeUI<UI::TextArea>(_t(MSG_LOAD_SAVE, 109), bgX+48, bgY+27);
+                saveGameLabel.setFont(font3_907824ff, color);
             }
 
             // DONE BUTTON LABEL
             {
-                auto doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 300), bgX+410, bgY+348);
-                doneButtonLabel->setFont(font3_907824ff, color);
+                auto& doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 300), bgX+410, bgY+348);
+                doneButtonLabel.setFont(font3_907824ff, color);
             }
 
             // CANCEL BUTTON LABEL
             {
-                auto cancelButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 121), bgX+515, bgY+348);
-                cancelButtonLabel->setFont(font3_907824ff, color);
+                auto& cancelButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 121), bgX+515, bgY+348);
+                cancelButtonLabel.setFont(font3_907824ff, color);
             }
         }
 

--- a/src/State/SaveGame.cpp
+++ b/src/State/SaveGame.cpp
@@ -18,10 +18,11 @@ namespace Falltergeist
 
     namespace State
     {
-        SaveGame::SaveGame(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        SaveGame::SaveGame(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void SaveGame::init()
@@ -65,19 +66,22 @@ namespace Falltergeist
             SDL_Color color = {0x90, 0x78, 0x24, 0xff};
 
             // SAVE GAME LABEL
-            auto saveGameLabel = new UI::TextArea(_t(MSG_LOAD_SAVE, 109), bgX+48, bgY+27);
-            saveGameLabel->setFont(font3_907824ff, color);
-            addUI(saveGameLabel);
+            {
+                auto saveGameLabel = makeUI<UI::TextArea>(_t(MSG_LOAD_SAVE, 109), bgX+48, bgY+27);
+                saveGameLabel->setFont(font3_907824ff, color);
+            }
 
             // DONE BUTTON LABEL
-            auto doneButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 300), bgX+410, bgY+348);
-            doneButtonLabel->setFont(font3_907824ff, color);
-            addUI(doneButtonLabel);
+            {
+                auto doneButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 300), bgX+410, bgY+348);
+                doneButtonLabel->setFont(font3_907824ff, color);
+            }
 
             // CANCEL BUTTON LABEL
-            auto cancelButtonLabel = new UI::TextArea(_t(MSG_OPTIONS, 121), bgX+515, bgY+348);
-            cancelButtonLabel->setFont(font3_907824ff, color);
-            addUI(cancelButtonLabel);
+            {
+                auto cancelButtonLabel = makeUI<UI::TextArea>(_t(MSG_OPTIONS, 121), bgX+515, bgY+348);
+                cancelButtonLabel->setFont(font3_907824ff, color);
+            }
         }
 
         void SaveGame::onDoneButtonClick(Event::Mouse* event)

--- a/src/State/SaveGame.cpp
+++ b/src/State/SaveGame.cpp
@@ -53,12 +53,12 @@ namespace Falltergeist
             // button: Done
             auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 391, bgY + 349});
             doneButton->mouseClickHandler().add(std::bind(&SaveGame::onDoneButtonClick, this, std::placeholders::_1));
-            addUI(doneButton);
+            addUI(std::move(doneButton));
 
             // button: Cancel
             auto cancelButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {bgX + 495, bgY + 349});
             cancelButton->mouseClickHandler().add(std::bind(&SaveGame::onCancelButtonClick, this, std::placeholders::_1));
-            addUI(cancelButton);
+            addUI(std::move(cancelButton));
 
             // LABELS
             std::string font3_907824ff = "font3.aaf";

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -1,4 +1,5 @@
 #include "../State/SettingsMenu.h"
+
 #include "../Audio/Mixer.h"
 #include "../functions.h"
 #include "../Game/Game.h"
@@ -19,10 +20,11 @@ namespace Falltergeist
 
     namespace State
     {
-        SettingsMenu::SettingsMenu(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        SettingsMenu::SettingsMenu(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void SettingsMenu::init()
@@ -81,48 +83,62 @@ namespace Falltergeist
             }
 
             {
-                auto combatLooksSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 387});
+                auto combatLooksSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "combat_looks",
+                        UI::MultistateImageButton::Type::BIG_SWITCH,
+                        Point{backgroundX + 76, backgroundY + 387});
                 combatLooksSwitch->setMaxState(2);
                 combatLooksSwitch->setState(settings->combatLooks());
-                addUI("combat_looks", combatLooksSwitch);
             }
 
             // Switches (small)
 
             {
-                auto combatMessagesSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74});
+                auto combatMessagesSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "combat_messages",
+                        UI::MultistateImageButton::Type::SMALL_SWITCH,
+                        Point{backgroundX + 299, backgroundY + 74});
                 combatMessagesSwitch->setState(settings->combatMessages());
-                addUI("combat_messages", combatMessagesSwitch);
             }
 
             {
-                auto combatTauntsSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66});
+                auto combatTauntsSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "combat_taunts",
+                        UI::MultistateImageButton::Type::SMALL_SWITCH,
+                        Point{backgroundX + 299, backgroundY + 74 + 66});
                 combatTauntsSwitch->setState(settings->combatTaunts());
-                addUI("combat_taunts", combatTauntsSwitch);
             }
 
             {
-                auto languageFilterSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX+299, backgroundY + 74 + 66 * 2});
+                auto languageFilterSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "language_filter",
+                        UI::MultistateImageButton::Type::SMALL_SWITCH,
+                        Point{backgroundX+299, backgroundY + 74 + 66 * 2});
                 languageFilterSwitch->setState(settings->languageFilter());
-                addUI("language_filter", languageFilterSwitch);
             }
 
             {
-                auto runningSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 3});
+                auto runningSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "running",
+                        UI::MultistateImageButton::Type::SMALL_SWITCH,
+                        Point{backgroundX + 299, backgroundY + 74 + 66 * 3});
                 runningSwitch->setState(settings->running());
-                addUI("running", runningSwitch);
             }
 
             {
-                auto subtitlesSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 4});
+                auto subtitlesSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "subtitles",
+                        UI::MultistateImageButton::Type::SMALL_SWITCH,
+                        Point{backgroundX + 299, backgroundY + 74 + 66 * 4});
                 subtitlesSwitch->setState(settings->subtitles());
-                addUI("subtitles", subtitlesSwitch);
             }
 
             {
-                auto itemHightlightSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 5});
+                auto itemHightlightSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "item_highlight",
+                        UI::MultistateImageButton::Type::SMALL_SWITCH,
+                        Point{backgroundX + 299, backgroundY + 74 + 66 * 5});
                 itemHightlightSwitch->setState(settings->itemHighlight());
-                addUI("item_highlight", itemHightlightSwitch);
             }
 
             // LABELS
@@ -350,7 +366,8 @@ namespace Falltergeist
             // SLIDERS
             // COMBAT SPEED SLIDER
             {
-                auto combatSpeedSlider = new UI::Slider(
+                auto combatSpeedSlider = makeNamedUI<UI::Slider>(
+                        "combat_speed",
                         backgroundPos.add(384, 50),
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
@@ -358,36 +375,36 @@ namespace Falltergeist
                 combatSpeedSlider->setMinValue(0.0);
                 combatSpeedSlider->setMaxValue(50.0);
                 combatSpeedSlider->setValue(settings->combatSpeed());
-                addUI("combat_speed", combatSpeedSlider);
             }
 
 
             // TEXT DELAY SLIDER
             {
-                auto textDelaySlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 125},
+                auto textDelaySlider = makeNamedUI<UI::Slider>(
+                        "text_delay",
+                        Point{backgroundX + 384, backgroundY + 125},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
                 textDelaySlider->setValue(settings->textDelay());
-                addUI("text_delay", textDelaySlider);
             }
 
             // MASTER AUDIO VOLUME SLIDER
             {
-                auto masterAudioVolumeSlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 196},
+                auto masterAudioVolumeSlider = makeNamedUI<UI::Slider>(
+                        "master_volume",
+                        Point{backgroundX + 384, backgroundY + 196},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
                 masterAudioVolumeSlider->setValue(settings->masterVolume());
-                addUI("master_volume", masterAudioVolumeSlider);
             }
 
             // MUSIC VOLUME SLIDER
             {
-                auto musicVolumeSlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 196 + 51},
+                auto musicVolumeSlider = makeNamedUI<UI::Slider>(
+                        "music_volume",
+                        Point{backgroundX + 384, backgroundY + 196 + 51},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
@@ -395,51 +412,50 @@ namespace Falltergeist
                 musicVolumeSlider->changeHandler().add([=](Event::Event* evt) {
                     Game::getInstance()->mixer()->setMusicVolume(musicVolumeSlider->value());
                 });
-                addUI("music_volume", musicVolumeSlider);
             }
 
             // SOUND EFFECTS VOLUME SLIDER
             {
-                auto soundEffectsVolumeSlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 196 + 51 * 2},
+                auto soundEffectsVolumeSlider = makeNamedUI<UI::Slider>(
+                        "sfx_volume",
+                        Point{backgroundX + 384, backgroundY + 196 + 51 * 2},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
                 soundEffectsVolumeSlider->setValue(settings->sfxVolume());
-                addUI("sfx_volume", soundEffectsVolumeSlider);
             }
 
             // SPEECH VOLUME SLIDER
             {
-                auto speechVolumeSlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 196 + 51 * 3},
+                auto speechVolumeSlider = makeNamedUI<UI::Slider>(
+                        "voice_volume",
+                        Point{backgroundX + 384, backgroundY + 196 + 51 * 3},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
                 speechVolumeSlider->setValue(settings->voiceVolume());
-                addUI("voice_volume", speechVolumeSlider);
             }
 
             // BRIGHTNESS LEVEL SLIDER
             {
-                auto brightnessLevelSlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 196 + 51 * 4},
+                auto brightnessLevelSlider = makeNamedUI<UI::Slider>(
+                        "brightness",
+                        Point{backgroundX + 384, backgroundY + 196 + 51 * 4},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
                 brightnessLevelSlider->setValue(settings->brightness());
-                addUI("brightness", brightnessLevelSlider);
             }
 
             // MOUSE SENSITIVITY SLIDER
             {
-                auto mouseSensitivitySlider = new UI::Slider(
-                        {backgroundX + 384, backgroundY + 196 + 51 * 5},
+                auto mouseSensitivitySlider = makeNamedUI<UI::Slider>(
+                        "mouse_sensitivity",
+                        Point{backgroundX + 384, backgroundY + 196 + 51 * 5},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
                 mouseSensitivitySlider->setValue(settings->mouseSensitivity());
-                addUI("mouse_sensitivity",mouseSensitivitySlider);
             }
         }
 

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -44,54 +44,86 @@ namespace Falltergeist
             auto settings = Game::getInstance()->settings();
 
             // Switches (big)
-            auto combatDifficultySwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 149});
-            combatDifficultySwitch->setMaxState(3);
-            combatDifficultySwitch->setState(settings->combatDifficulty());
-            addUI("combat_difficulty",combatDifficultySwitch);
+            {
+                auto combatDifficultySwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "combat_difficulty",
+                        UI::MultistateImageButton::Type::BIG_SWITCH,
+                        backgroundPos.add(76, 149));
+                combatDifficultySwitch->setMaxState(3);
+                combatDifficultySwitch->setState(settings->combatDifficulty());
+            }
 
-            auto gameDifficultySwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 71});
-            gameDifficultySwitch->setMaxState(3);
-            gameDifficultySwitch->setState(settings->gameDifficulty());
-            addUI("game_difficulty",gameDifficultySwitch);
+            {
+                auto gameDifficultySwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "game_difficulty",
+                        UI::MultistateImageButton::Type::BIG_SWITCH,
+                        backgroundPos.add(76, 71));
+                gameDifficultySwitch->setMaxState(3);
+                gameDifficultySwitch->setState(settings->gameDifficulty());
+            }
 
-            auto violenceLevelSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 227});
-            violenceLevelSwitch->setState(settings->violenceLevel());
-            addUI("violence_level",violenceLevelSwitch);
+            {
+                auto violenceLevelSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "violence_level",
+                        UI::MultistateImageButton::Type::BIG_SWITCH,
+                        backgroundPos.add(76, 227));
+                violenceLevelSwitch->setState(settings->violenceLevel());
+                addUI("violence_level", violenceLevelSwitch);
+            }
 
-            auto targetHighlightSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 309});
-            targetHighlightSwitch->setMaxState(3);
-            targetHighlightSwitch->setState(settings->targetHighlight());
-            addUI("target_highlight",targetHighlightSwitch);
+            {
+                auto targetHighlightSwitch = makeNamedUI<UI::MultistateImageButton>(
+                        "target_highlight",
+                        UI::MultistateImageButton::Type::BIG_SWITCH,
+                        backgroundPos.add(76, 309));
+                targetHighlightSwitch->setMaxState(3);
+                targetHighlightSwitch->setState(settings->targetHighlight());
+            }
 
-            auto combatLooksSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 387});
-            combatLooksSwitch->setMaxState(2);
-            combatLooksSwitch->setState(settings->combatLooks());
-            addUI("combat_looks",combatLooksSwitch);
+            {
+                auto combatLooksSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::BIG_SWITCH, {backgroundX + 76, backgroundY + 387});
+                combatLooksSwitch->setMaxState(2);
+                combatLooksSwitch->setState(settings->combatLooks());
+                addUI("combat_looks", combatLooksSwitch);
+            }
 
             // Switches (small)
-            auto combatMessagesSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74});
-            combatMessagesSwitch->setState(settings->combatMessages());
-            addUI("combat_messages",combatMessagesSwitch);
 
-            auto combatTauntsSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66});
-            combatTauntsSwitch->setState(settings->combatTaunts());
-            addUI("combat_taunts",combatTauntsSwitch);
+            {
+                auto combatMessagesSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74});
+                combatMessagesSwitch->setState(settings->combatMessages());
+                addUI("combat_messages", combatMessagesSwitch);
+            }
 
-            auto languageFilterSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX+299, backgroundY + 74 + 66 * 2});
-            languageFilterSwitch->setState(settings->languageFilter());
-            addUI("language_filter",languageFilterSwitch);
+            {
+                auto combatTauntsSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66});
+                combatTauntsSwitch->setState(settings->combatTaunts());
+                addUI("combat_taunts", combatTauntsSwitch);
+            }
 
-            auto runningSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 3});
-            runningSwitch->setState(settings->running());
-            addUI("running",runningSwitch);
+            {
+                auto languageFilterSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX+299, backgroundY + 74 + 66 * 2});
+                languageFilterSwitch->setState(settings->languageFilter());
+                addUI("language_filter", languageFilterSwitch);
+            }
 
-            auto subtitlesSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 4});
-            subtitlesSwitch->setState(settings->subtitles());
-            addUI("subtitles",subtitlesSwitch);
+            {
+                auto runningSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 3});
+                runningSwitch->setState(settings->running());
+                addUI("running", runningSwitch);
+            }
 
-            auto itemHightlightSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 5});
-            itemHightlightSwitch->setState(settings->itemHighlight());
-            addUI("item_highlight",itemHightlightSwitch);
+            {
+                auto subtitlesSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 4});
+                subtitlesSwitch->setState(settings->subtitles());
+                addUI("subtitles", subtitlesSwitch);
+            }
+
+            {
+                auto itemHightlightSwitch = new UI::MultistateImageButton(UI::MultistateImageButton::Type::SMALL_SWITCH, {backgroundX + 299, backgroundY + 74 + 66 * 5});
+                itemHightlightSwitch->setState(settings->itemHighlight());
+                addUI("item_highlight", itemHightlightSwitch);
+            }
 
             // LABELS
             SDL_Color color = {0x90, 0x78, 0x24, 0xff};
@@ -288,103 +320,127 @@ namespace Falltergeist
             // BUTTONS
 
             // button: Default
-            auto defaultButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 23, backgroundY + 450});
-            defaultButton->mouseClickHandler().add(std::bind(&SettingsMenu::onDefaultButtonClick, this, std::placeholders::_1));
-            addUI(defaultButton);
+            {
+                auto defaultButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 23, backgroundY + 450});
+                defaultButton->mouseClickHandler().add(std::bind(&SettingsMenu::onDefaultButtonClick, this, std::placeholders::_1));
+                addUI(std::move(defaultButton));
+            }
 
             // button: Done
-            auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 148, backgroundY + 450});
-            doneButton->mouseClickHandler().add([this](Event::Event* event){ this->doSave(); });
-            addUI(doneButton);
+            {
+                auto doneButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 148, backgroundY + 450});
+                doneButton->mouseClickHandler().add([this](Event::Event* event){ this->doSave(); });
+                addUI(std::move(doneButton));
+            }
 
             // button: Cancel
-            auto cancelButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 263, backgroundY + 450});
-            cancelButton->mouseClickHandler().add([this](Event::Event* event){ this->doCancel(); });
-            addUI(cancelButton);
+            {
+                auto cancelButton = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 263, backgroundY + 450});
+                cancelButton->mouseClickHandler().add([this](Event::Event* event){ this->doCancel(); });
+                addUI(std::move(cancelButton));
+            }
 
             // button: Affect player speed
-            auto affectPlayerSpeedCheckBox = imageButtonFactory->getByType(ImageButtonType::CHECKBOX, {backgroundX + 383, backgroundY + 68});
-            affectPlayerSpeedCheckBox->setChecked(settings->playerSpeedup());
-            addUI("player_speedup", affectPlayerSpeedCheckBox);
+            {
+                auto affectPlayerSpeedCheckBox = imageButtonFactory->getByType(ImageButtonType::CHECKBOX, {backgroundX + 383, backgroundY + 68});
+                affectPlayerSpeedCheckBox->setChecked(settings->playerSpeedup());
+                addUI("player_speedup", std::move(affectPlayerSpeedCheckBox));
+            }
 
             // SLIDERS
             // COMBAT SPEED SLIDER
-            auto combatSpeedSlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 50},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            combatSpeedSlider->setMinValue(0.0);
-            combatSpeedSlider->setMaxValue(50.0);
-            combatSpeedSlider->setValue(settings->combatSpeed());
-            addUI("combat_speed",combatSpeedSlider);
+            {
+                auto combatSpeedSlider = new UI::Slider(
+                        backgroundPos.add(384, 50),
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                combatSpeedSlider->setMinValue(0.0);
+                combatSpeedSlider->setMaxValue(50.0);
+                combatSpeedSlider->setValue(settings->combatSpeed());
+                addUI("combat_speed", combatSpeedSlider);
+            }
+
 
             // TEXT DELAY SLIDER
-            auto textDelaySlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 125},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            textDelaySlider->setValue(settings->textDelay());
-            addUI("text_delay",textDelaySlider);
+            {
+                auto textDelaySlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 125},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                textDelaySlider->setValue(settings->textDelay());
+                addUI("text_delay", textDelaySlider);
+            }
 
             // MASTER AUDIO VOLUME SLIDER
-            auto masterAudioVolumeSlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 196},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            masterAudioVolumeSlider->setValue(settings->masterVolume());
-            addUI("master_volume", masterAudioVolumeSlider);
+            {
+                auto masterAudioVolumeSlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 196},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                masterAudioVolumeSlider->setValue(settings->masterVolume());
+                addUI("master_volume", masterAudioVolumeSlider);
+            }
 
             // MUSIC VOLUME SLIDER
-            auto musicVolumeSlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 196 + 51},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            musicVolumeSlider->setValue(settings->musicVolume());
-            addUI("music_volume", musicVolumeSlider);
-            musicVolumeSlider->changeHandler().add([=](Event::Event* evt)
             {
-                Game::getInstance()->mixer()->setMusicVolume(musicVolumeSlider->value());
-            });
+                auto musicVolumeSlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 196 + 51},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                musicVolumeSlider->setValue(settings->musicVolume());
+                musicVolumeSlider->changeHandler().add([=](Event::Event* evt) {
+                    Game::getInstance()->mixer()->setMusicVolume(musicVolumeSlider->value());
+                });
+                addUI("music_volume", musicVolumeSlider);
+            }
 
             // SOUND EFFECTS VOLUME SLIDER
-            auto soundEffectsVolumeSlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 196 + 51 * 2},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            soundEffectsVolumeSlider->setValue(settings->sfxVolume());
-            addUI("sfx_volume", soundEffectsVolumeSlider);
+            {
+                auto soundEffectsVolumeSlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 196 + 51 * 2},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                soundEffectsVolumeSlider->setValue(settings->sfxVolume());
+                addUI("sfx_volume", soundEffectsVolumeSlider);
+            }
 
             // SPEECH VOLUME SLIDER
-            auto speechVolumeSlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 196 + 51 * 3},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            speechVolumeSlider->setValue(settings->voiceVolume());
-            addUI("voice_volume", speechVolumeSlider);
+            {
+                auto speechVolumeSlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 196 + 51 * 3},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                speechVolumeSlider->setValue(settings->voiceVolume());
+                addUI("voice_volume", speechVolumeSlider);
+            }
 
             // BRIGHTNESS LEVEL SLIDER
-            auto brightnessLevelSlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 196 + 51 * 4},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            brightnessLevelSlider->setValue(settings->brightness());
-            addUI("brightness", brightnessLevelSlider);
+            {
+                auto brightnessLevelSlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 196 + 51 * 4},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                brightnessLevelSlider->setValue(settings->brightness());
+                addUI("brightness", brightnessLevelSlider);
+            }
 
             // MOUSE SENSITIVITY SLIDER
-            auto mouseSensitivitySlider = new UI::Slider(
-                {backgroundX + 384, backgroundY + 196 + 51 * 5},
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldon.frm")),
-                std::unique_ptr<UI::Image>(resourceManager->getImage("art/intrface/prfsldof.frm"))
-            );
-            mouseSensitivitySlider->setValue(settings->mouseSensitivity());
-            addUI("mouse_sensitivity",mouseSensitivitySlider);
+            {
+                auto mouseSensitivitySlider = new UI::Slider(
+                        {backgroundX + 384, backgroundY + 196 + 51 * 5},
+                        resourceManager->getImage("art/intrface/prfsldon.frm"),
+                        resourceManager->getImage("art/intrface/prfsldof.frm")
+                );
+                mouseSensitivitySlider->setValue(settings->mouseSensitivity());
+                addUI("mouse_sensitivity",mouseSensitivitySlider);
+            }
         }
 
         //IniFileSection SettingsMenu::_getSettings()
@@ -447,30 +503,29 @@ namespace Falltergeist
         void SettingsMenu::doSave()
         {
             auto settings = Game::getInstance()->settings();
-            // TODO: remove C-style casts
-            settings->setCombatDifficulty(((UI::MultistateImageButton*)getUI("combat_difficulty"))->state());
-            settings->setGameDifficulty(((UI::MultistateImageButton*)getUI("game_difficulty"))->state());
-            settings->setViolenceLevel(((UI::MultistateImageButton*)getUI("violence_level"))->state());
-            settings->setTargetHighlight(((UI::MultistateImageButton*)getUI("target_highlight"))->state());
-            settings->setCombatLooks(((UI::MultistateImageButton*)getUI("combat_looks"))->state());
-            settings->setCombatMessages(((UI::MultistateImageButton*)getUI("combat_messages"))->state());
-            settings->setCombatTaunts(((UI::MultistateImageButton*)getUI("combat_taunts"))->state());
-            settings->setLanguageFilter(((UI::MultistateImageButton*)getUI("language_filter"))->state());
-            settings->setRunning(((UI::MultistateImageButton*)getUI("running"))->state());
-            settings->setSubtitles(((UI::MultistateImageButton*)getUI("subtitles"))->state());
-            settings->setItemHighlight(((UI::MultistateImageButton*)getUI("item_highlight"))->state());
+            settings->setCombatDifficulty(getUI<UI::MultistateImageButton>("combat_difficulty")->state());
+            settings->setGameDifficulty(getUI<UI::MultistateImageButton>("game_difficulty")->state());
+            settings->setViolenceLevel(getUI<UI::MultistateImageButton>("violence_level")->state());
+            settings->setTargetHighlight(getUI<UI::MultistateImageButton>("target_highlight")->state());
+            settings->setCombatLooks(getUI<UI::MultistateImageButton>("combat_looks")->state());
+            settings->setCombatMessages(getUI<UI::MultistateImageButton>("combat_messages")->state());
+            settings->setCombatTaunts(getUI<UI::MultistateImageButton>("combat_taunts")->state());
+            settings->setLanguageFilter(getUI<UI::MultistateImageButton>("language_filter")->state());
+            settings->setRunning(getUI<UI::MultistateImageButton>("running")->state());
+            settings->setSubtitles(getUI<UI::MultistateImageButton>("subtitles")->state());
+            settings->setItemHighlight(getUI<UI::MultistateImageButton>("item_highlight")->state());
 
-            settings->setMasterVolume(((UI::Slider*)getUI("master_volume"))->value());
-            settings->setMusicVolume(((UI::Slider*)getUI("music_volume"))->value());
-            settings->setVoiceVolume(((UI::Slider*)getUI("voice_volume"))->value());
-            settings->setSfxVolume(((UI::Slider*)getUI("sfx_volume"))->value());
+            settings->setMasterVolume(getUI<UI::Slider>("master_volume")->value());
+            settings->setMusicVolume(getUI<UI::Slider>("music_volume")->value());
+            settings->setVoiceVolume(getUI<UI::Slider>("voice_volume")->value());
+            settings->setSfxVolume(getUI<UI::Slider>("sfx_volume")->value());
 
-            settings->setTextDelay(((UI::Slider*)getUI("text_delay"))->value());
-            settings->setCombatSpeed(static_cast<unsigned>(((UI::Slider*)getUI("combat_speed"))->value()));
-            settings->setBrightness(((UI::Slider*)getUI("brightness"))->value());
-            settings->setMouseSensitivity(((UI::Slider*)getUI("mouse_sensitivity"))->value());
+            settings->setTextDelay(getUI<UI::Slider>("text_delay")->value());
+            settings->setCombatSpeed(static_cast<unsigned>(getUI<UI::Slider>("combat_speed")->value()));
+            settings->setBrightness(getUI<UI::Slider>("brightness")->value());
+            settings->setMouseSensitivity(getUI<UI::Slider>("mouse_sensitivity")->value());
 
-            settings->setPlayerSpeedup(((UI::ImageButton*)getUI("player_speedup"))->checked());
+            settings->setPlayerSpeedup(getUI<UI::ImageButton>("player_speedup")->checked());
 
             settings->save();
             Game::getInstance()->popState();

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -47,98 +47,97 @@ namespace Falltergeist
 
             // Switches (big)
             {
-                auto combatDifficultySwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& combatDifficultySwitch = makeNamedUI<UI::MultistateImageButton>(
                         "combat_difficulty",
                         UI::MultistateImageButton::Type::BIG_SWITCH,
                         backgroundPos.add(76, 149));
-                combatDifficultySwitch->setMaxState(3);
-                combatDifficultySwitch->setState(settings->combatDifficulty());
+                combatDifficultySwitch.setMaxState(3);
+                combatDifficultySwitch.setState(settings->combatDifficulty());
             }
 
             {
-                auto gameDifficultySwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& gameDifficultySwitch = makeNamedUI<UI::MultistateImageButton>(
                         "game_difficulty",
                         UI::MultistateImageButton::Type::BIG_SWITCH,
                         backgroundPos.add(76, 71));
-                gameDifficultySwitch->setMaxState(3);
-                gameDifficultySwitch->setState(settings->gameDifficulty());
+                gameDifficultySwitch.setMaxState(3);
+                gameDifficultySwitch.setState(settings->gameDifficulty());
             }
 
             {
-                auto violenceLevelSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& violenceLevelSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "violence_level",
                         UI::MultistateImageButton::Type::BIG_SWITCH,
                         backgroundPos.add(76, 227));
-                violenceLevelSwitch->setState(settings->violenceLevel());
-                addUI("violence_level", violenceLevelSwitch);
+                violenceLevelSwitch.setState(settings->violenceLevel());
             }
 
             {
-                auto targetHighlightSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& targetHighlightSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "target_highlight",
                         UI::MultistateImageButton::Type::BIG_SWITCH,
                         backgroundPos.add(76, 309));
-                targetHighlightSwitch->setMaxState(3);
-                targetHighlightSwitch->setState(settings->targetHighlight());
+                targetHighlightSwitch.setMaxState(3);
+                targetHighlightSwitch.setState(settings->targetHighlight());
             }
 
             {
-                auto combatLooksSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& combatLooksSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "combat_looks",
                         UI::MultistateImageButton::Type::BIG_SWITCH,
                         Point{backgroundX + 76, backgroundY + 387});
-                combatLooksSwitch->setMaxState(2);
-                combatLooksSwitch->setState(settings->combatLooks());
+                combatLooksSwitch.setMaxState(2);
+                combatLooksSwitch.setState(settings->combatLooks());
             }
 
             // Switches (small)
 
             {
-                auto combatMessagesSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& combatMessagesSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "combat_messages",
                         UI::MultistateImageButton::Type::SMALL_SWITCH,
                         Point{backgroundX + 299, backgroundY + 74});
-                combatMessagesSwitch->setState(settings->combatMessages());
+                combatMessagesSwitch.setState(settings->combatMessages());
             }
 
             {
-                auto combatTauntsSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& combatTauntsSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "combat_taunts",
                         UI::MultistateImageButton::Type::SMALL_SWITCH,
                         Point{backgroundX + 299, backgroundY + 74 + 66});
-                combatTauntsSwitch->setState(settings->combatTaunts());
+                combatTauntsSwitch.setState(settings->combatTaunts());
             }
 
             {
-                auto languageFilterSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& languageFilterSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "language_filter",
                         UI::MultistateImageButton::Type::SMALL_SWITCH,
                         Point{backgroundX+299, backgroundY + 74 + 66 * 2});
-                languageFilterSwitch->setState(settings->languageFilter());
+                languageFilterSwitch.setState(settings->languageFilter());
             }
 
             {
-                auto runningSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& runningSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "running",
                         UI::MultistateImageButton::Type::SMALL_SWITCH,
                         Point{backgroundX + 299, backgroundY + 74 + 66 * 3});
-                runningSwitch->setState(settings->running());
+                runningSwitch.setState(settings->running());
             }
 
             {
-                auto subtitlesSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& subtitlesSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "subtitles",
                         UI::MultistateImageButton::Type::SMALL_SWITCH,
                         Point{backgroundX + 299, backgroundY + 74 + 66 * 4});
-                subtitlesSwitch->setState(settings->subtitles());
+                subtitlesSwitch.setState(settings->subtitles());
             }
 
             {
-                auto itemHightlightSwitch = makeNamedUI<UI::MultistateImageButton>(
+                auto& itemHightlightSwitch = makeNamedUI<UI::MultistateImageButton>(
                         "item_highlight",
                         UI::MultistateImageButton::Type::SMALL_SWITCH,
                         Point{backgroundX + 299, backgroundY + 74 + 66 * 5});
-                itemHightlightSwitch->setState(settings->itemHighlight());
+                itemHightlightSwitch.setState(settings->itemHighlight());
             }
 
             // LABELS
@@ -366,96 +365,96 @@ namespace Falltergeist
             // SLIDERS
             // COMBAT SPEED SLIDER
             {
-                auto combatSpeedSlider = makeNamedUI<UI::Slider>(
+                auto& combatSpeedSlider = makeNamedUI<UI::Slider>(
                         "combat_speed",
                         backgroundPos.add(384, 50),
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                combatSpeedSlider->setMinValue(0.0);
-                combatSpeedSlider->setMaxValue(50.0);
-                combatSpeedSlider->setValue(settings->combatSpeed());
+                combatSpeedSlider.setMinValue(0.0);
+                combatSpeedSlider.setMaxValue(50.0);
+                combatSpeedSlider.setValue(settings->combatSpeed());
             }
 
 
             // TEXT DELAY SLIDER
             {
-                auto textDelaySlider = makeNamedUI<UI::Slider>(
+                auto& textDelaySlider = makeNamedUI<UI::Slider>(
                         "text_delay",
                         Point{backgroundX + 384, backgroundY + 125},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                textDelaySlider->setValue(settings->textDelay());
+                textDelaySlider.setValue(settings->textDelay());
             }
 
             // MASTER AUDIO VOLUME SLIDER
             {
-                auto masterAudioVolumeSlider = makeNamedUI<UI::Slider>(
+                auto& masterAudioVolumeSlider = makeNamedUI<UI::Slider>(
                         "master_volume",
                         Point{backgroundX + 384, backgroundY + 196},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                masterAudioVolumeSlider->setValue(settings->masterVolume());
+                masterAudioVolumeSlider.setValue(settings->masterVolume());
             }
 
             // MUSIC VOLUME SLIDER
             {
-                auto musicVolumeSlider = makeNamedUI<UI::Slider>(
+                auto& musicVolumeSlider = makeNamedUI<UI::Slider>(
                         "music_volume",
                         Point{backgroundX + 384, backgroundY + 196 + 51},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                musicVolumeSlider->setValue(settings->musicVolume());
-                musicVolumeSlider->changeHandler().add([=](Event::Event* evt) {
-                    Game::getInstance()->mixer()->setMusicVolume(musicVolumeSlider->value());
+                musicVolumeSlider.setValue(settings->musicVolume());
+                musicVolumeSlider.changeHandler().add([&](Event::Event* evt) {
+                    Game::getInstance()->mixer()->setMusicVolume(musicVolumeSlider.value());
                 });
             }
 
             // SOUND EFFECTS VOLUME SLIDER
             {
-                auto soundEffectsVolumeSlider = makeNamedUI<UI::Slider>(
+                auto& soundEffectsVolumeSlider = makeNamedUI<UI::Slider>(
                         "sfx_volume",
                         Point{backgroundX + 384, backgroundY + 196 + 51 * 2},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                soundEffectsVolumeSlider->setValue(settings->sfxVolume());
+                soundEffectsVolumeSlider.setValue(settings->sfxVolume());
             }
 
             // SPEECH VOLUME SLIDER
             {
-                auto speechVolumeSlider = makeNamedUI<UI::Slider>(
+                auto& speechVolumeSlider = makeNamedUI<UI::Slider>(
                         "voice_volume",
                         Point{backgroundX + 384, backgroundY + 196 + 51 * 3},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                speechVolumeSlider->setValue(settings->voiceVolume());
+                speechVolumeSlider.setValue(settings->voiceVolume());
             }
 
             // BRIGHTNESS LEVEL SLIDER
             {
-                auto brightnessLevelSlider = makeNamedUI<UI::Slider>(
+                auto& brightnessLevelSlider = makeNamedUI<UI::Slider>(
                         "brightness",
                         Point{backgroundX + 384, backgroundY + 196 + 51 * 4},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                brightnessLevelSlider->setValue(settings->brightness());
+                brightnessLevelSlider.setValue(settings->brightness());
             }
 
             // MOUSE SENSITIVITY SLIDER
             {
-                auto mouseSensitivitySlider = makeNamedUI<UI::Slider>(
+                auto& mouseSensitivitySlider = makeNamedUI<UI::Slider>(
                         "mouse_sensitivity",
                         Point{backgroundX + 384, backgroundY + 196 + 51 * 5},
                         resourceManager->getImage("art/intrface/prfsldon.frm"),
                         resourceManager->getImage("art/intrface/prfsldof.frm")
                 );
-                mouseSensitivitySlider->setValue(settings->mouseSensitivity());
+                mouseSensitivitySlider.setValue(settings->mouseSensitivity());
             }
         }
 
@@ -498,16 +497,12 @@ namespace Falltergeist
 
         std::shared_ptr<UI::TextArea> SettingsMenu::_addTextArea(const std::string& message, unsigned int x, unsigned int y)
         {
-            auto textArea = makeUI<UI::TextArea>(message, x, y);
-            addUI(textArea);
-            return textArea;
+            return makeSharedUI<UI::TextArea>(message, x, y);
         }
 
         std::shared_ptr<UI::TextArea> SettingsMenu::_addTextArea(std::shared_ptr<UI::TextArea> parent, unsigned int x, unsigned int y)
         {
-            auto textArea = makeUI<UI::TextArea>(*parent, Point(x, y));
-            addUI(textArea);
-            return textArea;
+            return makeSharedUI<UI::TextArea>(*parent, Point(x, y));
         }
 
         void SettingsMenu::doCancel()

--- a/src/State/SettingsMenu.cpp
+++ b/src/State/SettingsMenu.cpp
@@ -490,22 +490,22 @@ namespace Falltergeist
         //    });
         //}
 
-        UI::TextArea* SettingsMenu::_addLabel(const std::string& name, UI::TextArea* label)
+        std::shared_ptr<UI::TextArea> SettingsMenu::_addLabel(const std::string& name, std::shared_ptr<UI::TextArea> label)
         {
             _labels.insert(std::make_pair(name, label));
             return label;
         }
 
-        UI::TextArea* SettingsMenu::_addTextArea(const std::string& message, unsigned int x, unsigned int y)
+        std::shared_ptr<UI::TextArea> SettingsMenu::_addTextArea(const std::string& message, unsigned int x, unsigned int y)
         {
-            auto textArea = new UI::TextArea(message, x, y);
+            auto textArea = makeUI<UI::TextArea>(message, x, y);
             addUI(textArea);
             return textArea;
         }
 
-        UI::TextArea* SettingsMenu::_addTextArea(UI::TextArea* parent, unsigned int x, unsigned int y)
+        std::shared_ptr<UI::TextArea> SettingsMenu::_addTextArea(std::shared_ptr<UI::TextArea> parent, unsigned int x, unsigned int y)
         {
-            auto textArea = new UI::TextArea(*parent, Point(x, y));
+            auto textArea = makeUI<UI::TextArea>(*parent, Point(x, y));
             addUI(textArea);
             return textArea;
         }

--- a/src/State/SettingsMenu.h
+++ b/src/State/SettingsMenu.h
@@ -39,10 +39,10 @@ namespace Falltergeist
                 void onStateDeactivate(Event::State* event) override;
 
             protected:
-                std::map<std::string, UI::TextArea*> _labels;
-                UI::TextArea* _addLabel(const std::string& name, UI::TextArea* label);
-                UI::TextArea* _addTextArea(const std::string& message, unsigned int x, unsigned int y);
-                UI::TextArea* _addTextArea(UI::TextArea* parent, unsigned int x, unsigned int y);
+                std::map<std::string, std::shared_ptr<UI::TextArea>> _labels;
+                std::shared_ptr<UI::TextArea> _addLabel(const std::string& name, std::shared_ptr<UI::TextArea> label);
+                std::shared_ptr<UI::TextArea> _addTextArea(const std::string& message, unsigned int x, unsigned int y);
+                std::shared_ptr<UI::TextArea> _addTextArea(std::shared_ptr<UI::TextArea> parent, unsigned int x, unsigned int y);
 
             private:
                 std::shared_ptr<UI::IResourceManager> resourceManager;

--- a/src/State/Skilldex.cpp
+++ b/src/State/Skilldex.cpp
@@ -22,15 +22,18 @@ namespace Falltergeist
 
     namespace State
     {
-        Skilldex::Skilldex(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        Skilldex::Skilldex(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)},
+            imageButtonFactory{std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager)}
         {
-            this->resourceManager = resourceManager;
-            imageButtonFactory = std::make_unique<UI::Factory::ImageButtonFactory>(resourceManager);
         }
 
         void Skilldex::init()
         {
-            if (_initialized) return;
+            if (_initialized) {
+                return;
+            }
             State::init();
 
             setModal(true);
@@ -43,151 +46,187 @@ namespace Falltergeist
             auto backgroundX = (rendSize.width() + 640 - 2 * background->size().width()) / 2;
             auto backgroundY = (rendSize.height() - 480 + 6);
             background->setPosition({backgroundX, backgroundY});
+            addUI(background);
 
             // buttons
-            auto sneakButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44});
-            sneakButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SNEAK));
+            {
+                auto sneakButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44});
+                sneakButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SNEAK));
+                addUI(std::move(sneakButton));
+            }
 
-            auto lockpickButton = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36});
-            lockpickButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::LOCKPICK));
+            {
+                auto lockpickButton = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36});
+                lockpickButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::LOCKPICK));
+                addUI(std::move(lockpickButton));
+            }
 
-            auto stealButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 2});
-            stealButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::STEAL));
+            {
+                auto stealButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 2});
+                stealButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::STEAL));
+                addUI(std::move(stealButton));
+            }
 
-            auto trapsButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 3});
-            trapsButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::TRAPS));
+            {
+                auto trapsButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 3});
+                trapsButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::TRAPS));
+                addUI(std::move(trapsButton));
+            }
 
-            auto firstAidButton = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 4});
-            firstAidButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::FIRST_AID));
+            {
+                auto firstAidButton = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 4});
+                firstAidButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::FIRST_AID));
+                addUI(std::move(firstAidButton));
+            }
 
-            auto doctorButton   = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 5});
-            doctorButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::DOCTOR));
+            {
+                auto doctorButton   = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 5});
+                doctorButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::DOCTOR));
+                addUI(std::move(doctorButton));
+            }
 
-            auto scienceButton  = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 6});
-            scienceButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SCIENCE));
+            {
+                auto scienceButton  = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 6});
+                scienceButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SCIENCE));
+                addUI(std::move(scienceButton));
+            }
 
-            auto repairButton   = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 7});
-            repairButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::REPAIR));
+            {
+                auto repairButton   = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 7});
+                repairButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::REPAIR));
+                addUI(std::move(repairButton));
+            }
 
-            auto cancelButton   = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 48, backgroundY + 338});
-            cancelButton->mouseClickHandler().add(std::bind(&Skilldex::onCancelButtonClick, this));
+            {
+                auto cancelButton   = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 48, backgroundY + 338});
+                cancelButton->mouseClickHandler().add(std::bind(&Skilldex::onCancelButtonClick, this));
+                addUI(std::move(cancelButton));
+            }
+
 
             // counters
-            auto sneakCounter    = new UI::BigCounter({backgroundX + 111, backgroundY + 48}, 3);
-            sneakCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::SNEAK));
+            {
+                auto sneakCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48}, 3);
+                sneakCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::SNEAK));
+            }
 
-            auto lockpickCounter = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36}, 3);
-            lockpickCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::LOCKPICK));
+            {
+                auto lockpickCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36}, 3);
+                lockpickCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::LOCKPICK));
+            }
 
-            auto stealCounter    = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36 * 2}, 3);
-            stealCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::STEAL));
+            {
+                auto stealCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 2}, 3);
+                stealCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::STEAL));
+            }
 
-            auto trapsCounter    = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36 * 3}, 3);
-            trapsCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::TRAPS));
+            {
+                auto trapsCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 3}, 3);
+                trapsCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::TRAPS));
+            }
 
-            auto firstAidCounter = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36 * 4}, 3);
-            firstAidCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::FIRST_AID));
+            {
+                auto firstAidCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 4}, 3);
+                firstAidCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::FIRST_AID));
+            }
 
-            auto doctorCounter   = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36 * 5}, 3);
-            doctorCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::DOCTOR));
+            {
+                auto doctorCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 5}, 3);
+                doctorCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::DOCTOR));
+            }
 
-            auto scienceCounter  = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36 * 6}, 3);
-            scienceCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::SCIENCE));
+            {
+                auto scienceCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 6}, 3);
+                scienceCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::SCIENCE));
+            }
 
-            auto repairCounter   = new UI::BigCounter({backgroundX + 111, backgroundY + 48 + 36 * 7}, 3);
-            repairCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::REPAIR));
+            {
+                auto repairCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 7}, 3);
+                repairCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::REPAIR));
+            }
+
 
             // LABELS
             std::string font = "font3.aaf";
             SDL_Color color = {0xb8, 0x9c, 0x28, 0xff};
 
             // label: skilldex (100)
-            auto skilldexLabel = new UI::TextArea(_t(MSG_SKILLDEX, 100), backgroundX+56, backgroundY+14);
-            skilldexLabel->setFont(font, color);
-            skilldexLabel->setWidth(76);
-            skilldexLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto skilldexLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 100), backgroundX+56, backgroundY+14);
+                skilldexLabel->setFont(font, color);
+                skilldexLabel->setWidth(76);
+                skilldexLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: sneak (102)
-            auto sneakLabel = new UI::TextArea(_t(MSG_SKILLDEX, 102), backgroundX+17, backgroundY+52);
-            sneakLabel->setFont(font, color);
-            sneakLabel->setWidth(84);
-            sneakLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto sneakLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 102), backgroundX+17, backgroundY+52);
+                sneakLabel->setFont(font, color);
+                sneakLabel->setWidth(84);
+                sneakLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: lockpick (103)
-            auto lockpickLabel = new UI::TextArea(_t(MSG_SKILLDEX, 103), backgroundX+17, backgroundY+52+36);
-            lockpickLabel->setFont(font, color);
-            lockpickLabel->setWidth(84);
-            lockpickLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto lockpickLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 103), backgroundX+17, backgroundY+52+36);
+                lockpickLabel->setFont(font, color);
+                lockpickLabel->setWidth(84);
+                lockpickLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: steal (104)
-            auto stealLabel = new UI::TextArea(_t(MSG_SKILLDEX, 104), backgroundX+17, backgroundY+52+36*2);
-            stealLabel->setFont(font, color);
-            stealLabel->setWidth(84);
-            stealLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto stealLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 104), backgroundX+17, backgroundY+52+36*2);
+                stealLabel->setFont(font, color);
+                stealLabel->setWidth(84);
+                stealLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: traps (105)
-            auto trapsLabel = new UI::TextArea(_t(MSG_SKILLDEX, 105), backgroundX+17, backgroundY+52+36*3);
-            trapsLabel->setFont(font, color);
-            trapsLabel->setWidth(84);
-            trapsLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto trapsLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 105), backgroundX+17, backgroundY+52+36*3);
+                trapsLabel->setFont(font, color);
+                trapsLabel->setWidth(84);
+                trapsLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: first aid (106)
-            auto firstAidLabel = new UI::TextArea(_t(MSG_SKILLDEX, 106), backgroundX+17, backgroundY+52+36*4);
-            firstAidLabel->setFont(font, color);
-            firstAidLabel->setWidth(84);
-            firstAidLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto firstAidLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 106), backgroundX+17, backgroundY+52+36*4);
+                firstAidLabel->setFont(font, color);
+                firstAidLabel->setWidth(84);
+                firstAidLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: doctor (107)
-            auto doctorLabel = new UI::TextArea(_t(MSG_SKILLDEX, 107), backgroundX+17, backgroundY+52+36*5);
-            doctorLabel->setFont(font, color);
-            doctorLabel->setWidth(84);
-            doctorLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto doctorLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 107), backgroundX+17, backgroundY+52+36*5);
+                doctorLabel->setFont(font, color);
+                doctorLabel->setWidth(84);
+                doctorLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: science (108)
-            auto scienceLabel = new UI::TextArea(_t(MSG_SKILLDEX, 108), backgroundX+17, backgroundY+52+36*6);
-            scienceLabel->setFont(font, color);
-            scienceLabel->setWidth(84);
-            scienceLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto scienceLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 108), backgroundX+17, backgroundY+52+36*6);
+                scienceLabel->setFont(font, color);
+                scienceLabel->setWidth(84);
+                scienceLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: repair (109)
-            auto repairLabel = new UI::TextArea(_t(MSG_SKILLDEX, 109), backgroundX+17, backgroundY+52+36*7);
-            repairLabel->setFont(font, color);
-            repairLabel->setWidth(84);
-            repairLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            {
+                auto repairLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 109), backgroundX+17, backgroundY+52+36*7);
+                repairLabel->setFont(font, color);
+                repairLabel->setWidth(84);
+                repairLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+            }
 
             // label: cancel (101)
-            auto cancelButtonLabel = new UI::TextArea(_t(MSG_SKILLDEX, 101), backgroundX+70, backgroundY+337);
-            cancelButtonLabel->setFont(font, color);
-
-            // add all buttons and labels and counters
-            addUI(background);
-            addUI(std::move(sneakButton));
-            addUI(std::move(lockpickButton));
-            addUI(std::move(stealButton));
-            addUI(std::move(trapsButton));
-            addUI(std::move(firstAidButton));
-            addUI(std::move(doctorButton));
-            addUI(std::move(scienceButton));
-            addUI(std::move(repairButton));
-            addUI(std::move(cancelButton));
-            addUI(skilldexLabel);
-            addUI(sneakLabel);
-            addUI(lockpickLabel);
-            addUI(stealLabel);
-            addUI(trapsLabel);
-            addUI(firstAidLabel);
-            addUI(doctorLabel);
-            addUI(scienceLabel);
-            addUI(repairLabel);
-            addUI(cancelButtonLabel);
-            addUI(sneakCounter);
-            addUI(lockpickCounter);
-            addUI(stealCounter);
-            addUI(trapsCounter);
-            addUI(firstAidCounter);
-            addUI(doctorCounter);
-            addUI(scienceCounter);
-            addUI(repairCounter);
+            {
+                auto cancelButtonLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 101), backgroundX+70, backgroundY+337);
+                cancelButtonLabel->setFont(font, color);
+            }
         }
 
         void Skilldex::onCancelButtonClick()

--- a/src/State/Skilldex.cpp
+++ b/src/State/Skilldex.cpp
@@ -161,15 +161,15 @@ namespace Falltergeist
 
             // add all buttons and labels and counters
             addUI(background);
-            addUI(sneakButton);
-            addUI(lockpickButton);
-            addUI(stealButton);
-            addUI(trapsButton);
-            addUI(firstAidButton);
-            addUI(doctorButton);
-            addUI(scienceButton);
-            addUI(repairButton);
-            addUI(cancelButton);
+            addUI(std::move(sneakButton));
+            addUI(std::move(lockpickButton));
+            addUI(std::move(stealButton));
+            addUI(std::move(trapsButton));
+            addUI(std::move(firstAidButton));
+            addUI(std::move(doctorButton));
+            addUI(std::move(scienceButton));
+            addUI(std::move(repairButton));
+            addUI(std::move(cancelButton));
             addUI(skilldexLabel);
             addUI(sneakLabel);
             addUI(lockpickLabel);

--- a/src/State/Skilldex.cpp
+++ b/src/State/Skilldex.cpp
@@ -46,103 +46,94 @@ namespace Falltergeist
             auto backgroundX = (rendSize.width() + 640 - 2 * background->size().width()) / 2;
             auto backgroundY = (rendSize.height() - 480 + 6);
             background->setPosition({backgroundX, backgroundY});
-            addUI(background);
+            addSharedUI(background);
 
             // buttons
             {
-                auto sneakButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44});
-                sneakButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SNEAK));
-                addUI(std::move(sneakButton));
+                auto& sneakButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44}));
+                sneakButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SNEAK));
             }
 
             {
-                auto lockpickButton = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36});
-                lockpickButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::LOCKPICK));
-                addUI(std::move(lockpickButton));
+                auto& lockpickButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36}));
+                lockpickButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::LOCKPICK));
             }
 
             {
-                auto stealButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 2});
-                stealButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::STEAL));
-                addUI(std::move(stealButton));
+                auto& stealButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 2}));
+                stealButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::STEAL));
             }
 
             {
-                auto trapsButton    = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 3});
-                trapsButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::TRAPS));
-                addUI(std::move(trapsButton));
+                auto& trapsButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 3}));
+                trapsButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::TRAPS));
             }
 
             {
-                auto firstAidButton = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 4});
-                firstAidButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::FIRST_AID));
-                addUI(std::move(firstAidButton));
+                auto& firstAidButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 4}));
+                firstAidButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::FIRST_AID));
             }
 
             {
-                auto doctorButton   = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 5});
-                doctorButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::DOCTOR));
-                addUI(std::move(doctorButton));
+                auto& doctorButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 5}));
+                doctorButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::DOCTOR));
             }
 
             {
-                auto scienceButton  = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 6});
-                scienceButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SCIENCE));
-                addUI(std::move(scienceButton));
+                auto& scienceButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 6}));
+                scienceButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::SCIENCE));
             }
 
             {
-                auto repairButton   = imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 7});
-                repairButton->mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::REPAIR));
-                addUI(std::move(repairButton));
+                auto& repairButton = addUI(imageButtonFactory->getByType(ImageButtonType::SKILLDEX_BUTTON, {backgroundX + 14, backgroundY + 44 + 36 * 7}));
+                repairButton.mouseClickHandler().add(std::bind(&Skilldex::onSkillButtonClick, this, SKILL::REPAIR));
             }
 
             {
-                auto cancelButton   = imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 48, backgroundY + 338});
-                cancelButton->mouseClickHandler().add(std::bind(&Skilldex::onCancelButtonClick, this));
-                addUI(std::move(cancelButton));
+                auto& cancelButton = addUI(imageButtonFactory->getByType(ImageButtonType::SMALL_RED_CIRCLE, {backgroundX + 48, backgroundY + 338}));
+                cancelButton.mouseClickHandler().add(std::bind(&Skilldex::onCancelButtonClick, this));
             }
 
 
             // counters
             {
-                auto sneakCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48}, 3);
-                sneakCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::SNEAK));
+                auto& sneakCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48}, 3);
+                sneakCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::SNEAK));
             }
 
             {
-                auto lockpickCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36}, 3);
-                lockpickCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::LOCKPICK));
+                auto& lockpickCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36}, 3);
+                lockpickCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::LOCKPICK));
             }
 
             {
-                auto stealCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 2}, 3);
-                stealCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::STEAL));
+                auto& stealCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 2}, 3);
+                stealCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::STEAL));
             }
 
             {
-                auto trapsCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 3}, 3);
-                trapsCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::TRAPS));
+                auto& trapsCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 3}, 3);
+                trapsCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::TRAPS));
             }
 
             {
-                auto firstAidCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 4}, 3);
-                firstAidCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::FIRST_AID));
+                auto& firstAidCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 4}, 3);
+                firstAidCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::FIRST_AID));
             }
 
             {
-                auto doctorCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 5}, 3);
-                doctorCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::DOCTOR));
+                auto& doctorCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 5}, 3);
+                doctorCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::DOCTOR));
             }
 
             {
-                auto scienceCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 6}, 3);
-                scienceCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::SCIENCE));
+                auto& scienceCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 6}, 3);
+                scienceCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::SCIENCE));
             }
 
             {
-                auto repairCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 7}, 3);
-                repairCounter->setNumber(Game::getInstance()->player()->skillValue(SKILL::REPAIR));
+                auto& repairCounter = makeUI<UI::BigCounter>(Point{backgroundX + 111, backgroundY + 48 + 36 * 7}, 3);
+                repairCounter.setNumber(Game::getInstance()->player()->skillValue(SKILL::REPAIR));
             }
 
 
@@ -152,80 +143,80 @@ namespace Falltergeist
 
             // label: skilldex (100)
             {
-                auto skilldexLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 100), backgroundX+56, backgroundY+14);
-                skilldexLabel->setFont(font, color);
-                skilldexLabel->setWidth(76);
-                skilldexLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& skilldexLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 100), backgroundX+56, backgroundY+14);
+                skilldexLabel.setFont(font, color);
+                skilldexLabel.setWidth(76);
+                skilldexLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: sneak (102)
             {
-                auto sneakLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 102), backgroundX+17, backgroundY+52);
-                sneakLabel->setFont(font, color);
-                sneakLabel->setWidth(84);
-                sneakLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& sneakLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 102), backgroundX+17, backgroundY+52);
+                sneakLabel.setFont(font, color);
+                sneakLabel.setWidth(84);
+                sneakLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: lockpick (103)
             {
-                auto lockpickLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 103), backgroundX+17, backgroundY+52+36);
-                lockpickLabel->setFont(font, color);
-                lockpickLabel->setWidth(84);
-                lockpickLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& lockpickLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 103), backgroundX+17, backgroundY+52+36);
+                lockpickLabel.setFont(font, color);
+                lockpickLabel.setWidth(84);
+                lockpickLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: steal (104)
             {
-                auto stealLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 104), backgroundX+17, backgroundY+52+36*2);
-                stealLabel->setFont(font, color);
-                stealLabel->setWidth(84);
-                stealLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& stealLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 104), backgroundX+17, backgroundY+52+36*2);
+                stealLabel.setFont(font, color);
+                stealLabel.setWidth(84);
+                stealLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: traps (105)
             {
-                auto trapsLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 105), backgroundX+17, backgroundY+52+36*3);
-                trapsLabel->setFont(font, color);
-                trapsLabel->setWidth(84);
-                trapsLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& trapsLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 105), backgroundX+17, backgroundY+52+36*3);
+                trapsLabel.setFont(font, color);
+                trapsLabel.setWidth(84);
+                trapsLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: first aid (106)
             {
-                auto firstAidLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 106), backgroundX+17, backgroundY+52+36*4);
-                firstAidLabel->setFont(font, color);
-                firstAidLabel->setWidth(84);
-                firstAidLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& firstAidLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 106), backgroundX+17, backgroundY+52+36*4);
+                firstAidLabel.setFont(font, color);
+                firstAidLabel.setWidth(84);
+                firstAidLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: doctor (107)
             {
-                auto doctorLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 107), backgroundX+17, backgroundY+52+36*5);
-                doctorLabel->setFont(font, color);
-                doctorLabel->setWidth(84);
-                doctorLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& doctorLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 107), backgroundX+17, backgroundY+52+36*5);
+                doctorLabel.setFont(font, color);
+                doctorLabel.setWidth(84);
+                doctorLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: science (108)
             {
-                auto scienceLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 108), backgroundX+17, backgroundY+52+36*6);
-                scienceLabel->setFont(font, color);
-                scienceLabel->setWidth(84);
-                scienceLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& scienceLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 108), backgroundX+17, backgroundY+52+36*6);
+                scienceLabel.setFont(font, color);
+                scienceLabel.setWidth(84);
+                scienceLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: repair (109)
             {
-                auto repairLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 109), backgroundX+17, backgroundY+52+36*7);
-                repairLabel->setFont(font, color);
-                repairLabel->setWidth(84);
-                repairLabel->setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
+                auto& repairLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 109), backgroundX+17, backgroundY+52+36*7);
+                repairLabel.setFont(font, color);
+                repairLabel.setWidth(84);
+                repairLabel.setHorizontalAlign(UI::TextArea::HorizontalAlign::CENTER);
             }
 
             // label: cancel (101)
             {
-                auto cancelButtonLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 101), backgroundX+70, backgroundY+337);
-                cancelButtonLabel->setFont(font, color);
+                auto& cancelButtonLabel = makeUI<UI::TextArea>(_t(MSG_SKILLDEX, 101), backgroundX+70, backgroundY+337);
+                cancelButtonLabel.setFont(font, color);
             }
         }
 

--- a/src/State/Start.cpp
+++ b/src/State/Start.cpp
@@ -49,7 +49,7 @@ namespace Falltergeist
             _delayTimer = std::make_unique<Game::Timer>(3000);
             _delayTimer->start();
             _delayTimer->tickHandler().add([game, this](Event::Event*) {
-                game->setState(new MainMenu(resourceManager));
+                game->setState(std::make_unique<MainMenu>(resourceManager));
                 game->pushState(new Movie(17));
                 game->pushState(new Movie(1));
                 game->pushState(new Movie(0));

--- a/src/State/Start.cpp
+++ b/src/State/Start.cpp
@@ -50,9 +50,9 @@ namespace Falltergeist
             _delayTimer->start();
             _delayTimer->tickHandler().add([game, this](Event::Event*) {
                 game->setState(std::make_unique<MainMenu>(resourceManager));
-                game->pushState(new Movie(17));
-                game->pushState(new Movie(1));
-                game->pushState(new Movie(0));
+                game->pushState(std::make_unique<Movie>(17));
+                game->pushState(std::make_unique<Movie>(1));
+                game->pushState(std::make_unique<Movie>(0));
             });
 
             Game::getInstance()->mouse()->setState(Input::Mouse::Cursor::WAIT);

--- a/src/State/Start.cpp
+++ b/src/State/Start.cpp
@@ -22,9 +22,10 @@ namespace Falltergeist
 
     namespace State
     {
-        Start::Start(std::shared_ptr<UI::IResourceManager> resourceManager) : State()
+        Start::Start(std::shared_ptr<UI::IResourceManager> _resourceManager) :
+            State{},
+            resourceManager{std::move(_resourceManager)}
         {
-            this->resourceManager = std::move(resourceManager);
         }
 
         void Start::init()
@@ -32,6 +33,7 @@ namespace Falltergeist
             if (_initialized) {
                 return;
             }
+
             State::init();
 
             setModal(true);

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -133,11 +133,10 @@ namespace Falltergeist
 
         void State::popUI()
         {
-            if (_ui.size() == 0) {
-                return;
+            if (not _ui.empty()) {
+                _uiToDelete.emplace_back(std::move(_ui.back()));
+                _ui.pop_back();
             }
-            _uiToDelete.emplace_back(std::move(_ui.back()));
-            _ui.pop_back();
         }
 
         void State::onStateActivate(Event::State* event)

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -92,51 +92,23 @@ namespace Falltergeist
             _modal = value;
         }
 
-        // TODO: change to accept unique_ptr
-        UI::Base* State::addUI(UI::Base* ui)
+        void State::addUI(std::shared_ptr<UI::Base> ui)
         {
             // Add to UI state position
             ui->setPosition(ui->position() - ui->offset() + position());
-
-            _ui.push_back(std::unique_ptr<UI::Base>(ui));
-            return ui;
+            _ui.emplace_back(std::move(ui));
         }
 
-        UI::Base* State::addUI(const std::string& name, UI::Base* ui)
+        void State::addUI(std::string name, std::shared_ptr<UI::Base> ui)
         {
             addUI(ui);
-            _labeledUI.insert(std::pair<std::string, UI::Base*>(name, ui));
-            return ui;
+            _labeledUI.insert({ std::move(name), std::move(ui) });
         }
 
-        void State::addUI(const std::vector<UI::Base*>& uis)
+        std::shared_ptr<UI::Base> State::getUIInternal(const std::string& name) const
         {
-            for (auto ui : uis) {
-                addUI(ui);
-            }
-        }
-
-        UI::TextArea* State::getTextArea(const std::string& name)
-        {
-            return dynamic_cast<UI::TextArea*>(getUI(name));
-        }
-
-        UI::ImageList* State::getImageList(const std::string& name)
-        {
-            return dynamic_cast<UI::ImageList*>(getUI(name));
-        }
-
-        UI::SmallCounter* State::getSmallCounter(const std::string& name)
-        {
-            return dynamic_cast<UI::SmallCounter*>(getUI(name));
-        }
-
-        UI::Base* State::getUI(const std::string& name)
-        {
-            if (_labeledUI.find(name) != _labeledUI.end()) {
-                return _labeledUI.at(name);
-            }
-            return nullptr;
+            auto it = _labeledUI.find(name);
+            return it != _labeledUI.end() ? it->second : std::shared_ptr<UI::Base>{nullptr};
         }
 
         void State::handle(Event::Event* event)

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -92,19 +92,6 @@ namespace Falltergeist
             _modal = value;
         }
 
-        void State::addUI(std::shared_ptr<UI::Base> ui)
-        {
-            // Add to UI state position
-            ui->setPosition(ui->position() - ui->offset() + position());
-            _ui.emplace_back(std::move(ui));
-        }
-
-        void State::addUI(std::string name, std::shared_ptr<UI::Base> ui)
-        {
-            addUI(ui);
-            _labeledUI.insert({ std::move(name), std::move(ui) });
-        }
-
         std::shared_ptr<UI::Base> State::getUIInternal(const std::string& name) const
         {
             auto it = _labeledUI.find(name);

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -61,14 +61,6 @@ namespace Falltergeist
 
                 template<class T,
                         typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
-                std::shared_ptr<T> addUI(T* ui) {
-                    // TODO: this is a temporary API-compatible version of addUI that allows existing code to compile
-                    // TODO: ideally, the existing code should be refactored to use smart pointers (the other overloads)
-                    return this->addUI(std::shared_ptr<T>{ui});
-                }
-
-                template<class T,
-                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> addUI(std::shared_ptr<T> ui)
                 {
                     // ui->setPosition(ui->position() - ui->offset() + position());  // TODO: unsure why this is needed

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -101,14 +101,6 @@ namespace Falltergeist
                     return ret;
                 }
 
-                template<class T,
-                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
-                std::shared_ptr<T> addUI(std::string name, T* ui) {
-                    // TODO: this is a temporary API-compatible version of addUI that allows existing code to compile
-                    // TODO: ideally, the existing code should be refactored to use smart pointers (the other overloads)
-                    return this->addUI(std::move(name), std::shared_ptr<T>{ui});
-                }
-
                 template<typename T = UI::Base,
                         typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> getUI(const std::string& name) const {

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -71,8 +71,7 @@ namespace Falltergeist
                         typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T>  addUI(std::shared_ptr<T> ui)
                 {
-                    // Add to UI state position
-                    ui->setPosition(ui->position() - ui->offset() + position());
+                    // ui->setPosition(ui->position() - ui->offset() + position());  // TODO: unsure why this is needed
                     _ui.emplace_back(ui);
                     return ui;
                 }

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -69,7 +69,7 @@ namespace Falltergeist
 
                 template<class T,
                         typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
-                std::shared_ptr<T>  addUI(std::shared_ptr<T> ui)
+                std::shared_ptr<T> addUI(std::shared_ptr<T> ui)
                 {
                     // ui->setPosition(ui->position() - ui->offset() + position());  // TODO: unsure why this is needed
                     _ui.emplace_back(ui);
@@ -78,7 +78,7 @@ namespace Falltergeist
 
                 template<class T,
                         typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
-                std::shared_ptr<T>  addUI(std::unique_ptr<T> ui)
+                std::shared_ptr<T> addUI(std::unique_ptr<T> ui)
                 {
                     return addUI(std::shared_ptr<T>{std::move(ui)});
                 }

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -39,7 +39,9 @@ namespace Falltergeist
                 State& operator=(const State&) = delete;
                 virtual ~State() = default;
 
-                template<class T, class ...TCtorArgs, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        class ...TCtorArgs,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> makeUI(TCtorArgs&&... args)
                 {
                     auto p = std::make_shared<T>(std::forward<TCtorArgs>(args)...);
@@ -47,7 +49,9 @@ namespace Falltergeist
                     return p;
                 }
 
-                template<class T, class ...TCtorArgs, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        class ...TCtorArgs,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> makeNamedUI(std::string name, TCtorArgs&&... args)
                 {
                     auto p = std::make_shared<T>(std::forward<TCtorArgs>(args)...);
@@ -55,7 +59,16 @@ namespace Falltergeist
                     return p;
                 }
 
-                template<class T, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                std::shared_ptr<T> addUI(T* ui) {
+                    // TODO: this is a temporary API-compatible version of addUI that allows existing code to compile
+                    // TODO: ideally, the existing code should be refactored to use smart pointers (the other overloads)
+                    return this->addUI(std::shared_ptr<T>{ui});
+                }
+
+                template<class T,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T>  addUI(std::shared_ptr<T> ui)
                 {
                     // Add to UI state position
@@ -64,21 +77,24 @@ namespace Falltergeist
                     return ui;
                 }
 
-                template<class T, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T>  addUI(std::unique_ptr<T> ui)
                 {
                     return addUI(std::shared_ptr<T>{std::move(ui)});
                 }
 
-                template<class T, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> addUI(std::string name, std::shared_ptr<T> ui)
                 {
                     auto ret = addUI(ui);
-                    _labeledUI.insert({ std::move(name), std::move(ui) });
+                    _labeledUI.insert({ std::move(name), ui });
                     return ret;
                 }
 
-                template<class T, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> addUI(std::string name, std::unique_ptr<T> ui)
                 {
                     auto ret = addUI(std::shared_ptr<T>{std::move(ui)});
@@ -86,7 +102,16 @@ namespace Falltergeist
                     return ret;
                 }
 
-                template<typename T = UI::Base, typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                template<class T,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
+                std::shared_ptr<T> addUI(std::string name, T* ui) {
+                    // TODO: this is a temporary API-compatible version of addUI that allows existing code to compile
+                    // TODO: ideally, the existing code should be refactored to use smart pointers (the other overloads)
+                    return this->addUI(std::move(name), std::shared_ptr<T>{ui});
+                }
+
+                template<typename T = UI::Base,
+                        typename = std::enable_if_t<std::is_base_of<UI::Base, T>::value>>
                 std::shared_ptr<T> getUI(const std::string& name) const {
                     return std::dynamic_pointer_cast<T>(getUIInternal(name));
                 }

--- a/src/State/WorldMap.cpp
+++ b/src/State/WorldMap.cpp
@@ -36,7 +36,7 @@ namespace Falltergeist
             unsigned int renderHeight = Game::getInstance()->renderer()->height();
 
             // loading map tiles
-            _tiles = new UI::ImageList({0, 0}, {
+            _tiles = std::make_shared<UI::ImageList>(Point{0, 0}, std::vector<std::shared_ptr<UI::Image>> {
                 resourceManager->getImage("art/intrface/wrldmp00.frm"),
                 resourceManager->getImage("art/intrface/wrldmp01.frm"),
                 resourceManager->getImage("art/intrface/wrldmp02.frm"),

--- a/src/State/WorldMap.h
+++ b/src/State/WorldMap.h
@@ -2,15 +2,12 @@
 
 #include "../State/State.h"
 #include "../UI/IResourceManager.h"
+#include "../UI/Factory/ImageButtonFactory.h"
 
 namespace Falltergeist
 {
     namespace UI
     {
-        namespace Factory
-        {
-            class ImageButtonFactory;
-        }
         class Image;
         class ImageButton;
         class ImageList;

--- a/src/State/WorldMap.h
+++ b/src/State/WorldMap.h
@@ -35,9 +35,9 @@ namespace Falltergeist
                 std::shared_ptr<UI::IResourceManager> resourceManager;
                 std::unique_ptr<UI::Factory::ImageButtonFactory> imageButtonFactory;
 
-                UI::Image* _panel = nullptr;
-                UI::ImageList* _tiles = nullptr;
-                UI::ImageButton* _hotspot = nullptr;
+                std::shared_ptr<UI::Image> _panel = nullptr;
+                std::shared_ptr<UI::ImageList> _tiles = nullptr;
+                std::shared_ptr<UI::ImageButton> _hotspot = nullptr;
 
                 // temporary!
                 // @todo: move it to other place!

--- a/src/UI/BigCounter.cpp
+++ b/src/UI/BigCounter.cpp
@@ -5,7 +5,7 @@ namespace Falltergeist
 {
     namespace UI
     {
-        BigCounter::BigCounter(const Point& pos, unsigned int length) : Base(pos)
+        BigCounter::BigCounter(Point pos, unsigned int length) : Base(pos)
         {
             _length = length;
             _sprite = std::make_shared<Graphics::Sprite>("art/intrface/bignum.frm");

--- a/src/UI/BigCounter.h
+++ b/src/UI/BigCounter.h
@@ -19,7 +19,7 @@ namespace Falltergeist
                     RED
                 };
 
-                BigCounter(const Point& pos = Point(), unsigned int length = 2);
+                BigCounter(Point pos = Point(), unsigned int length = 2);
                 virtual ~BigCounter() = default;
 
                 BigCounter(const BigCounter&) = delete;

--- a/src/UI/Factory/ImageButtonFactory.cpp
+++ b/src/UI/Factory/ImageButtonFactory.cpp
@@ -133,29 +133,29 @@ namespace Falltergeist
                 };
             }
 
-            ImageButton* ImageButtonFactory::getByType(Type type, const Graphics::Point &position)
+            std::unique_ptr<ImageButton> ImageButtonFactory::getByType(Type type, const Graphics::Point &position)
             {
                 auto buttonUpSprite = uiResourceManager->getSprite(buttonUpSpriteFilenames.at(type));
                 auto buttonDownSprite = uiResourceManager->getSprite(buttonDownSpriteFilenames.at(type));
-
-                std::string buttonDownSoundFilename;
-                if (buttonDownSoundFilenames.find(type) != buttonDownSoundFilenames.end()) {
-                    buttonDownSoundFilename = buttonDownSoundFilenames.at(type);
-                }
 
                 std::string buttonUpSoundFilename;
                 if (buttonUpSoundFilenames.find(type) != buttonUpSoundFilenames.end()) {
                     buttonUpSoundFilename = buttonUpSoundFilenames.at(type);
                 }
 
+                std::string buttonDownSoundFilename;
+                if (buttonDownSoundFilenames.find(type) != buttonDownSoundFilenames.end()) {
+                    buttonDownSoundFilename = buttonDownSoundFilenames.at(type);
+                }
+
                 bool checkboxMode = (type == Type::CHECKBOX);
 
-                return new ImageButton(
+                return std::make_unique<ImageButton>(
                     position,
                     buttonUpSprite,
                     buttonDownSprite,
-                    buttonUpSoundFilename,
-                    buttonDownSoundFilename,
+                    std::move(buttonUpSoundFilename),
+                    std::move(buttonDownSoundFilename),
                     checkboxMode
                 );
             }

--- a/src/UI/Factory/ImageButtonFactory.h
+++ b/src/UI/Factory/ImageButtonFactory.h
@@ -54,7 +54,7 @@ namespace Falltergeist
 
                     ImageButtonFactory(std::shared_ptr<IResourceManager> uiResourceManager);
 
-                    ImageButton* getByType(Type type, const Graphics::Point &position);
+                    std::unique_ptr<ImageButton> getByType(Type type, const Graphics::Point &position);
 
                 private:
                     std::shared_ptr<IResourceManager> uiResourceManager;

--- a/src/UI/IResourceManager.h
+++ b/src/UI/IResourceManager.h
@@ -19,7 +19,7 @@ namespace Falltergeist
             public:
                 virtual ~IResourceManager() = default;
 
-                virtual std::unique_ptr<Image> getImage(const std::string &filename) = 0;
+                virtual std::shared_ptr<Image> getImage(const std::string &filename) = 0;
                 virtual std::shared_ptr<Graphics::Sprite> getSprite(const std::string &filename) = 0;
         };
     }

--- a/src/UI/IResourceManager.h
+++ b/src/UI/IResourceManager.h
@@ -19,8 +19,7 @@ namespace Falltergeist
             public:
                 virtual ~IResourceManager() = default;
 
-                // TODO replace with smart pointer
-                virtual Image* getImage(const std::string &filename) = 0;
+                virtual std::unique_ptr<Image> getImage(const std::string &filename) = 0;
                 virtual std::shared_ptr<Graphics::Sprite> getSprite(const std::string &filename) = 0;
         };
     }

--- a/src/UI/ImageList.cpp
+++ b/src/UI/ImageList.cpp
@@ -6,7 +6,7 @@ namespace Falltergeist
 {
     namespace UI
     {
-        ImageList::ImageList(Point pos, std::vector<std::unique_ptr<Image>> imageList) :
+        ImageList::ImageList(Point pos, std::vector<std::shared_ptr<Image>> imageList) :
             Falltergeist::UI::Base{pos},
             _images{std::move(imageList)}
         {
@@ -31,7 +31,7 @@ namespace Falltergeist
             _images.back()->setPosition(position());
         }
 
-        const std::vector<std::unique_ptr<Image>>& ImageList::images() const
+        const std::vector<std::shared_ptr<Image>>& ImageList::images() const
         {
             return _images;
         }

--- a/src/UI/ImageList.cpp
+++ b/src/UI/ImageList.cpp
@@ -6,11 +6,12 @@ namespace Falltergeist
 {
     namespace UI
     {
-        ImageList::ImageList(const Point& pos, const std::vector<Image*> &imageList) : Falltergeist::UI::Base(pos)
+        ImageList::ImageList(Point pos, std::vector<std::unique_ptr<Image>> imageList) :
+            Falltergeist::UI::Base{pos},
+            _images{std::move(imageList)}
         {
-            for (auto& image : imageList) {
-                auto imagePtr = std::unique_ptr<Image>(image);
-                addImage(imagePtr);
+            for (auto& image : _images) {
+                image->setPosition(position());
             }
         }
 

--- a/src/UI/ImageList.h
+++ b/src/UI/ImageList.h
@@ -12,13 +12,13 @@ namespace Falltergeist
         class ImageList : public Falltergeist::UI::Base
         {
             public:
-                ImageList(Point pos, std::vector<std::unique_ptr<Image>> imageList);
+                ImageList(Point pos, std::vector<std::shared_ptr<Image>> imageList);
                 virtual ~ImageList() = default;
 
                 void addImage(std::unique_ptr<Image> &image);
                 void setCurrentImage(unsigned int number);
                 unsigned int currentImage() const;
-                const std::vector<std::unique_ptr<Image>>& images() const;
+                const std::vector<std::shared_ptr<Image>>& images() const;
 
                 virtual bool opaque(const Point &pos) override;
 
@@ -26,7 +26,7 @@ namespace Falltergeist
                 virtual void setPosition(const Point &pos) override;
 
             private:
-                std::vector<std::unique_ptr<Image>> _images;
+                std::vector<std::shared_ptr<Image>> _images;
                 unsigned int _currentImage = 0;
         };
     }

--- a/src/UI/ImageList.h
+++ b/src/UI/ImageList.h
@@ -12,7 +12,7 @@ namespace Falltergeist
         class ImageList : public Falltergeist::UI::Base
         {
             public:
-                ImageList(const Point& pos, const std::vector<Image*> &imageList);
+                ImageList(Point pos, std::vector<std::unique_ptr<Image>> imageList);
                 virtual ~ImageList() = default;
 
                 void addImage(std::unique_ptr<Image> &image);

--- a/src/UI/InventoryItem.cpp
+++ b/src/UI/InventoryItem.cpp
@@ -17,7 +17,7 @@ namespace Falltergeist
     {
         using Graphics::Rect;
 
-        InventoryItem::InventoryItem(Game::ItemObject *item, const Point& pos) : Falltergeist::UI::Base(pos)
+        InventoryItem::InventoryItem(Game::ItemObject *item, Point pos) : Falltergeist::UI::Base(pos)
         {
             _item = item;
             mouseDownHandler().add(std::bind(&InventoryItem::onMouseLeftDown, this, std::placeholders::_1));

--- a/src/UI/InventoryItem.h
+++ b/src/UI/InventoryItem.h
@@ -25,7 +25,7 @@ namespace Falltergeist
                     DRAG
                 };
 
-                InventoryItem(Game::ItemObject* item, const Point& pos = Point());
+                InventoryItem(Game::ItemObject* item, Point pos = Point());
                 ~InventoryItem() override;
 
                 Type type() const;

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -18,7 +18,7 @@ namespace Falltergeist
     {
         using Graphics::Rect;
 
-        ItemsList::ItemsList(const Point& pos) : Falltergeist::UI::Base(pos)
+        ItemsList::ItemsList(Point pos) : Falltergeist::UI::Base(pos)
         {
             mouseDownHandler().add( std::bind(&ItemsList::onMouseLeftDown, this, std::placeholders::_1));
             mouseDragStartHandler().add(std::bind(&ItemsList::onMouseDragStart, this, std::placeholders::_1));

--- a/src/UI/ItemsList.h
+++ b/src/UI/ItemsList.h
@@ -19,7 +19,7 @@ namespace Falltergeist
         class ItemsList : public Falltergeist::UI::Base
         {
             public:
-                ItemsList(const Point& pos);
+                ItemsList(Point pos);
 
                 void setItems(std::vector<Game::ItemObject*>* items);
                 std::vector<Game::ItemObject*>* items();

--- a/src/UI/PlayerPanel.cpp
+++ b/src/UI/PlayerPanel.cpp
@@ -309,38 +309,37 @@ namespace Falltergeist
 
         void PlayerPanel::openGameMenu()
         {
-            Game::getInstance()->pushState(new State::GameMenu(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::GameMenu>(resourceManager));
             playWindowOpenSfx();
         }
 
         void PlayerPanel::openInventory()
         {
-            auto state = new State::Inventory(resourceManager);
-            Game::getInstance()->pushState(state);
+            Game::getInstance()->pushState(std::make_unique<State::Inventory>(resourceManager));
             playWindowOpenSfx();
         }
 
         void PlayerPanel::openSkilldex()
         {
-            Game::getInstance()->pushState(new State::Skilldex(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::Skilldex>(resourceManager));
             playWindowOpenSfx();
         }
 
         void PlayerPanel::openMap()
         {
-            Game::getInstance()->pushState(new State::WorldMap(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::WorldMap>(resourceManager));
             playWindowOpenSfx();
         }
 
         void PlayerPanel::openCharacterScreen()
         {
-            Game::getInstance()->pushState(new State::PlayerEdit(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::PlayerEdit>(resourceManager));
             playWindowOpenSfx();
         }
 
         void PlayerPanel::openPipBoy()
         {
-            Game::getInstance()->pushState(new State::PipBoy(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::PipBoy>(resourceManager));
             playWindowOpenSfx();
         }
 
@@ -400,7 +399,7 @@ namespace Falltergeist
                 case SDLK_x:
                     if (event->controlPressed())
                     {
-                        Game::getInstance()->pushState(new State::ExitConfirm(resourceManager));
+                        Game::getInstance()->pushState(std::make_unique<State::ExitConfirm>(resourceManager));
                         playWindowOpenSfx();
                     }
                 case SDLK_SLASH:
@@ -434,7 +433,7 @@ namespace Falltergeist
                     // @TODO: quick load logic
                     break;
                 case SDLK_F10:
-                    Game::getInstance()->pushState(new State::ExitConfirm(resourceManager));
+                    Game::getInstance()->pushState(std::make_unique<State::ExitConfirm>(resourceManager));
                     playWindowOpenSfx();
                     break;
                 case SDLK_F12:
@@ -445,13 +444,13 @@ namespace Falltergeist
 
         void PlayerPanel::openSaveGame()
         {
-            Game::getInstance()->pushState(new State::SaveGame(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::SaveGame>(resourceManager));
             playWindowOpenSfx();
         }
 
         void PlayerPanel::openLoadGame()
         {
-            Game::getInstance()->pushState(new State::LoadGame(resourceManager));
+            Game::getInstance()->pushState(std::make_unique<State::LoadGame>(resourceManager));
             playWindowOpenSfx();
         }
 

--- a/src/UI/Rectangle.cpp
+++ b/src/UI/Rectangle.cpp
@@ -6,7 +6,7 @@ namespace Falltergeist
 {
     namespace UI
     {
-        Rectangle::Rectangle(const Point &pos, const Size &size, SDL_Color color) : Base(pos), _size(size), _color(color)
+        Rectangle::Rectangle(Point pos, Size size, SDL_Color color) : Base(pos), _size(size), _color(color)
         {
         }
 

--- a/src/UI/Rectangle.h
+++ b/src/UI/Rectangle.h
@@ -11,7 +11,7 @@ namespace Falltergeist
         class Rectangle final : public Base
         {
             public:
-                Rectangle(const Point& pos, const Size& size, SDL_Color color);
+                Rectangle(Point pos, Size size, SDL_Color color);
                 void render(bool eggTransparency = false) override;
 
                 bool opaque(unsigned int x, unsigned int y);

--- a/src/UI/ResourceManager.cpp
+++ b/src/UI/ResourceManager.cpp
@@ -6,9 +6,9 @@ namespace Falltergeist
 {
     namespace UI
     {
-        std::unique_ptr<Image> ResourceManager::getImage(const std::string &filename)
+        std::shared_ptr<Image> ResourceManager::getImage(const std::string &filename)
         {
-            return std::make_unique<Image>(std::make_unique<Graphics::Sprite>(filename));
+            return std::make_shared<Image>(std::make_unique<Graphics::Sprite>(filename));
         }
 
         std::shared_ptr<Graphics::Sprite> ResourceManager::getSprite(const std::string &filename)

--- a/src/UI/ResourceManager.cpp
+++ b/src/UI/ResourceManager.cpp
@@ -6,9 +6,9 @@ namespace Falltergeist
 {
     namespace UI
     {
-        Image* ResourceManager::getImage(const std::string &filename)
+        std::unique_ptr<Image> ResourceManager::getImage(const std::string &filename)
         {
-            return new Image(std::make_unique<Graphics::Sprite>(filename));
+            return std::make_unique<Image>(std::make_unique<Graphics::Sprite>(filename));
         }
 
         std::shared_ptr<Graphics::Sprite> ResourceManager::getSprite(const std::string &filename)

--- a/src/UI/ResourceManager.h
+++ b/src/UI/ResourceManager.h
@@ -12,7 +12,7 @@ namespace Falltergeist
                 ResourceManager() = default;
                 virtual ~ResourceManager() = default;
 
-                Image* getImage(const std::string &filename) override;
+                std::unique_ptr<Image> getImage(const std::string &filename) override;
                 std::shared_ptr<Graphics::Sprite> getSprite(const std::string &filename) override;
         };
     }

--- a/src/UI/ResourceManager.h
+++ b/src/UI/ResourceManager.h
@@ -12,7 +12,7 @@ namespace Falltergeist
                 ResourceManager() = default;
                 virtual ~ResourceManager() = default;
 
-                std::unique_ptr<Image> getImage(const std::string &filename) override;
+                std::shared_ptr<Image> getImage(const std::string &filename) override;
                 std::shared_ptr<Graphics::Sprite> getSprite(const std::string &filename) override;
         };
     }

--- a/src/UI/Slider.cpp
+++ b/src/UI/Slider.cpp
@@ -10,15 +10,16 @@ namespace Falltergeist
 {
     namespace UI
     {
-        Slider::Slider(const Point& pos, std::unique_ptr<Image> imageOn, std::unique_ptr<Image> imageOff) : Base(pos)
+        Slider::Slider(Point pos, std::shared_ptr<Image> _imageOn, std::shared_ptr<Image> _imageOff) :
+            Base{pos},
+            imageOn{std::move(_imageOn)},
+            imageOff{std::move(_imageOff)},
+            _downSound{"sound/sfx/ib1p1xx1.acm"},
+            _upSound{"sound/sfx/ib1lu1x1.acm"}
         {
             mouseDragHandler().add(std::bind(&Slider::_onDrag, this, std::placeholders::_1));
             mouseDownHandler().add(std::bind(&Slider::_onLeftButtonDown, this, std::placeholders::_1));
             mouseUpHandler().add(std::bind(&Slider::_onLeftButtonUp, this, std::placeholders::_1));
-            this->imageOn = std::move(imageOn);
-            this->imageOff = std::move(imageOff);
-            _downSound = "sound/sfx/ib1p1xx1.acm";
-            _upSound = "sound/sfx/ib1lu1x1.acm";
         }
 
         void Slider::handle(Event::Event* event)

--- a/src/UI/Slider.h
+++ b/src/UI/Slider.h
@@ -15,7 +15,7 @@ namespace Falltergeist
         class Slider : public Falltergeist::UI::Base
         {
             public:
-                Slider(const Point& pos, std::unique_ptr<Image> imageOn, std::unique_ptr<Image> imageOff);
+                Slider(Point pos, std::shared_ptr<Image> imageOn, std::shared_ptr<Image> imageOff);
                 virtual ~Slider() = default;
 
                 void handle(Event::Event* event) override;
@@ -38,8 +38,8 @@ namespace Falltergeist
                 Event::Handler& changeHandler();
 
             private:
-                std::unique_ptr<Image> imageOn;
-                std::unique_ptr<Image> imageOff;
+                std::shared_ptr<Image> imageOn;
+                std::shared_ptr<Image> imageOff;
 
                 double _minValue = 0.0;
                 double _maxValue = 1.0;

--- a/src/UI/TextArea.cpp
+++ b/src/UI/TextArea.cpp
@@ -15,23 +15,22 @@ namespace Falltergeist
     {
         using Graphics::Rect;
 
-        TextArea::TextArea(const Point& pos) : Base(pos)
+        TextArea::TextArea(Point pos) : Base(pos)
         {
             _timestampCreated = SDL_GetTicks();
-
         }
 
         TextArea::TextArea(int x, int y) : TextArea(Point(x, y))
         {
         }
 
-        TextArea::TextArea(const std::string& text, const Point& pos) : Base(pos)
+        TextArea::TextArea(std::string text, Point pos) : Base(pos)
         {
             _timestampCreated = SDL_GetTicks();
-            setText(text);
+            setText(std::move(text));
         }
 
-        TextArea::TextArea(const std::string& text, int x, int y) : TextArea(text, Point(x, y))
+        TextArea::TextArea(std::string text, int x, int y) : TextArea(std::move(text), Point(x, y))
         {
         }
 

--- a/src/UI/TextArea.h
+++ b/src/UI/TextArea.h
@@ -35,7 +35,7 @@ namespace Falltergeist
             /**
              * Creates empty TextArea at the given position.
              */
-            TextArea(const Point& pos = Point());
+            TextArea(Point pos = Point());
 
             /**
              * Creates empty TextArea at the given position.
@@ -45,12 +45,12 @@ namespace Falltergeist
             /**
              * Creates TextArea with given text at the given position.
              */
-            TextArea(const std::string& text, const Point& pos = Point());
+            TextArea(std::string text, Point pos = Point());
 
             /**
              * Creates TextArea with given text at the given position.
              */
-            TextArea(const std::string& text, int x, int y);
+            TextArea(std::string text, int x, int y);
 
             /**
              * Creates TextArea as copy of another TextArea, placed at the given position (0,0 by default).

--- a/src/UI/TextAreaList.cpp
+++ b/src/UI/TextAreaList.cpp
@@ -6,7 +6,7 @@ namespace Falltergeist
 {
     namespace UI
     {
-        TextAreaList::TextAreaList(const Point &pos) : Falltergeist::UI::Base(pos)
+        TextAreaList::TextAreaList(Point pos) : Falltergeist::UI::Base(pos)
         {
         }
 

--- a/src/UI/TextAreaList.h
+++ b/src/UI/TextAreaList.h
@@ -12,7 +12,7 @@ namespace Falltergeist
         class TextAreaList : public Falltergeist::UI::Base
         {
             public:
-                TextAreaList(const Point& pos = Point());
+                TextAreaList(Point pos = Point());
                 ~TextAreaList() override;
 
                 void addArea(std::unique_ptr<TextArea> area);

--- a/src/VM/Handler/Opcode80DEHandler.cpp
+++ b/src/VM/Handler/Opcode80DEHandler.cpp
@@ -62,14 +62,14 @@ namespace Falltergeist {
                         mood = State::CritterInteract::Mood::GOOD;
                     }
                 }
-                auto interact = new State::CritterInteract(std::make_shared<UI::ResourceManager>());
+                auto interact = std::make_unique<State::CritterInteract>(std::make_shared<UI::ResourceManager>());
                 interact->setBackgroundID(backgroundID);
                 interact->setHeadID(headID);
                 interact->setMood(mood);
                 interact->setCritter(critter);
                 interact->setMsgFileID(msgFileID);
                 interact->setScript(_script);
-                Game::getInstance()->pushState(interact);
+                Game::getInstance()->pushState(std::move(interact));
             }
         }
     }

--- a/src/VM/Handler/Opcode8115Handler.cpp
+++ b/src/VM/Handler/Opcode8115Handler.cpp
@@ -39,8 +39,7 @@ namespace Falltergeist {
             void Opcode8115::_run() {
                 Logger::debug("SCRIPT") << "[8115] [*] void playMovie(int movie)" << std::endl;
                 int movie = _script->dataStack()->popInteger();
-                auto state = new State::Movie(movie);
-                Game::Game::getInstance()->pushState(state);
+                Game::Game::getInstance()->pushState(std::make_unique<State::Movie>(movie));
             }
         }
     }

--- a/src/VM/Handler/Opcode811CHandler.cpp
+++ b/src/VM/Handler/Opcode811CHandler.cpp
@@ -42,7 +42,7 @@ namespace Falltergeist {
             void Opcode811C::_run() {
                 Logger::debug("SCRIPT") << "[811C] [?] gsay_start" << std::endl;
 
-                if (auto interact = dynamic_cast<Falltergeist::State::CritterInteract *>(Game::getInstance()->topState())) {
+                if (auto interact = dynamic_cast<Falltergeist::State::CritterInteract*>(&Game::getInstance()->topState())) {
                     interact->dialogReview()->setCritterName(_script->owner()->scrName());
                     interact->switchSubState(State::CritterInteract::SubState::DIALOG);
                 }

--- a/src/VM/Handler/Opcode811DHandler.cpp
+++ b/src/VM/Handler/Opcode811DHandler.cpp
@@ -40,12 +40,12 @@ namespace Falltergeist {
 
             void Opcode811D::_run() {
                 Logger::debug("SCRIPT") << "[811D] [?] gsay_end" << std::endl;
-                auto dialog = dynamic_cast<State::CritterDialog *>(Game::getInstance()->topState());
+                auto dialog = dynamic_cast<State::CritterDialog *>(&Game::getInstance()->topState());
                 if (dialog->hasAnswers()) {
                     _script->dataStack()->push(0); // function return value
                     throw HaltException();
                 }
-                if (auto interact = dynamic_cast<Falltergeist::State::CritterInteract *>(Game::getInstance()->topState(
+                if (auto interact = dynamic_cast<Falltergeist::State::CritterInteract *>(&Game::getInstance()->topState(
                         1))) {
                     interact->switchSubState(State::CritterInteract::SubState::NONE);
                 }

--- a/src/VM/Handler/Opcode811EHandler.cpp
+++ b/src/VM/Handler/Opcode811EHandler.cpp
@@ -40,7 +40,7 @@ namespace Falltergeist {
 
             void Opcode811E::_run() {
                 Logger::debug("SCRIPT") << "[811E] [=] void gSay_Reply(int msg_file_num, int msg_num)" << std::endl;
-                auto dialog = dynamic_cast<State::CritterDialog *>(Game::getInstance()->topState());
+                auto dialog = dynamic_cast<State::CritterDialog *>(&Game::getInstance()->topState());
                 dialog->deleteAnswers();
                 if (_script->dataStack()->top().type() == StackValue::Type::STRING) {
                     auto question = _script->dataStack()->popString();
@@ -51,7 +51,7 @@ namespace Falltergeist {
                     dialog->setQuestion(_script->msgMessage(msg_file_num, msg_num));
                     auto speech = _script->msgSpeech(msg_file_num, msg_num);
                     if (speech != "") {
-                        if (auto interact = dynamic_cast<State::CritterInteract *>(Game::getInstance()->topState(1))) {
+                        if (auto interact = dynamic_cast<State::CritterInteract *>(&Game::getInstance()->topState(1))) {
                             interact->playSpeech(speech);
                         }
                     }

--- a/src/VM/Handler/Opcode8121Handler.cpp
+++ b/src/VM/Handler/Opcode8121Handler.cpp
@@ -58,7 +58,7 @@ namespace Falltergeist {
                 }
                 auto iq = dataStack->popInteger();
                 auto game = Game::getInstance();
-                auto dialog = dynamic_cast<State::CritterDialog *>(game->topState());
+                auto dialog = dynamic_cast<State::CritterDialog *>(&game->topState());
                 if (iq >= 0) {
                     if (game->player()->stat(STAT::INTELLIGENCE) >= iq) {
                         dialog->reactions()->push_back(reaction);

--- a/src/VM/Handler/Opcode8136Handler.cpp
+++ b/src/VM/Handler/Opcode8136Handler.cpp
@@ -43,8 +43,8 @@ namespace Falltergeist {
                 Logger::debug("SCRIPT") << "[8136] [=] void gfade_out(int time)" << std::endl
                                         << "    time = " << time << std::endl;
 
-                auto state = Game::getInstance()->topState();
-                state->scriptFade(_script, false);
+                auto& state = Game::getInstance()->topState();
+                state.scriptFade(_script, false);
                 throw HaltException();
             }
         }

--- a/src/VM/Handler/Opcode8137Handler.cpp
+++ b/src/VM/Handler/Opcode8137Handler.cpp
@@ -43,8 +43,8 @@ namespace Falltergeist {
                 Logger::debug("SCRIPT") << "[8137] [=] void gfade_in(int time)" << std::endl
                                         << "    time = " << time << std::endl;
 
-                auto state = Game::getInstance()->topState();
-                state->scriptFade(_script, true);
+                auto& state = Game::getInstance()->topState();
+                state.scriptFade(_script, true);
                 throw HaltException();
             }
         }


### PR DESCRIPTION
This is a work-in-progress refactor.

The `State` base classed used in *many* places in Falltergeist currently uses bare pointers. Bare pointers aren't, by themselves, the worst thing in the world, but they're potentially quite nasty in this particular part of Falltergeist because it's unclear what the order of destruction is when (e.g.) states are popped but other parts of components depend on pointers to now-stale elements, etc. etc.

Maybe it's because COVID is making me go crazy or maybe, deep down, I just prefer refactoring to adding new bugs, but this PR covers refactoring the `State` to use shared pointers. 

I will try to limit this work to only adding shared-pointer support, but if I see any benign-looking refactors as I move forward I will also do them (provided their diffs make sense in the greater context of the work).