### PR TITLE
Fix crash when moveObjectToHexagon is called with a nullptr hexagon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Under development
 - [bugfix] Opcode810D (obj_carrying_pid_obj) checks containers as well (JanSimek)
 - [bugfix] Fix linking release builds on Windows and prevent closing console after a crash (JanSimek)
 - [bugfix] Fix GLEW initialization on Wayland (ids1024)
+- [bugfix] Fix crash on Broken Hills map (broken1) when SSL function add_obj_to_inven is called (JanSimek)
 - [feature] Search data files in parent dir too (alexeevdv)
 - [feature] Basic barter system (Zervox, JanSimek)
 - [feature] Fix and update Travis build (JanSimek)

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -966,8 +966,8 @@ namespace Falltergeist
                 }
             }
 
-            object->setHexagon(hexagon);
             if (hexagon) {
+                object->setHexagon(hexagon);
                 hexagon->objects()->push_back(object);
             }
 

--- a/src/VM/Handler/Opcode80D8Handler.cpp
+++ b/src/VM/Handler/Opcode80D8Handler.cpp
@@ -63,7 +63,7 @@ namespace Falltergeist {
                 if (item->hexagon()) {
                     auto location = Game::Game::getInstance()->locationState();
                     if (location) {
-                        location->moveObjectToHexagon(item, nullptr);
+                        location->removeObjectFromMap(item);
                     }
                 }
             }


### PR DESCRIPTION
Happens on the Broken Hills map (broken1) when Opcode80D8 is called.