### PR TITLE
Prevent dangling pointers when removing obj from map. Closes #531, closes #538

### DIFF
--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -1217,7 +1217,11 @@ namespace Falltergeist
         Game::Object *Location::addObject(unsigned int PID, unsigned int position, unsigned int elevation)
         {
             auto object = Game::ObjectFactory::getInstance()->createObject(PID);
-            _objects.emplace_back(object);
+
+            // FIXME: This prevents the default destructor of shared_ptr from leaving a dangling pointer
+            //        in removeObjectFromMap() - until we get rid of raw pointers.
+            _objects.emplace_back(std::shared_ptr<Game::Object>(std::shared_ptr<Game::Object>{}, object));
+
             moveObjectToHexagon(object, hexagonGrid()->at(position));
             object->setElevation(elevation);
             return object;


### PR DESCRIPTION
To reproduce the crash simply load the `artemple` map and open the inventory.

Use [aliasing constructor](https://www.codesynthesis.com/~boris/blog/2012/04/25/shared-ptr-aliasing-constructor/) until we unravel the mix of raw and smart pointers. 

@adamkewley I do not have much experience with smart pointers but this seems like the easiest fix for now