### PR TITLE
Fix crash when loading nonexisting map

### DIFF
--- a/src/Helpers/GameLocationHelper.cpp
+++ b/src/Helpers/GameLocationHelper.cpp
@@ -14,9 +14,9 @@ namespace Falltergeist
             auto game = Game::getInstance();
             auto initialLocation = getByName(game->settings()->initialLocation());
             if (!initialLocation) {
-                auto defaultSettings = new Settings;
+                Settings defaultSettings(false);
                 Logger::warning() << "No such map: `" << game->settings()->initialLocation() << "`; using default map" << std::endl;
-                initialLocation = getByName(defaultSettings->initialLocation());
+                initialLocation = getByName(defaultSettings.initialLocation());
             }
             return initialLocation;
         }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -7,9 +7,15 @@
 
 namespace Falltergeist
 {
-    Settings::Settings()
+    Settings::Settings() : Settings::Settings(true)
     {
-        if (!load()) {
+    }
+
+    /**
+     * @param loadFromFile if true then load a configuration file or create a new one, otherwise use default values
+     */
+    Settings::Settings(bool loadFromFile) {
+        if (loadFromFile && !load()) {
             save();
         }
     }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -18,6 +18,7 @@ namespace Falltergeist
         public:
 
             Settings();
+            Settings(bool loadFromFile);
             ~Settings();
 
             bool save();


### PR DESCRIPTION
To reproduce set `init_location=blabla` in your config.ini file.