### PR TITLE
Fix crash on Location::removeObjectFromMap()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Under development
 - [feature] Added missing logo in the Pipboy window and special date greetings (JanSimek)
 - [feature] Added ladders and stairs funtionality (667bdrm)
 - [feature] Added elevators support (667bdrm)
+- [bugfix] Fix crash on vctydwtn and modinn maps when calling removeObjectFromMap (667bdrm)
 
 0.3.1 (2018-01-14)
 =======================

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -1040,14 +1040,23 @@ namespace Falltergeist
 
         void Location::removeObjectFromMap(Game::Object *object)
         {
-            auto objectsAtHex = object->hexagon()->objects();
+            auto hexagon = object->hexagon();
 
-            for (auto it = objectsAtHex->begin(); it != objectsAtHex->end(); ++it) {
-                if (*it == object) {
-                    objectsAtHex->erase(it);
-                    break;
+            if (hexagon != nullptr) {
+                auto objectsAtHex = hexagon->objects();
+
+                for (auto it = objectsAtHex->begin(); it != objectsAtHex->end(); ++it) {
+                    if (*it == object) {
+                        objectsAtHex->erase(it);
+                        break;
+                    }
                 }
+            } else {
+                auto &warning =  Logger::warning("LOCATION");
+                warning << "removeObjectFromMap(): object->hexagon() == nullptr for PID = ";
+                warning << object->PID() << " (" << object->name() << ")" << std::endl;
             }
+
             if (_objectUnderCursor == object) {
                 _objectUnderCursor = nullptr;
             }


### PR DESCRIPTION
When Location::removeObjectFromMap() called on vctydwtn and modinn maps, object->hexagon() == nullptr (called from 80F4 opcode). Checking for nullptr will preven to call anything from null.