### PR TITLE
Inventory dropdowns, cursor fixes, UI::Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Under development
 - [feature] Added missing logo in the Pipboy window and special date greetings (JanSimek)
 - [feature] Added ladders and stairs funtionality (667bdrm)
 - [feature] Added elevators support (667bdrm)
+- [bugfix] Now toggling cursor from hand to arrow on right click when mouse over any element as in vanilla engine (667bdrm)
+- [bugfix] Allow dragging items only when the cursor set to hand as in vanilla engine (667bdrm)
+- [feature] Support action dropdown on left click on the inventory item (667bdrm)
+- [feature] Showing inventory item description on player panel on action look cursor (667bdrm)
+- [feature] Basic UI::Panel implementation (667bdrm)
 
 0.3.1 (2018-01-14)
 =======================

--- a/src/State/Inventory.h
+++ b/src/State/Inventory.h
@@ -2,6 +2,10 @@
 
 #include "../ILogger.h"
 #include "../State/State.h"
+#include "../Game/Object.h"
+#include "../Game/Timer.h"
+#include "../Input/Mouse.h"
+
 #include "../UI/IResourceManager.h"
 
 namespace Falltergeist
@@ -9,9 +13,11 @@ namespace Falltergeist
     namespace Game
     {
         class ItemObject;
+        class Timer;
     }
     namespace UI
     {
+        class Panel;
         namespace Factory
         {
             class ImageButtonFactory;
@@ -41,15 +47,29 @@ namespace Falltergeist
                 //void onSlotMouseUp(Event::Mouse* event);
                 //void onSlotDrag(Event::Mouse* event);
                 void backgroundRightClick(Event::Mouse* event);
+                void handle(Event::Event* event) override;
                 void onKeyDown(Event::Keyboard* event) override;
+                void onMouseDown(Event::Mouse *event);
+                void onStateDeactivate(Event::State* event) override;
                 void onInventoryModified();
+                void toggleCursorMode();
+                void _screenShow (unsigned int PID);
+                Game::ItemObject* _item = nullptr;
+                Game::ItemObject* _actionCursorLastItem = nullptr;
+                std::vector<Input::Mouse::Icon> getCursorIconsForItem(Game::ItemObject *item);
+                Game::Timer _actionCursorTimer;
+                bool _actionCursorButtonPressed = false;
+                void think(const float &deltaTime) override;
+            protected:
+                Event::MouseHandler _mouseDownHandler;
+                unsigned int _actionCursorTicks = 0;
 
             private:
                 std::shared_ptr<ILogger> logger;
                 std::string _handItemSummary (Game::ItemObject* hand);
                 std::shared_ptr<UI::IResourceManager> resourceManager;
                 std::unique_ptr<UI::Factory::ImageButtonFactory> imageButtonFactory;
-                void _screenShow (unsigned int PID);
+                UI::Panel* statsPanel;
         };
     }
 }

--- a/src/State/Location.cpp
+++ b/src/State/Location.cpp
@@ -180,7 +180,7 @@ namespace Falltergeist
             elevation->floor()->init();
             elevation->roof()->init();
 
-            //loadAmbient(name);
+            //loadAmbient(_location->name());
 
             initLight();
 

--- a/src/UI/InventoryItem.h
+++ b/src/UI/InventoryItem.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "../Format/Enums.h"
+#include "../Game/Timer.h"
+#include "../Input/Mouse.h"
 #include "../UI/Base.h"
 
 namespace Falltergeist
@@ -39,7 +41,9 @@ namespace Falltergeist
 
                 virtual bool opaque(const Point &pos) override;
 
+                void onMouseDown(Event::Mouse* event);
                 void onMouseLeftDown(Event::Mouse* event);
+                void onMouseRightDown(Event::Mouse* event);
                 void onMouseDragStart(Event::Mouse* event);
                 void onMouseDrag(Event::Mouse* event);
                 void onMouseDragStop(Event::Mouse* event);
@@ -53,6 +57,7 @@ namespace Falltergeist
                 Game::ItemObject* _item = nullptr;
                 Type _type = Type::INVENTORY;
                 Type _oldType = Type::INVENTORY;
+                std::shared_ptr<UI::IResourceManager> resourceManager;
 
                 Event::MouseHandler _itemDragStopHandler;
         };

--- a/src/UI/ItemsList.cpp
+++ b/src/UI/ItemsList.cpp
@@ -20,7 +20,7 @@ namespace Falltergeist
 
         ItemsList::ItemsList(const Point& pos) : Falltergeist::UI::Base(pos)
         {
-            mouseDownHandler().add( std::bind(&ItemsList::onMouseLeftDown, this, std::placeholders::_1));
+            mouseDownHandler().add( std::bind(&ItemsList::onMouseDown, this, std::placeholders::_1));
             mouseDragStartHandler().add(std::bind(&ItemsList::onMouseDragStart, this, std::placeholders::_1));
             mouseDragHandler().add(     std::bind(&ItemsList::onMouseDrag, this, std::placeholders::_1));
             mouseDragStopHandler().add( std::bind(&ItemsList::onMouseDragStop, this, std::placeholders::_1));
@@ -68,14 +68,36 @@ namespace Falltergeist
             return _inventoryItems;
         }
 
+        void ItemsList::onMouseDown(Event::Mouse* event)
+        {
+            if (event->leftButton()) {
+                onMouseLeftDown(event);
+            }
+
+            if (event->rightButton()) {
+                onMouseRightDown(event);
+            }
+        }
+
         void ItemsList::onMouseLeftDown(Event::Mouse* event)
+        {
+            unsigned int index = (event->position().y() - y())/_slotHeight;
+            auto clickedItem = _inventoryItems.at(index).get();
+            if (clickedItem) {
+                clickedItem->onMouseLeftDown(event);
+            }
+        }
+
+        void ItemsList::onMouseRightDown(Event::Mouse* event)
         {
         }
 
         void ItemsList::onMouseDragStart(Event::Mouse* event)
         {
             unsigned int index = (event->position().y() - y())/_slotHeight;
-            if (index < _inventoryItems.size()) {
+            auto mouseState = Game::Game::getInstance()->mouse()->state();
+
+            if (index < _inventoryItems.size() && (mouseState == Input::Mouse::Cursor::HAND || mouseState == Input::Mouse::Cursor::BIG_ARROW)) {
                 Game::Game::getInstance()->mouse()->pushState(Input::Mouse::Cursor::NONE);
                 Game::Game::getInstance()->mixer()->playACMSound("sound/sfx/ipickup1.acm");
                 _draggedItem = _inventoryItems.at(index).get();

--- a/src/UI/ItemsList.h
+++ b/src/UI/ItemsList.h
@@ -43,7 +43,9 @@ namespace Falltergeist
 
                 virtual void render(bool eggTransparency = false) override;
 
+                void onMouseDown(Event::Mouse* event);
                 void onMouseLeftDown(Event::Mouse* event);
+                void onMouseRightDown(Event::Mouse* event);
                 void onMouseDragStart(Event::Mouse* event);
                 void onMouseDrag(Event::Mouse* event);
                 void onMouseDragStop(Event::Mouse* event);

--- a/src/UI/Panel.cpp
+++ b/src/UI/Panel.cpp
@@ -1,0 +1,103 @@
+#include "../UI/Panel.h"
+#include "../UI/Base.h"
+#include "../UI/TextArea.h"
+#include "../Event/Event.h"
+#include "../Event/Mouse.h"
+#include "../Graphics/Renderer.h"
+
+namespace Falltergeist
+{
+    using namespace std;
+
+    namespace UI
+    {
+        Panel::Panel(const Point& pos) : Base(pos)
+        {
+        }
+
+        UI::Base* Panel::addUI(UI::Base* ui)
+        {
+            // Add to UI state position
+            ui->setPosition(ui->position() - ui->offset() + position());
+
+            _children.push_back(std::unique_ptr<UI::Base>(ui));
+            return ui;
+        }
+
+        UI::Base* Panel::addUI(const std::string& name, UI::Base* ui)
+        {
+            addUI(ui);
+            _childrenLabeledUI.insert(std::pair<std::string, UI::Base*>(name, ui));
+            return ui;
+        }
+
+        void Panel::addUI(const std::vector<UI::Base*>& uis)
+        {
+            for (auto ui : uis) {
+                addUI(ui);
+            }
+        }
+
+        UI::Base* Panel::getUI(const std::string& name)
+        {
+            if (_childrenLabeledUI.find(name) != _childrenLabeledUI.end()) {
+                return _childrenLabeledUI.at(name);
+            }
+            return nullptr;
+        }
+
+        UI::TextArea* Panel::getTextArea(const std::string& name)
+        {
+            return dynamic_cast<UI::TextArea*>(getUI(name));
+        }
+
+        void Panel::setVisible(bool value)
+        {
+            _visible = value;
+        }
+
+        void Panel::handle(Event::Event *event)
+        {
+            UI::Base::handle(event);
+            if (auto mouseEvent = dynamic_cast<Event::Mouse*>(event))
+            {
+                mouseEvent->setObstacle(false);
+                mouseEvent->setHandled(false);
+
+                if (event->handled()) {
+                    return;
+                }
+
+                if (_visible) {
+                    for (auto it = _children.begin(); it != _children.end(); it++)
+                    {
+                       (*it)->handle(dynamic_cast<Event::Mouse*>(event));
+                    }
+                }
+            }
+        }
+
+        void Panel::think(const float &deltaTime)
+        {
+            UI::Base::think(deltaTime);
+            for (auto it = _children.begin(); it != _children.end(); it++)
+            {
+                (*it)->think(deltaTime);
+            }
+        }
+
+        void Panel::render(bool eggTransparency)
+        {
+            if (_visible) {
+                UI::Base::render(eggTransparency);
+
+                for (auto it = _children.begin(); it != _children.end(); it++)
+                {
+                    if ((*it)->visible()) {
+                        (*it)->render(eggTransparency);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/UI/Panel.h
+++ b/src/UI/Panel.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "../UI/Base.h"
+#include <map>
+
+namespace Falltergeist
+{
+    namespace Event
+    {
+        class Keyboard;
+        class Mouse;
+    }
+
+    namespace UI
+    {
+        class TextArea;
+        class Panel : public UI::Base
+        {
+            public:
+
+                Panel(const Point& pos = Point(0, 0));
+                void setVisible(bool value) override;
+                void handle(Event::Event *event) override;
+                void think(const float &deltaTime) override;
+                void render(bool eggTransparency) override;
+                UI::Base* addUI(UI::Base* ui);
+                UI::Base* addUI(const std::string& name, UI::Base* ui);
+                void addUI(const std::vector<UI::Base*>& uis);
+                UI::Base* getUI(const std::string& name);
+                UI::TextArea* getTextArea(const std::string& name);
+
+            private:
+                Size _size;
+                std::vector<std::unique_ptr<UI::Base>> _children;
+                std::vector<std::unique_ptr<UI::Base>> _childrenToDelete;
+                std::map<std::string, UI::Base*> _childrenLabeledUI;
+        };
+    }
+}


### PR DESCRIPTION
Toggling cursor from hand to arrow on right click when mouse over any element as in vanilla engine.
Dragging items only when cursor set to hand as in vanilla engine.
Support action dropdown on left click on the item (inventory, armor, hands)
Showing inventory item description on action look cursor
Initial UI::Panel implementation (#415). Panel allow access to children, hiding all children if panel set to hide. Could be used in PipBoy screens implementation and inentory refactoring