### PR TITLE
Fix incompatible cast in VertexArray

### DIFF
--- a/src/Graphics/VertexArray.cpp
+++ b/src/Graphics/VertexArray.cpp
@@ -25,7 +25,7 @@ namespace Falltergeist {
         void VertexArray::addBuffer(const std::unique_ptr<VertexBuffer>& buffer, const VertexBufferLayout &bufferLayout) {
             bind();
             buffer->bind();
-            unsigned int offset = 0;
+            void * offset = 0;
             unsigned int stride = 0;
 
             if (bufferLayout.attributes().size() > 1) {
@@ -52,9 +52,9 @@ namespace Falltergeist {
                     glType,
                     attribute.normalized() ? GL_TRUE : GL_FALSE,
                     stride,
-                    (const void *) offset
+                    static_cast<const void *>(offset)
                 ));
-                offset += attribute.size();
+                offset = static_cast<char*>(offset) + attribute.size();
             }
         }
     }


### PR DESCRIPTION
Cast from `unsigned int` to `void *` for small amounts of data it's ok, but it could lead to
unpredictable results in the future.