### PR TITLE
CMake missing sdl2main lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ else()
 	target_link_libraries(
 		falltergeist
 		${ZLIB_LIBRARIES}
+		${SDL2MAIN_LIBRARY}
 		${SDL2_LIBRARY}
 		${SDL_MIXER_LIBRARY}
 		${SDL_IMAGE_LIBRARY}


### PR DESCRIPTION
I have noticed that sdl2main.lib was not linked with CMake.